### PR TITLE
🔧(tooling:mypy) update domain types

### DIFF
--- a/src/notebook/pyproject.toml
+++ b/src/notebook/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 formats = "ipynb,md"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 exclude = [
     ".Trash-*",
     ".ipynb_checkpoints",

--- a/src/tycho/domain/types.py
+++ b/src/tycho/domain/types.py
@@ -1,15 +1,14 @@
 """Common type definitions for the domain layer."""
 
-from typing import Dict, List, Union
+from typing import Union
 
-from typing_extensions import TypeAlias
-
-JsonDataType: TypeAlias = Union[
+# Using PEP 695 type alias syntax for Python 3.12+
+type JsonDataType = Union[
     None,
     int,
     float,
     str,
     bool,
-    List["JsonDataType"],
-    Dict[str, "JsonDataType"],
+    list["JsonDataType"],
+    dict[str, "JsonDataType"],
 ]

--- a/src/tycho/pyproject.toml
+++ b/src/tycho/pyproject.toml
@@ -84,7 +84,7 @@ testpaths = [
 ]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 # Exclude a variety of commonly ignored directories.
 exclude = [
   "migrations",
@@ -120,6 +120,7 @@ select = [
 convention = "google"
 
 [tool.mypy]
+python_version = "3.12"
 ignore_missing_imports = true
 plugins = ["mypy_django_plugin.main"]
 exclude = [


### PR DESCRIPTION
## 📝 Description

`"RecursionError: maximum recursion depth exceeded - If you made use of an implicit recursive type alias (e.g. `MyType = list['MyType']), consider using PEP 695 type aliases instead"` raised.

Updating `domain/types.py` to make it compliant with python 3.12 raises `mypy` error:
```
invalid-syntax: Cannot use `type` alias statement on Python 3.10 (syntax was added in Python 3.12)
 --> domain/types.py:6:1
  |
5 | # Using PEP 695 type alias syntax for Python 3.12+
6 | type JsonDataType = Union[
  | ^^^^
7 |     None,
8 |     int,
  |
```
## 🏷️ Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Technical change

## 🔧 Changes
- update `target-version` in `tool.ruff` of `pyproject.toml` files

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
