### PR TITLE
CI: split dev workflow to chore + dev

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
     types: [ opened, synchronize, reopened, edited ]
 
+permissions:
+  contents: read
+
 jobs:
   build-dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - "dev/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "src/notebook/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-notebook:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

We always need to check git commit format and generic linters (thanks to pre-commit). Thus we can split chore checks from dev-only related checks.

## Proposal

- [x] split `dev` CI workflow to `chore` + `dev`
- [x] add more linters (fixup commits + changelogs)
