### PR TITLE
🔧(sass) configure Sass/SCSS tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,15 @@ create-superuser: ## create tycho super user
 	@bin/manage createsuperuser --noinput || true
 .PHONY: create-superuser
 
+### SASS
+sass-compile: ## compile SCSS files to CSS
+	@bin/sass compile
+.PHONY: sass-compile
+
+sass-watch: ## watch and compile SCSS files on changes
+	@bin/sass watch
+.PHONY: sass-watch
+
 ### RUN
 run-all: ## run the whole stack
 run-all: \

--- a/bin/sass
+++ b/bin/sass
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Configuration
+SCSS_DIR="${SCSS_DIR:-src/tycho/presentation/assets/styles}"
+CSS_DIR="${CSS_DIR:-src/tycho/presentation/static/css}"
+SOURCE_MAP="${SOURCE_MAP:-false}"
+
+# Check if sass is installed
+if ! command -v sass >/dev/null 2>&1; then
+    echo "Error: Dart Sass CLI not found." >&2
+    exit 1
+fi
+
+# Parse command
+case "${1:-compile}" in
+    compile)
+        sass "$SCSS_DIR:$CSS_DIR" --no-source-map
+        ;;
+    watch)
+        sass "$SCSS_DIR:$CSS_DIR" --watch --no-source-map
+        ;;
+    *)
+        echo "Usage: $0 {compile|watch}" >&2
+        exit 1
+        ;;
+esac

--- a/docs/sass_configuration.md
+++ b/docs/sass_configuration.md
@@ -1,0 +1,26 @@
+# Sass/SCSS Configuration
+
+This project uses **Dart Sass CLI** (standalone binary) for compiling Sass/SCSS files.
+
+## Prerequisites
+
+[Install Dart Sass](https://sass-lang.com/install/#command-line)
+
+## Usage
+
+Compile once:
+```bash
+make sass-compile
+```
+
+Watch mode (auto-compile on save):
+```bash
+make sass-watch
+```
+
+## File Structure
+
+- **Sources**: `src/tycho/presentation/assets/styles/`
+- **Compiled**: `src/tycho/presentation/static/css/`
+
+Both SCSS and generated CSS files are committed.

--- a/src/tycho/presentation/assets/styles/main.scss
+++ b/src/tycho/presentation/assets/styles/main.scss
@@ -1,0 +1,5 @@
+.hello {
+  .world {
+    color: blue;
+  }
+}

--- a/src/tycho/presentation/static/css/main.css
+++ b/src/tycho/presentation/static/css/main.css
@@ -1,0 +1,3 @@
+.hello .world {
+  color: blue;
+}


### PR DESCRIPTION
## 📝 Description
Configure Sass/SCSS tooling using Dart Sass CLI (standalone binary) to enable CSS preprocessing without npm dependencies.

## 🏷️ Type of change
- [x] 🔧 Technical change

## 🔧 Changes
- Add `bin/sass` script for SCSS compilation (configurable via env vars)
- Create `assets/styles/` directory for source SCSS files
- Configure output to `static/css/` for compiled CSS
- Add Makefile targets: `sass-compile` and `sass-watch`
- Add documentation in `docs/sass_configuration.md`

🛸 **Dependency**: [Dart Sass CLI](https://sass-lang.com/install/#command-line)

## 🏝️ How to test
```bash
brew install sass/sass/sass
make sass-compile
make sass-watch
```

## 📸 Screenshots
N/A

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests. (N/A tooling)
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.