### PR TITLE
🔧(tooling) disable commitzen check on merge

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -33,6 +33,7 @@ jobs:
   commit-format:
     needs: build-dev
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && !github.event.pull_request.merged
     defaults:
       run:
         working-directory: ./dev

--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -14,6 +14,8 @@ dev = [
 [tool.commitizen]
 name = "cz_customize"
 version = "0.1.0"
+check_consistency = true
+ignore_merge_commits = true
 
 [tool.commitizen.customize]
 message_template = "{{change_type}}({{scope}}) {{subject}}{% if body %}\n\n{{body}}{% endif %}{% if footer %}\n\n{{footer}}{% endif %}"


### PR DESCRIPTION
## 📝 Description
🎸 prevent `commit-format` to be run when merging a PR

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Technical change

## 🔧 Changes
* update commitzen conf in `pyproject.toml`
* disable step in `chore.yml` on merge

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
