### PR TITLE
🐛(candidate) fix opportunity variable reference in feedback component inclusion

### DIFF
--- a/src/tycho/presentation/templates/candidate/components/_opportunity_drawer_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_opportunity_drawer_content.html
@@ -20,7 +20,7 @@
                 {% dsfr_accordion_group opportunity.accordions %}
             {% endif %}
         </div>
-        {% include "candidate/components/_opportunity_feedback.html" with opportunity_id=concours.opportunity_id opportunity_type=concours.opportunity_type %}
+        {% include "candidate/components/_opportunity_feedback.html" with opportunity_id=opportunity.opportunity_id opportunity_type=opportunity.opportunity_type %}
     </div>
 </div>
 <footer class="csplab-drawer__footer">


### PR DESCRIPTION
An improperly resolved conflict caused the user feedback key in local storage to be empty, breaking the feature