### PR TITLE
♻️(backend) use fixtures instead of setup methods to make container in tests

### DIFF
--- a/src/tycho/tests/candidate/integration/test_integration_retrieve_corps.py
+++ b/src/tycho/tests/candidate/integration/test_integration_retrieve_corps.py
@@ -27,6 +27,10 @@ from infrastructure.repositories.shared import (
 from tests.fixtures.fixture_loader import load_fixture
 from tests.utils.mock_embedding_generator import MockEmbeddingGenerator
 
+# Test constants
+EXPECTED_TEST_CORPS_COUNT = 2
+EXPECTED_TEST_CORPS_COUNT_WITH_LIMIT = 1
+
 
 @pytest.fixture(name="embeddings", scope="session")
 def embeddings_fixture():
@@ -85,7 +89,7 @@ def corps_data_fixture(shared_container, embeddings):
     vector_repository = shared_container.vector_repository()
 
     corps_list = []
-    for corps_id, fixture_data in list(embeddings.items())[:2]:
+    for corps_id, fixture_data in list(embeddings.items())[:EXPECTED_TEST_CORPS_COUNT]:
         corps = Corps(
             id=int(corps_id),
             code=f"CODE{corps_id}",
@@ -129,7 +133,7 @@ def test_retrieve_corps_with_valid_query_returns_results(
 
     result = retrieve_corps_usecase.execute(query, limit=10)
 
-    assert len(result) == 2
+    assert len(result) == EXPECTED_TEST_CORPS_COUNT
     assert isinstance(result, list)
     assert isinstance(result[0], tuple)
     assert isinstance(result[0][0], Corps)
@@ -173,7 +177,7 @@ def test_retrieve_corps_respects_limit_parameter(
 
     result = retrieve_corps_usecase.execute(query, limit=1)
 
-    assert len(result) == 1
+    assert len(result) == EXPECTED_TEST_CORPS_COUNT_WITH_LIMIT
     assert isinstance(result[0], tuple)
     assert isinstance(result[0][0], Corps)
     assert isinstance(result[0][1], float)


### PR DESCRIPTION
## 📝 Description
🎸 convert django test style into pytest style

## 🏷️ Type of change
- [x] ♻️ Refactoring
- [x] 🔧 Technical change

## 🔧 Changes

Removed class-based structure - Converted from TransactionTestCase class to standalone pytest functions

Created pytest fixtures for setup:
- embedding_fixtures (session-scoped) - loads fixture data once for all tests
- shared_container - sets up the shared container with dependencies
- candidate_container - sets up the candidate container with mock services
- retrieve_corps_usecase - provides the usecase instance
- corps_data - creates test data in the database

Converted test methods to standalone functions with fixture dependencies

Replaced unittest assertions with pytest assertions:
- self.assertEqual() → assert ==
- self.assertIsInstance() → assert isinstance()
- self.assertGreaterEqual() → assert >=
- self.assertLessEqual() → assert <=

Improved dependency injection - Each fixture clearly defines its dependencies and what it provides

Add constants to avoid the magic number linting error

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
