### PR TITLE
🔧(dev) add auto-reload and django-browser-reload integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,14 @@ run-tycho: ## run the tycho service
 	@bin/manage runserver
 .PHONY: run-tycho
 
+dev: ## run tycho with sass watch and browser auto-reload
+	@echo "🚀 Starting development server with auto-reload..."
+	@echo "   Press Ctrl+C to stop all processes"
+	@trap 'kill 0' EXIT; \
+	bin/sass watch & \
+	bin/manage runserver
+.PHONY: dev
+
 ## LINT
 # -- Global linting
 lint: ## lint all sources

--- a/docs/browser_auto_reload.md
+++ b/docs/browser_auto_reload.md
@@ -1,0 +1,26 @@
+# Browser Auto-Reload
+
+Uses **django-browser-reload** to automatically reload the browser during development when templates, CSS, or Python files change.
+
+## Usage
+
+```bash
+make dev
+```
+
+Starts Django server + Sass watch mode with auto-reload.
+
+## Configuration
+
+- [config/settings/dev.py](../src/tycho/config/settings/dev.py) - Django settings
+- [config/urls.py](../src/tycho/config/urls.py) - `__reload__/` endpoint
+- [Makefile](../../Makefile) - `dev` target runs both processes
+
+## Details
+
+- Only active in DEBUG mode
+- Uses Server-Sent Events (no WebSocket)
+
+## Resources
+
+- [django-browser-reload](https://github.com/adamchainz/django-browser-reload)

--- a/src/tycho/config/settings/dev.py
+++ b/src/tycho/config/settings/dev.py
@@ -14,10 +14,14 @@ INTERNAL_IPS = ["127.0.0.1"]
 INSTALLED_APPS.extend(  # noqa: F405
     [
         "debug_toolbar",
+        "django_browser_reload",
     ]
 )
 
-MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa F405
+MIDDLEWARE += [  # noqa F405
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "django_browser_reload.middleware.BrowserReloadMiddleware",
+]
 
 DEBUG_TOOLBAR_CONFIG = {
     # https://django-debug-toolbar.readthedocs.io/en/latest/panels.html#panels

--- a/src/tycho/config/urls.py
+++ b/src/tycho/config/urls.py
@@ -18,3 +18,6 @@ if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
     from debug_toolbar.toolbar import debug_toolbar_urls
 
     urlpatterns = [*urlpatterns] + debug_toolbar_urls()
+
+if settings.DEBUG and "django_browser_reload" in settings.INSTALLED_APPS:
+    urlpatterns.append(path("__reload__/", include("django_browser_reload.urls")))

--- a/src/tycho/pyproject.toml
+++ b/src/tycho/pyproject.toml
@@ -35,10 +35,10 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+  "django-browser-reload>=1.17.0",
   "django-debug-toolbar>=6.1.0",
   "djlint>=1.36.4",
   "git-cliff>=2.11.0",
-  "honcho>=2.0.0",
   "mypy>=1.18.2",
   "polyfactory>=3.0.0",
   "pytest>=8.4.2",

--- a/src/tycho/uv.lock
+++ b/src/tycho/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 2
-requires-python = ">=3.12.0, <3.13"
+revision = 3
+requires-python = "==3.12.*"
 
 [[package]]
 name = "annotated-types"
@@ -165,6 +165,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/e1/894115c6bd70e2c8b66b0c40a3c367d83a5a48c034a4d904d31b62f7c53a/django-6.0.3.tar.gz", hash = "sha256:90be765ee756af8a6cbd6693e56452404b5ad15294f4d5e40c0a55a0f4870fe1", size = 10872701, upload-time = "2026-03-03T13:55:15.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/b1/23f2556967c45e34d3d3cf032eb1bd3ef925ee458667fb99052a0b3ea3a6/django-6.0.3-py3-none-any.whl", hash = "sha256:2e5974441491ddb34c3f13d5e7a9f97b07ba03bf70234c0a9c68b79bbb235bc3", size = 8358527, upload-time = "2026-03-03T13:55:10.552Z" },
+]
+
+[[package]]
+name = "django-browser-reload"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/ef/ab407c1a2f14e13c75a6419a2d124954aa0364f62580ad95a3d31dc6c73d/django_browser_reload-1.21.0.tar.gz", hash = "sha256:3335ad3d107eb657f623d1a8e680dfbcab8a83ae1f94df1895e069dddf5604ba", size = 15800, upload-time = "2025-09-22T17:00:35.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/61/1b4a8c589652859995bcab87682286443eb9fdf2d7fd584975b9ffc1db33/django_browser_reload-1.21.0-py3-none-any.whl", hash = "sha256:0b2a86ab460774fa9bb142a121c70e75a72f18109f51a4f6de409cd633d3a70d", size = 12852, upload-time = "2025-09-22T17:00:33.479Z" },
 ]
 
 [[package]]
@@ -390,18 +403,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "honcho"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/65/c8/d860888358bf5c8a6e7d78d1b508b59b0e255afd5655f243b8f65166dafd/honcho-2.0.0.tar.gz", hash = "sha256:af3815c03c634bf67d50f114253ea9fef72ecff26e4fd06b29234789ac5b8b2e", size = 45618, upload-time = "2024-10-06T14:26:53.871Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/1c/25631fc359955569e63f5446dbb7022c320edf9846cbe892ee5113433a7e/honcho-2.0.0-py3-none-any.whl", hash = "sha256:56dcd04fc72d362a4befb9303b1a1a812cba5da283526fbc6509be122918ddf3", size = 22093, upload-time = "2024-10-06T14:26:52.181Z" },
 ]
 
 [[package]]
@@ -1114,10 +1115,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "django-browser-reload" },
     { name = "django-debug-toolbar" },
     { name = "djlint" },
     { name = "git-cliff" },
-    { name = "honcho" },
     { name = "mypy" },
     { name = "polyfactory" },
     { name = "pytest" },
@@ -1161,10 +1162,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "django-browser-reload", specifier = ">=1.17.0" },
     { name = "django-debug-toolbar", specifier = ">=6.1.0" },
     { name = "djlint", specifier = ">=1.36.4" },
     { name = "git-cliff", specifier = ">=2.11.0" },
-    { name = "honcho", specifier = ">=2.0.0" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "polyfactory", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=8.4.2" },


### PR DESCRIPTION
## 📝 Description
Add browser auto-reload capability for improved DX when working on UI. Uses `django-browser-reload` to automatically refresh the browser when templates, CSS, or Python files change.

## 🏷️ Type of change
- [ ] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [x] 🔧 Technical change

## 🔧 Changes
- Add `django-browser-reload` to dev dependencies
- Configure middleware and URL patterns in dev settings
- Add `make dev` command to run Django + Sass watch in parallel
- Add documentation in `docs/browser_auto_reload.md`

## 🏝️ How to test
1. Run `make dev`
2. Open http://localhost:8000
3. Edit a template, SCSS file, or Python file
4. Browser should auto-reload (it seems to not always pick up first change, but subsequent changes seem to work reliably)

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
