### PR TITLE
✨(candidate) add feedback modal and trigger button in cv results page when matching return results

### DIFF
--- a/src/tycho/presentation/assets/styles/components/_feedback-modal.scss
+++ b/src/tycho/presentation/assets/styles/components/_feedback-modal.scss
@@ -1,0 +1,19 @@
+.csplab-feedback-btn {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 500;
+  opacity: 0;
+  animation: csplab-feedback-fade-in 0.5s ease-out 3s forwards;
+}
+
+@keyframes csplab-feedback-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/tycho/presentation/assets/styles/components/_index.scss
+++ b/src/tycho/presentation/assets/styles/components/_index.scss
@@ -4,3 +4,4 @@
 @forward "spinner";
 @forward "drawer";
 @forward "feedback";
+@forward "feedback-modal";

--- a/src/tycho/presentation/static/css/main.css
+++ b/src/tycho/presentation/static/css/main.css
@@ -1074,6 +1074,25 @@ hr {
   pointer-events: none;
 }
 
+.csplab-feedback-btn {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 500;
+  opacity: 0;
+  animation: csplab-feedback-fade-in 0.5s ease-out 3s forwards;
+}
+
+@keyframes csplab-feedback-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 .csplab-hero__title {
   font-size: 2rem;
   line-height: 112.5%;

--- a/src/tycho/presentation/templates/candidate/components/_tally_results_modal.html
+++ b/src/tycho/presentation/templates/candidate/components/_tally_results_modal.html
@@ -1,0 +1,24 @@
+{% if tally_form_id %}
+    <button class="csplab-feedback-btn fr-btn fr-icon-chat-quote-line fr-btn--icon-left"
+            aria-controls="tally-results-modal"
+            data-fr-opened="false">Donnez votre avis sur ces résultats</button>
+    <dialog id="tally-results-modal"
+            class="fr-modal"
+            aria-labelledby="tally-results-modal-title">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn" aria-controls="tally-results-modal">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h1 id="tally-results-modal-title" class="fr-modal__title">Donnez votre avis</h1>
+                            {% include "candidate/components/_tally_feedback.html" with tally_form_id=tally_form_id cv_uuid=cv_uuid iframe_height=400 %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
+{% endif %}

--- a/src/tycho/presentation/templates/candidate/cv_results.html
+++ b/src/tycho/presentation/templates/candidate/cv_results.html
@@ -6,6 +6,7 @@
 {% block main %}
     {% include "candidate/components/_results_content.html" %}
     {% include "components/_drawer.html" with drawer_id="opportunity-drawer" drawer_label="Détail de l'opportunité" drawer_body_id="opportunity-drawer-body" %}
+    {% include "candidate/components/_tally_results_modal.html" %}
 {% endblock main %}
 {% block page_js %}
     {{ block.super }}

--- a/src/tycho/tests/candidate/integration/test_cv_results_view.py
+++ b/src/tycho/tests/candidate/integration/test_cv_results_view.py
@@ -475,3 +475,30 @@ def test_cv_results_no_results_includes_tally_iframe(
     assert response.status_code == HTTPStatus.OK
     assertContains(response, "tally.so/embed/test-no-results-form")
     assertContains(response, f"cv_uuid={cv_uuid}")
+
+
+@patch("presentation.candidate.views.cv_flow.CVResultsView._get_cv_processing_status")
+def test_cv_results_with_results_includes_tally_modal(
+    mock_get_status, client, db, settings
+):
+    cv_uuid = uuid4()
+    settings.TALLY_FORM_ID_RESULTS = "test-results-form"
+    mock_get_status.return_value = {
+        "status": CVStatus.COMPLETED,
+        "opportunities": [
+            {
+                "title": "Poste test",
+                "location_value": "75",
+                "category_value": "a",
+                "opportunity_type": OpportunityType.CONCOURS,
+                "concours_id": str(uuid4()),
+            },
+        ],
+    }
+
+    response = client.get(reverse("candidate:cv_results", kwargs={"cv_uuid": cv_uuid}))
+
+    assert response.status_code == HTTPStatus.OK
+    assertContains(response, "tally.so/embed/test-results-form")
+    assertContains(response, f"cv_uuid={cv_uuid}")
+    assertContains(response, "tally-results-modal")


### PR DESCRIPTION
## 📝 Description
🎸 see title

## 🏷️ Type of change
- [ ] 🐛 Bug fix
- [x] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
- add a static button in bottom hand corner to trigger feedback modal open which gets displayed after a 3s delay
- add a modal containing a tally iframe form to

## 🏝️ How to test (if applicable)
- navigate to a cv results page
- wait 3s
- click on button in bottom right hand corner
- inspect modal and close

Note : 
- the modal open button placement is subject to change, to be discussed before eventual stabilization
- if we keep this behaviour, we should improve keyboard navigation, right now it is tedious to trigger, maybe in link with #259 

## 📸 Screenshots (if applicable)
<img width="424" height="154" alt="Capture d’écran 2026-03-05 à 11 21 29" src="https://github.com/user-attachments/assets/e965f723-b675-4f7f-bc85-28e49df3581e" />
<img width="1707" height="961" alt="Capture d’écran 2026-03-05 à 11 21 36" src="https://github.com/user-attachments/assets/77a81368-781e-43b4-94f7-9b16c8d286a0" />


## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
