### PR TITLE
🔧(backend) let add custom domain to allowed hosts in dev

### DIFF
--- a/src/tycho/config/settings/dev.py
+++ b/src/tycho/config/settings/dev.py
@@ -4,7 +4,7 @@ from config.settings.base import *  # noqa: F403
 
 DEBUG = True
 
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "192.168.0.1", "0.0.0.0"]  # noqa S104
+ALLOWED_HOSTS += ["localhost", "127.0.0.1", "192.168.0.1", "0.0.0.0"]  # noqa S104
 
 # placeholder for dev logger setup
 


### PR DESCRIPTION
## 📝 Description
🎸 Locally, I use [DNS proxies](https://laravel.com/docs/12.x/valet#proxying-services) (`projectname.test` instead of `localhost:port`) to simplify dev ports management. For this project to handle this, it requires adding `csplab.test` in dev.py `ALLOWED_HOSTS`.

We could use as well use an env var ?

## 🏷️ Type of change
- [x] 🔧 Technical change

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
