### PR TITLE
🐛(security) fix request.csp_nonce into csp_nonce

### DIFF
--- a/src/tycho/presentation/templates/candidate/cv_results.html
+++ b/src/tycho/presentation/templates/candidate/cv_results.html
@@ -12,5 +12,5 @@
     {{ block.super }}
     <script src="{% static 'candidate/js/opportunity-feedback.js' %}"
             defer
-            nonce="{{ request.csp_nonce }}"></script>
+            nonce="{{ csp_nonce }}"></script>
 {% endblock page_js %}

--- a/src/tycho/presentation/templates/layouts/base.html
+++ b/src/tycho/presentation/templates/layouts/base.html
@@ -53,10 +53,9 @@
         {% block theme_modale %}
             {% dsfr_theme_modale %}
         {% endblock theme_modale %}
-        {% dsfr_js nonce=request.csp_nonce %}
-        {% htmx_script %}
+        {% dsfr_js nonce=csp_nonce %}
         {% if MATOMO_BASE_URL %}
-            <script nonce="{{ request.csp_nonce }}">
+            <script nonce="{{ csp_nonce }}">
                 var _paq = window._paq = window._paq || [];
                 _paq.push(['trackPageView']);
                 _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
## 📝 Description
🎸 `request.csp_nonce` used by `django-csp`, which is not installed. `csp_nonce` should be used with ` django.middleware.csp.ContentSecurityPolicyMiddleware`


## 🏷️ Type of change
- [x] 🐛 Bug fix


## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
