### PR TITLE
🤸(candidate) add sr-only hints on result cards and drawer

### DIFF
--- a/src/tycho/presentation/templates/candidate/components/_opportunity_drawer_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_opportunity_drawer_content.html
@@ -31,7 +31,7 @@
                 <a class="fr-btn"
                    href="{{ opportunity.url }}"
                    target="_blank"
-                   rel="noopener noreferrer">{{ opportunity.cta_label }}</a>
+                   rel="noopener noreferrer">{{ opportunity.cta_label }}<span class="fr-sr-only">- nouvelle fenêtre</span></a>
             </li>
         </ul>
     </div>

--- a/src/tycho/presentation/templates/candidate/components/_result_card_concours.html
+++ b/src/tycho/presentation/templates/candidate/components/_result_card_concours.html
@@ -26,7 +26,9 @@
             </div>
             {% if concours.location %}
                 <div class="fr-card__end">
-                    <p class="fr-card__detail fr-icon-map-pin-2-line">{{ concours.location }}</p>
+                    <p class="fr-card__detail fr-icon-map-pin-2-line">
+                        <span class="fr-sr-only">Localisation :</span>{{ concours.location }}
+                    </p>
                 </div>
             {% endif %}
         </div>

--- a/src/tycho/presentation/templates/candidate/components/_result_card_offer.html
+++ b/src/tycho/presentation/templates/candidate/components/_result_card_offer.html
@@ -24,7 +24,9 @@
             </div>
             {% if offer.location %}
                 <div class="fr-card__end">
-                    <p class="fr-card__detail fr-icon-map-pin-2-line">{{ offer.location }}</p>
+                    <p class="fr-card__detail fr-icon-map-pin-2-line">
+                        <span class="fr-sr-only">Localisation :</span>{{ offer.location }}
+                    </p>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
## 📝 Description
Add screen-reader-only hints on result cards and opportunity drawer.

## 🏷️ Type of change
- [x] 🐛 Bug fix

## 🔧 Changes
- **Offer/concours cards**: add `<span class="fr-sr-only">Localisation : </span>` before location text (RGAA 10.14)
- **Drawer CTA**: add `<span class="fr-sr-only"> - nouvelle fenêtre</span>` on `target="_blank"` link (RGAA 13.2)

## 🏝️ How to test
1. Navigate to CV results page
2. With VoiceOver/NVDA, verify location is announced as "Localisation : Paris"
3. Open the drawer, verify the CTA announces "nouvelle fenêtre"

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.