### PR TITLE
🐛(candidate) allow for optional field in cv experience

### DIFF
--- a/src/tycho/domain/value_objects/cv_extraction_types.py
+++ b/src/tycho/domain/value_objects/cv_extraction_types.py
@@ -9,9 +9,9 @@ class CVExperience(BaseModel):
     """Structure for a CV experience entry."""
 
     title: str
-    company: str
+    company: Optional[str]
     sector: Optional[str]
-    description: str
+    description: Optional[str]
 
 
 class CVExtractionResult(BaseModel):

--- a/src/tycho/tests/candidate/unit/test_unit_process_uploaded_cv.py
+++ b/src/tycho/tests/candidate/unit/test_unit_process_uploaded_cv.py
@@ -178,3 +178,54 @@ async def test_execute_json_decode_error_with_details(
     # Verify the error message contains detailed JSON parsing information
     error_message = str(exc_info.value)
     assert expected_error_message in error_message
+
+
+@pytest.mark.parametrize(
+    "container_name",
+    ["albert_candidate_container", "openai_candidate_container"],
+)
+async def test_execute_with_none_values_in_cv_data(
+    httpx_mock,
+    request,
+    pdf_content,
+    container_name,
+    cv_metadata_initial,
+    test_app_config,
+):
+    """Test that CV processing handles None values in company and description fields."""
+    container = request.getfixturevalue(container_name)
+    extractor_type = "albert" if "albert" in container_name else "openai"
+
+    # Use the new fixture with None values
+    mock_response = MockApiResponseFactory.create_ocr_response_with_none_values()
+
+    # Configuration spécifique selon l'extracteur
+    if extractor_type == "albert":
+        api_url = f"{test_app_config.albert_api_base_url}v1/ocr-beta"
+        response_json = MockApiResponseFactory.create_albert_ocr_response(mock_response)
+    else:  # openai
+        api_url = f"{test_app_config.openrouter_base_url}/chat/completions"
+        response_json = {
+            "choices": [{"message": {"content": json.dumps(mock_response)}}]
+        }
+
+    httpx_mock.add_response(
+        method="POST",
+        url=api_url,
+        json=response_json,
+        status_code=200,
+    )
+
+    # Unpack fixture data
+    initial_cv, cv_id = cv_metadata_initial
+
+    # Prepopulate the repository
+    repo = container.async_cv_metadata_repository()
+    await repo.save(initial_cv)
+
+    usecase = container.process_uploaded_cv_usecase()
+
+    # This should not raise a ValidationError anymore
+    result = await usecase.execute(cv_id, pdf_content)
+    assert isinstance(result, CVMetadata)
+    assert result.status == CVStatus.COMPLETED

--- a/src/tycho/tests/utils/mock_api_response_factory.py
+++ b/src/tycho/tests/utils/mock_api_response_factory.py
@@ -115,3 +115,28 @@ class MockApiResponseFactory:
                 "requests": 1,
             },
         }
+
+    @staticmethod
+    def create_ocr_response_with_none_values() -> Dict:
+        """Create a mock response with None values for company and description.
+
+        Returns:
+            Mock API response with None values that previously caused validation errors
+        """
+        return {
+            "experiences": [
+                {
+                    "title": "Développeur Senior",
+                    "company": None,
+                    "sector": "IT",
+                    "description": "Développement web",
+                },
+                {
+                    "title": "Chef de projet",
+                    "company": "StartupXYZ",
+                    "sector": None,
+                    "description": None,
+                },
+            ],
+            "skills": ["Python", "Django", "React"],
+        }


### PR DESCRIPTION
company not allways found by albert, so optionnal now

## 📝 Description
On some CV, Albert OCR does not identify company. Pydantic schema was strict abiout this field. It should be optinnal. Same for description.

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
Only title is mandatory now in `CVExperience` pydantic schema.

🛸 Required dependencies for this change (if applicable)

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
