### PR TITLE
🐛(candidate) fix htmx targetError on poll-to-results transition

### DIFF
--- a/src/tycho/presentation/candidate/views/cv_flow.py
+++ b/src/tycho/presentation/candidate/views/cv_flow.py
@@ -119,6 +119,14 @@ class CVResultsView(BreadcrumbMixin, TemplateView):
             response["HX-Reswap"] = "none"
             return response
 
+        if is_htmx and request.GET.get("poll"):
+            response = HttpResponse()
+            cv_uuid = self.kwargs["cv_uuid"]
+            response["HX-Redirect"] = str(
+                reverse_lazy("candidate:cv_results", kwargs={"cv_uuid": cv_uuid})
+            )
+            return response
+
         if self.status == CVStatus.FAILED:
             messages.error(
                 request,

--- a/src/tycho/presentation/templates/candidate/components/_processing_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_processing_content.html
@@ -1,6 +1,6 @@
 {% load static %}
 <div class="fr-background-alt--blue-france"
-     hx-get="{% url 'candidate:cv_results' cv_uuid %}"
+     hx-get="{% url 'candidate:cv_results' cv_uuid %}?poll=1"
      hx-trigger="every {{ poll_interval }}s"
      hx-swap="outerHTML">
     <div class="fr-container">

--- a/src/tycho/tests/candidate/integration/test_cv_results_view.py
+++ b/src/tycho/tests/candidate/integration/test_cv_results_view.py
@@ -37,6 +37,7 @@ def test_cv_results_page_loads_correctly(
     assertTemplateUsed(response, "candidate/cv_results.html")
     assertContains(response, "Vos opportunités professionnelles")
     assertContains(response, "fr-breadcrumb")
+    assertContains(response, 'id="opportunity-drawer-body"')
 
 
 def test_cv_results_invalid_uuid_returns_404(client, db):
@@ -295,7 +296,7 @@ def test_cv_processing_flow_pending_to_completed(
         f'hx-trigger="every {settings.CV_PROCESSING_POLL_INTERVAL}s"',
     )
 
-    response_poll = client.get(url, HTTP_HX_REQUEST="true")
+    response_poll = client.get(url, {"poll": "1"}, HTTP_HX_REQUEST="true")
     assert response_poll.status_code == HTTPStatus.NO_CONTENT
     assert response_poll["HX-Reswap"] == "none"
 
@@ -303,11 +304,9 @@ def test_cv_processing_flow_pending_to_completed(
         "status": CVStatus.COMPLETED,
         "opportunities": [{"title": "Test opportunity"}],
     }
-    response_completed = client.get(url, HTTP_HX_REQUEST="true")
+    response_completed = client.get(url, {"poll": "1"}, HTTP_HX_REQUEST="true")
     assert response_completed.status_code == HTTPStatus.OK
-    assertTemplateUsed(response_completed, "candidate/components/_results_content.html")
-    assertContains(response_completed, "Vos opportunités professionnelles")
-    assertNotContains(response_completed, 'hx-trigger="every')
+    assert response_completed["HX-Redirect"] == url
 
 
 def test_cv_results_with_pending_cv_in_database_shows_processing(client, db):
@@ -360,17 +359,16 @@ def test_cv_results_htmx_poll_pending_to_completed_transition(
     model.save()
     url = reverse("candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id})
 
-    response_pending = client.get(url, HTTP_HX_REQUEST="true")
+    response_pending = client.get(url, {"poll": "1"}, HTTP_HX_REQUEST="true")
     assert response_pending.status_code == HTTPStatus.NO_CONTENT
     assert response_pending["HX-Reswap"] == "none"
 
     model.status = CVStatus.COMPLETED.value
     model.save()
 
-    response_completed = client.get(url, HTTP_HX_REQUEST="true")
-    assertTemplateUsed(response_completed, "candidate/components/_results_content.html")
-    assertContains(response_completed, "Vos opportunités professionnelles")
-    assertNotContains(response_completed, 'hx-trigger="every')
+    response_completed = client.get(url, {"poll": "1"}, HTTP_HX_REQUEST="true")
+    assert response_completed.status_code == HTTPStatus.OK
+    assert response_completed["HX-Redirect"] == url
 
 
 def test_cv_results_nonexistent_cv_redirects_to_upload(client, db):


### PR DESCRIPTION
 new drawer/dialog component was not included in partial used to replace content by htmx when switching from polling to results page => decided to change detection mechanism to  using `?poll=1` in request and full `HX-Redirect` when cv anazlysis completed to include the whole page

## 🏝️ How to test
1. Try the full flow (cv upload, redirection on results and opening an offer drawer) => should show no error now

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
