### PR TITLE
♻️(candidate) reactivate assertions on score in match_cv_to_opportunities

### DIFF
--- a/src/tycho/tests/candidate/integration/test_integration_match_cv_to_opportunities.py
+++ b/src/tycho/tests/candidate/integration/test_integration_match_cv_to_opportunities.py
@@ -136,9 +136,8 @@ def test_execute_with_valid_cv_returns_opportunities(
     assert isinstance(results, list)
     assert len(results) == limit
 
-    similarities = [r[1] for r in results]
+    similarities = [score for _, score in results]
     assert sorted(similarities, reverse=True) == similarities
 
-    # TODO - reactivate these assertions
-    # assert all(0.0 <= score <= 1.0 for _, score in result)
-    # assert all(isinstance(score, float) for _, score in result)
+    assert all(0.0 <= score <= 1 for score in similarities)
+    assert all(isinstance(score, float) for score in similarities)


### PR DESCRIPTION
## 📝 Description
🎸 Assertions on similarity score tests were deactivated in match_cv_to_opportunities integration tests. Let's reactivate them

## 🏷️ Type of change
- [x] ♻️ Refactoring
- [x] 🔧 Technical change


## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
