### PR TITLE
✨(test:tycho) update test command to accept additional arguments (allows filtering)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,8 @@ test: \
 .PHONY: test
 
 test-tycho: ## test tycho python sources
-	@echo 'test:tychostarted…'
-	$(TYCHO_UV) pytest --numprocesses=logical --create-db
+	@echo 'test:tycho started…'
+	$(TYCHO_UV) pytest --numprocesses=logical --create-db $(ARGS)
 .PHONY: test-tycho
 
 ## MANAGE docker services


### PR DESCRIPTION
## Problème
La commande `make test` actuelle force le lancement de tous les tests, ce qui peut être pénible lorsqu'on itère sur scope réduit.

## Solution
Mettre à jour la commande pour passer les arguments à pytest