### PR TITLE
✨(candidate) implement pagination for cv results

### DIFF
--- a/src/tycho/config/settings/base.py
+++ b/src/tycho/config/settings/base.py
@@ -181,6 +181,9 @@ CV_PROCESSING_POLL_INTERVAL = 2
 # Maximum number of opportunities returned by the matching use case
 CV_MAX_OPPORTUNITIES = 10
 
+# Number of results per page in CV results view
+CV_RESULTS_PER_PAGE = 6
+
 # Logging configuration
 LOG_LEVEL = env.str("LOG_LEVEL")
 

--- a/src/tycho/presentation/candidate/views/cv_flow.py
+++ b/src/tycho/presentation/candidate/views/cv_flow.py
@@ -6,10 +6,12 @@ from uuid import UUID
 
 from django.conf import settings
 from django.contrib import messages
+from django.core.paginator import Paginator
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import FormView, TemplateView
+from dsfr.utils import list_pages
 
 from domain.entities.concours import Concours
 from domain.entities.cv_metadata import CVMetadata
@@ -247,8 +249,14 @@ class CVResultsView(BreadcrumbMixin, TemplateView):
         # TODO We may want to use a template tag to count opportunities to display,
         # and get context lighter.
         if isinstance(self.opportunities, list):
-            context["results"] = self._filter_results(self.opportunities)
-            context["results_count"] = len(context["results"])
+            filtered = self._filter_results(self.opportunities)
+            context["results_count"] = len(filtered)
+
+            paginator = Paginator(filtered, settings.CV_RESULTS_PER_PAGE)
+            page_obj = paginator.get_page(self.request.GET.get("page", 1))
+            list_pages(page_obj)
+            context["results"] = page_obj.object_list
+            context["page_obj"] = page_obj
 
         if self.opportunities:
             context["tally_form_id"] = settings.TALLY_FORM_ID_RESULTS

--- a/src/tycho/presentation/templates/candidate/components/_results_list.html
+++ b/src/tycho/presentation/templates/candidate/components/_results_list.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n dsfr_tags %}
 <div class="fr-stack-3w">
     <p class="fr-text--lg">
         <span class="fr-text--bold">{{ results_count|default:0 }} résultat{{ results_count|pluralize:"s" }}</span>
@@ -17,4 +17,11 @@
             <p class="fr-text--sm fr-text--disabled">Aucun résultat pour le moment.</p>
         {% endif %}
     </div>
+    {% if page_obj.paginator.num_pages > 1 %}
+        <div class="fr-grid-row fr-grid-row--center"
+             hx-boost="true"
+             hx-target="#results-zone"
+             hx-swap="innerHTML"
+             hx-push-url="true">{% dsfr_pagination page_obj %}</div>
+    {% endif %}
 </div>

--- a/src/tycho/tests/candidate/integration/test_cv_results_view.py
+++ b/src/tycho/tests/candidate/integration/test_cv_results_view.py
@@ -561,3 +561,94 @@ def test_cv_results_with_results_includes_tally_modal(
     assertContains(response, "tally.so/embed/test-results-form")
     assertContains(response, f"cv_uuid={cv_uuid}")
     assertContains(response, "tally-results-modal")
+
+
+@patch("presentation.candidate.views.cv_flow.CVResultsView._get_cv_processing_status")
+def test_cv_results_pagination_default_page(
+    mock_get_status, client, db, db_cv_uuid, settings
+):
+    settings.CV_RESULTS_PER_PAGE = 2
+    mock_get_status.return_value = {
+        "status": CVStatus.COMPLETED,
+        "opportunities": [
+            {
+                "title": f"Opportunity {i}",
+                "location_value": "75",
+                "category_value": "a",
+                "opportunity_type": OpportunityType.CONCOURS,
+                "concours_id": str(uuid4()),
+            }
+            for i in range(5)
+        ],
+    }
+    response = client.get(
+        reverse("candidate:cv_results", kwargs={"cv_uuid": db_cv_uuid})
+    )
+    assert response.status_code == HTTPStatus.OK
+    assertContains(response, "Opportunity 0")
+    assertContains(response, "Opportunity 1")
+    assertNotContains(response, "Opportunity 2")
+
+
+@patch("presentation.candidate.views.cv_flow.CVResultsView._get_cv_processing_status")
+def test_cv_results_pagination_second_page(
+    mock_get_status, client, db, db_cv_uuid, settings
+):
+    settings.CV_RESULTS_PER_PAGE = 2
+    mock_get_status.return_value = {
+        "status": CVStatus.COMPLETED,
+        "opportunities": [
+            {
+                "title": f"Opportunity {i}",
+                "location_value": "75",
+                "category_value": "a",
+                "opportunity_type": OpportunityType.CONCOURS,
+                "concours_id": str(uuid4()),
+            }
+            for i in range(5)
+        ],
+    }
+    response = client.get(
+        reverse("candidate:cv_results", kwargs={"cv_uuid": db_cv_uuid}), {"page": "2"}
+    )
+    assert response.status_code == HTTPStatus.OK
+    assertContains(response, "Opportunity 2")
+    assertContains(response, "Opportunity 3")
+    assertNotContains(response, "Opportunity 0")
+
+
+@patch("presentation.candidate.views.cv_flow.CVResultsView._get_cv_processing_status")
+def test_cv_results_pagination_with_filters(
+    mock_get_status, client, db, db_cv_uuid, settings
+):
+    settings.CV_RESULTS_PER_PAGE = 1
+    mock_get_status.return_value = {
+        "status": CVStatus.COMPLETED,
+        "opportunities": [
+            {
+                "title": f"Paris {i}",
+                "location_value": "75",
+                "category_value": "a",
+                "opportunity_type": OpportunityType.CONCOURS,
+                "concours_id": str(uuid4()),
+            }
+            for i in range(3)
+        ]
+        + [
+            {
+                "title": "Lyon 0",
+                "location_value": "69",
+                "category_value": "a",
+                "opportunity_type": OpportunityType.CONCOURS,
+                "concours_id": str(uuid4()),
+            },
+        ],
+    }
+    response = client.get(
+        reverse("candidate:cv_results", kwargs={"cv_uuid": db_cv_uuid}),
+        {"filter-location": "75", "page": "2"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    assertContains(response, "Paris 1")
+    assertNotContains(response, "Paris 0")
+    assertNotContains(response, "Lyon 0")


### PR DESCRIPTION
## 📝 Description
🎸 see title

## 🏷️ Type of change
- [ ] 🐛 Bug fix
- [x] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
- use django paginator to paginate cv matching results
- add django-dsfr pagination component
- wire through htmx

## 🏝️ How to test (if applicable)
- navigate to a cv results page and play with pagination
- reload page 2 to verify full reload works well

## 📸 Screenshots (if applicable)
<img width="383" height="296" alt="Capture d’écran 2026-03-06 à 13 25 46" src="https://github.com/user-attachments/assets/e0bf5988-0a17-4190-8a8b-f87cac2d9c66" />
<img width="1365" height="565" alt="Capture d’écran 2026-03-06 à 13 25 59" src="https://github.com/user-attachments/assets/591236a1-26a1-446f-9c06-42d57608505e" />


## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
