### PR TITLE
✨(candidate) add simple client opportunity user feedback mechanism

### DIFF
--- a/src/tycho/config/settings/base.py
+++ b/src/tycho/config/settings/base.py
@@ -112,6 +112,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.contrib.messages.context_processors.messages",
                 "dsfr.context_processors.site_config",
+                "presentation.context_processors.matomo",
             ],
         },
     },

--- a/src/tycho/presentation/assets/styles/components/_feedback.scss
+++ b/src/tycho/presentation/assets/styles/components/_feedback.scss
@@ -1,0 +1,3 @@
+.csplab-feedback--throttled {
+  pointer-events: none;
+}

--- a/src/tycho/presentation/assets/styles/components/_index.scss
+++ b/src/tycho/presentation/assets/styles/components/_index.scss
@@ -3,3 +3,4 @@
 @forward "file-card";
 @forward "spinner";
 @forward "drawer";
+@forward "feedback";

--- a/src/tycho/presentation/candidate/mappers.py
+++ b/src/tycho/presentation/candidate/mappers.py
@@ -60,6 +60,8 @@ class ConcoursToTemplateMapper:
             )
         return {
             "title": concours.corps,
+            "opportunity_id": str(concours.id),
+            "opportunity_type": OpportunityType.CONCOURS,
             "opportunity_type_display": format_opportunity_type_display(
                 OpportunityType.CONCOURS
             ),
@@ -119,6 +121,8 @@ class OfferToTemplateMapper:
             )
         return {
             "title": offer.title,
+            "opportunity_id": str(offer.id),
+            "opportunity_type": OpportunityType.OFFER,
             "opportunity_type_display": format_opportunity_type_display(
                 OpportunityType.OFFER
             ),

--- a/src/tycho/presentation/candidate/types.py
+++ b/src/tycho/presentation/candidate/types.py
@@ -56,6 +56,8 @@ class DrawerContext(TypedDict):
     """Template context for an opportunity drawer."""
 
     title: str
+    opportunity_id: str
+    opportunity_type: str
     opportunity_type_display: str
     versant_display: str
     category_display: str

--- a/src/tycho/presentation/context_processors.py
+++ b/src/tycho/presentation/context_processors.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+from django.http import HttpRequest
+
+
+def matomo(request: HttpRequest) -> dict[str, object]:
+    return {
+        "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
+        "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
+    }

--- a/src/tycho/presentation/static/candidate/js/opportunity-feedback.js
+++ b/src/tycho/presentation/static/candidate/js/opportunity-feedback.js
@@ -1,0 +1,180 @@
+class OpportunityFeedbackHandler {
+  static STORAGE_KEY = 'csplab-feedback';
+  static DEBUG_KEY = 'csplab-feedback-debug';
+  static THROTTLE_MS = 1000;
+  static ICON_RE = /fr-icon-thumb-(up|down)-(line|fill)/;
+
+  /** @type {HTMLElement} */
+  container;
+
+  /** @type {string} */
+  opportunityId;
+
+  /** @type {string} */
+  opportunityType;
+
+  /** @type {number|null} */
+  throttleTimer;
+
+  /**
+   * @param {HTMLElement} container
+   */
+  constructor(container) {
+    this.container = container;
+    this.opportunityId = container.dataset.opportunityId;
+    this.opportunityType = container.dataset.opportunityType;
+    this.throttleTimer = null;
+
+    this.init();
+  }
+
+  init() {
+    this.restoreState();
+    OpportunityFeedbackHandler.log('init', {
+      opportunityId: this.opportunityId,
+      opportunityType: this.opportunityType,
+      restored: OpportunityFeedbackHandler.getStoredFeedbacks()[this.opportunityId] ?? null,
+    });
+
+    if (this.container.dataset.feedbackInit) return;
+    this.container.dataset.feedbackInit = 'true';
+
+    this.setupClickHandler();
+  }
+
+  restoreState() {
+    const stored = OpportunityFeedbackHandler.getStoredFeedbacks();
+    if (stored[this.opportunityId]) {
+      this.updateButtonStates(stored[this.opportunityId]);
+    }
+  }
+
+  setupClickHandler() {
+    this.container.addEventListener('click', (e) => this.handleClick(e));
+  }
+
+  /**
+   * @param {MouseEvent} e
+   */
+  handleClick(e) {
+    const btn = e.target.closest('.csplab-feedback__btn');
+    if (!btn) return;
+    if (this.throttleTimer) return;
+
+    const { sentiment } = btn.dataset;
+
+    this.throttleTimer = setTimeout(() => {
+      this.setThrottled(false);
+      this.throttleTimer = null;
+    }, OpportunityFeedbackHandler.THROTTLE_MS);
+    this.setThrottled(true);
+
+    const currentSentiment = OpportunityFeedbackHandler.getStoredFeedbacks()[this.opportunityId];
+
+    if (currentSentiment === sentiment) {
+      this.updateButtonStates(null);
+      OpportunityFeedbackHandler.removeFeedback(this.opportunityId);
+      this.trackMatomoEvent('neutral');
+      return;
+    }
+
+    this.updateButtonStates(sentiment);
+    OpportunityFeedbackHandler.storeFeedback(this.opportunityId, sentiment);
+    this.trackMatomoEvent(sentiment);
+  }
+
+  /**
+   * @param {string|null} activeSentiment
+   */
+  updateButtonStates(activeSentiment) {
+    for (const btn of this.container.querySelectorAll('.csplab-feedback__btn')) {
+      const isActive = btn.dataset.sentiment === activeSentiment;
+      btn.setAttribute('aria-pressed', String(isActive));
+
+      const match = btn.className.match(OpportunityFeedbackHandler.ICON_RE);
+      if (match) {
+        const variant = isActive ? 'fill' : 'line';
+        btn.className = btn.className.replace(
+          OpportunityFeedbackHandler.ICON_RE,
+          `fr-icon-thumb-${match[1]}-${variant}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * @param {boolean} throttled
+   */
+  setThrottled(throttled) {
+    this.container.classList.toggle('csplab-feedback--throttled', throttled);
+  }
+
+  /**
+   * @param {string} sentiment
+   */
+  trackMatomoEvent(sentiment) {
+    const label = `${this.opportunityType}:${this.opportunityId}`;
+    OpportunityFeedbackHandler.log('trackEvent', {
+      category: 'OpportunityFeedback',
+      action: sentiment,
+      name: label,
+    });
+
+    const paq = (window._paq ??= []);
+    paq.push(['trackEvent', 'OpportunityFeedback', sentiment, label]);
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  static isDebug() {
+    return localStorage.getItem(OpportunityFeedbackHandler.DEBUG_KEY) === 'true';
+  }
+
+  /**
+   * @param  {...any} args
+   */
+  static log(...args) {
+    if (OpportunityFeedbackHandler.isDebug()) {
+      console.debug('%c[feedback]', 'color: #6a6af4; font-weight: bold', ...args);
+    }
+  }
+
+  /**
+   * @returns {Record<string, string>}
+   */
+  static getStoredFeedbacks() {
+    try {
+      return JSON.parse(localStorage.getItem(OpportunityFeedbackHandler.STORAGE_KEY) ?? '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * @param {string} opportunityId
+   * @param {string} sentiment
+   */
+  static storeFeedback(opportunityId, sentiment) {
+    const feedbacks = OpportunityFeedbackHandler.getStoredFeedbacks();
+    feedbacks[opportunityId] = sentiment;
+    localStorage.setItem(OpportunityFeedbackHandler.STORAGE_KEY, JSON.stringify(feedbacks));
+  }
+
+  /**
+   * @param {string} opportunityId
+   */
+  static removeFeedback(opportunityId) {
+    const feedbacks = OpportunityFeedbackHandler.getStoredFeedbacks();
+    delete feedbacks[opportunityId];
+    localStorage.setItem(OpportunityFeedbackHandler.STORAGE_KEY, JSON.stringify(feedbacks));
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.csplab-feedback').forEach((el) => new OpportunityFeedbackHandler(el));
+});
+
+document.addEventListener('htmx:afterSwap', () => {
+  document.querySelectorAll('.csplab-feedback').forEach((el) => new OpportunityFeedbackHandler(el));
+});

--- a/src/tycho/presentation/static/css/main.css
+++ b/src/tycho/presentation/static/css/main.css
@@ -1070,6 +1070,10 @@ hr {
     transition: none;
   }
 }
+.csplab-feedback--throttled {
+  pointer-events: none;
+}
+
 .csplab-hero__title {
   font-size: 2rem;
   line-height: 112.5%;

--- a/src/tycho/presentation/templates/candidate/components/_opportunity_drawer_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_opportunity_drawer_content.html
@@ -1,22 +1,27 @@
 {% load dsfr_tags %}
-<div class="csplab-drawer__content fr-stack-3w">
-    <h2 id="drawer-title" data-drawer-title class="fr-h4">{{ opportunity.title }}</h2>
-    <ul class="fr-tags-group">
-        {% if opportunity.opportunity_type_display %}
-            <li>
-                {% dsfr_tag label=opportunity.opportunity_type_display extra_classes="fr-icon-briefcase-line fr-tag--icon-left" %}
-            </li>
-        {% endif %}
-        {% if opportunity.versant_display %}
-            <li>{% dsfr_tag label=opportunity.versant_display extra_classes="fr-icon-government-line fr-tag--icon-left" %}</li>
-        {% endif %}
-        {% if opportunity.category_display %}
-            <li>{% dsfr_tag label=opportunity.category_display extra_classes="fr-icon-award-line fr-tag--icon-left" %}</li>
-        {% endif %}
-    </ul>
-    {% if opportunity.accordions %}
-        {% dsfr_accordion_group opportunity.accordions %}
-    {% endif %}
+<div class="csplab-drawer__content">
+    <div class="fr-stack-4w fr-stack-md-5w">
+        <div class="fr-stack-2w fr-stack-md-3w">
+            <h2 id="drawer-title" data-drawer-title class="fr-h4">{{ opportunity.title }}</h2>
+            <ul class="fr-tags-group">
+                {% if opportunity.opportunity_type_display %}
+                    <li>
+                        {% dsfr_tag label=opportunity.opportunity_type_display extra_classes="fr-icon-briefcase-line fr-tag--icon-left" %}
+                    </li>
+                {% endif %}
+                {% if opportunity.versant_display %}
+                    <li>{% dsfr_tag label=opportunity.versant_display extra_classes="fr-icon-government-line fr-tag--icon-left" %}</li>
+                {% endif %}
+                {% if opportunity.category_display %}
+                    <li>{% dsfr_tag label=opportunity.category_display extra_classes="fr-icon-award-line fr-tag--icon-left" %}</li>
+                {% endif %}
+            </ul>
+            {% if opportunity.accordions %}
+                {% dsfr_accordion_group opportunity.accordions %}
+            {% endif %}
+        </div>
+        {% include "candidate/components/_opportunity_feedback.html" with opportunity_id=concours.opportunity_id opportunity_type=concours.opportunity_type %}
+    </div>
 </div>
 <footer class="csplab-drawer__footer">
     <div class="fr-background-alt--grey fr-p-3w fr-stack-2w">

--- a/src/tycho/presentation/templates/candidate/components/_opportunity_feedback.html
+++ b/src/tycho/presentation/templates/candidate/components/_opportunity_feedback.html
@@ -1,0 +1,21 @@
+<div class="csplab-feedback fr-stack-1w"
+     data-opportunity-id="{{ opportunity_id }}"
+     data-opportunity-type="{{ opportunity_type }}">
+    <p class="fr-text--bold">Que pensez-vous de cette proposition&nbsp;?</p>
+    <ul class="fr-btns-group fr-btns-group--inline">
+        <li>
+            <button type="button"
+                    class="fr-btn fr-btn--tertiary fr-icon-thumb-up-line csplab-feedback__btn"
+                    data-sentiment="positive"
+                    aria-pressed="false"
+                    aria-label="Cette proposition est pertinente"></button>
+        </li>
+        <li>
+            <button type="button"
+                    class="fr-btn fr-btn--tertiary fr-icon-thumb-down-line csplab-feedback__btn"
+                    data-sentiment="negative"
+                    aria-pressed="false"
+                    aria-label="Cette proposition n'est pas pertinente"></button>
+        </li>
+    </ul>
+</div>

--- a/src/tycho/presentation/templates/candidate/cv_results.html
+++ b/src/tycho/presentation/templates/candidate/cv_results.html
@@ -7,3 +7,9 @@
     {% include "candidate/components/_results_content.html" %}
     {% include "components/_drawer.html" with drawer_id="opportunity-drawer" drawer_label="Détail de l'opportunité" drawer_body_id="opportunity-drawer-body" %}
 {% endblock main %}
+{% block page_js %}
+    {{ block.super }}
+    <script src="{% static 'candidate/js/opportunity-feedback.js' %}"
+            defer
+            nonce="{{ request.csp_nonce }}"></script>
+{% endblock page_js %}

--- a/src/tycho/presentation/templates/layouts/base.html
+++ b/src/tycho/presentation/templates/layouts/base.html
@@ -55,6 +55,20 @@
         {% endblock theme_modale %}
         {% dsfr_js nonce=request.csp_nonce %}
         {% htmx_script %}
+        {% if MATOMO_BASE_URL %}
+            <script nonce="{{ request.csp_nonce }}">
+                var _paq = window._paq = window._paq || [];
+                _paq.push(['trackPageView']);
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="{{ MATOMO_BASE_URL }}";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '{{ MATOMO_SITE_ID }}']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            </script>
+        {% endif %}
         {% block page_js %}
         {% endblock page_js %}
     </body>


### PR DESCRIPTION
## 📝 Description
Add thumbs up/down feedback buttons in the opportunity drawer (offers & concours). Feedback is tracked via Matomo `trackEvent` and persisted client-side in `localStorage`.

## 🏷️ Type of change
- [x] 🎢 New feature (non-breaking change that adds functionality)

## 🔧 Changes

- **Matomo**: context processor + tracking script with CSP nonce in `base.html`
- **Feedback partial**: DSFR tertiary buttons with thumb icons, included in both drawer content templates
- **JS**: localStorage persistence, toggle to neutral on re-click, 1s throttle with `pointer-events: none`, `htmx:afterSwap` re-init, opt-in debug mode
- **Mappers/Types**: `opportunity_id` + `opportunity_type` added to `DrawerContext` and both `map_for_drawer()` methods
- **SCSS**: hover neutralization during throttle

<img width="519" height="912" alt="Capture d’écran 2026-03-05 à 08 49 59" src="https://github.com/user-attachments/assets/d9e96936-d9a6-446e-93f6-ab8e5dadf65f" />
<img width="470" height="118" alt="Capture d’écran 2026-03-05 à 08 52 51" src="https://github.com/user-attachments/assets/333cfb12-e9a7-43d4-b327-ab439ed51290" />

## 🏝️ How to test

1. Open CV results → click an opportunity → drawer opens
2. Thumbs buttons appear below the accordions
3. Click a thumb → filled icon, re-click → reset (neutral event)
4. Close/reopen drawer → state restored from `localStorage`
5. Debug: enter `localStorage.setItem("csplab-feedback-debug", "true")` in the browser console to see Matomo events logged in the console

<img width="738" height="244" alt="Capture d’écran 2026-03-05 à 08 51 59" src="https://github.com/user-attachments/assets/529e2f83-c222-4096-b863-1be3d54a2d56" />
<img width="739" height="259" alt="Capture d’écran 2026-03-05 à 08 52 33" src="https://github.com/user-attachments/assets/a812bfdf-cb91-45b0-b19b-e40e466a5b06" />

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.
