### PR TITLE
🔒️(config) add style-src-attr CSP directive and dev overrides

### DIFF
--- a/src/tycho/config/settings/base.py
+++ b/src/tycho/config/settings/base.py
@@ -253,6 +253,7 @@ SECURE_CSP = {
     "script-src-elem": script_src,
     "style-src": style_src,
     "style-src-elem": style_src,
+    "style-src-attr": [CSP.UNSAFE_INLINE],
 }
 
 # Django REST Framework

--- a/src/tycho/config/settings/dev.py
+++ b/src/tycho/config/settings/dev.py
@@ -1,5 +1,7 @@
 """Django settings for tycho project in dev mode."""
 
+from django.utils.csp import CSP
+
 from config.settings.base import *  # noqa: F403
 
 DEBUG = True
@@ -37,3 +39,13 @@ STORAGES = {
 }
 
 SENTRY_DNS = "example.com"
+
+# CSP: replace nonce with unsafe-inline for debug toolbar in dev
+SECURE_CSP["script-src"] = [CSP.SELF, CSP.UNSAFE_INLINE, "https://tally.so"]  # noqa: F405
+SECURE_CSP["script-src-elem"] = [CSP.SELF, CSP.UNSAFE_INLINE, "https://tally.so"]  # noqa: F405
+SECURE_CSP["style-src"] = [CSP.SELF, CSP.UNSAFE_INLINE, "https://fonts.googleapis.com"]  # noqa: F405
+SECURE_CSP["style-src-elem"] = [  # noqa: F405
+    CSP.SELF,
+    CSP.UNSAFE_INLINE,
+    "https://fonts.googleapis.com",
+]


### PR DESCRIPTION
## 📝 Description
- Add `style-src-attr: 'unsafe-inline'` to CSP policy to allow inline styles applied by htmx when transitionning DOM.

## 🏷️ Type of change
- [x] 🔒️ Security fix

## 🏝️ How to test
1. Test app in local dev => verify no csp errors in console
2. In staging env => verify we have no `style-src-attr` error in console when using htmx transitions

## ✅ Checklist
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.