### PR TITLE
🔧(tooling) make sure both vscode djlint and cli djlint use same config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,11 @@
     }
   },
   "[html][django-html][handlebars][hbs][mustache][jinja][jinja-html][nj][njk][nunjucks][twig]": {
-    "editor.defaultFormatter": "monosans.djlint"
+    "editor.defaultFormatter": "monosans.djlint",
+    "editor.formatOnSave": true
   },
   "djlint.useVenv": true,
+  "djlint.useEditorIndentation": false,
   "ruff.enable": true,
   "ruff.importStrategy": "fromEnvironment",
   "ruff.configuration": "${workspaceFolder}/src/tycho/pyproject.toml",
@@ -48,5 +50,8 @@
   "stylelint.enable": true,
   "stylelint.validate": ["css", "scss"],
   "stylelint.configFile": "${workspaceFolder}/.stylelintrc.json",
-  "prettier.enable": true
+  "prettier.enable": true,
+  "emmet.includeLanguages": {
+    "django-html": "html"
+  }
 }

--- a/src/tycho/pyproject.toml
+++ b/src/tycho/pyproject.toml
@@ -145,3 +145,7 @@ ignore_missing_imports = true
 [tool.django-stubs]
 django_settings_module = "config.settings.test"
 ignore_missing_model_attributes = true
+
+[tool.djlint]
+profile = "django"
+indent = 4


### PR DESCRIPTION
## 📝 Description
🎸 A misconfiguration was preventing cli djlint and vscode extension djlint to share config : one was applying 2 spaces indentation, the other 4

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Technical change