### PR TITLE
🤸(a11y) announce results to assisting technologies after HTMX wap

### DIFF
--- a/src/tycho/presentation/templates/candidate/components/_results_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_results_content.html
@@ -46,8 +46,14 @@
                 </section>
             </div>
             <!-- Results zone -->
-            <div class="fr-col-12 fr-col-md-8 fr-pl-md-4w csplab-results__results-column"
-                 id="results-zone">{% include "candidate/components/_results_list.html" %}</div>
+            <div class="fr-col-12 fr-col-md-8 fr-pl-md-4w csplab-results__results-column">
+                <p role="status" class="fr-sr-only" id="results-announcer"></p>
+                <div id="results-zone"
+                     class="fr-stack-3w"
+                     hx-on::after-settle="this.querySelector('#results-heading')?.focus()">
+                    {% include "candidate/components/_results_list.html" %}
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/src/tycho/presentation/templates/candidate/components/_results_list.html
+++ b/src/tycho/presentation/templates/candidate/components/_results_list.html
@@ -1,27 +1,31 @@
-{% load i18n dsfr_tags %}
-<div class="fr-stack-3w">
-    <p class="fr-text--lg">
-        <span class="fr-text--bold">{{ results_count|default:0 }} résultat{{ results_count|pluralize:"s" }}</span>
-        {% if results_count %}<span class="fr-text-mention--grey fr-ml-1w">triés par pertinence</span>{% endif %}
-    </p>
-    <div id="results-list" class="fr-stack-3w">
-        {% if results %}
-            {% for result in results %}
-                {% if result.opportunity_type == opportunity_type_offer %}
-                    {% include "candidate/components/_result_card_offer.html" with offer=result %}
-                {% elif result.opportunity_type == opportunity_type_concours %}
-                    {% include "candidate/components/_result_card_concours.html" with concours=result %}
-                {% endif %}
-            {% endfor %}
-        {% else %}
-            <p class="fr-text--sm fr-text--disabled">Aucun résultat pour le moment.</p>
-        {% endif %}
-    </div>
-    {% if page_obj.paginator.num_pages > 1 %}
-        <div class="fr-grid-row fr-grid-row--center"
-             hx-boost="true"
-             hx-target="#results-zone"
-             hx-swap="innerHTML"
-             hx-push-url="true">{% dsfr_pagination page_obj %}</div>
+{% load dsfr_tags %}
+<h2 class="fr-text--lg" id="results-heading" tabindex="-1">
+    <span class="fr-text--bold">{{ results_count|default:0 }} résultat{{ results_count|pluralize:"s" }}</span>
+    {% if results_count %}
+        <span class="fr-text--regular fr-text-mention--grey fr-ml-1w">triés par pertinence</span>
     {% endif %}
-</div>
+</h2>
+{% if results %}
+    {% for result in results %}
+        {% if result.opportunity_type == opportunity_type_offer %}
+            {% include "candidate/components/_result_card_offer.html" with offer=result %}
+        {% elif result.opportunity_type == opportunity_type_concours %}
+            {% include "candidate/components/_result_card_concours.html" with concours=result %}
+        {% endif %}
+    {% endfor %}
+{% else %}
+    <p class="fr-text--sm fr-text--disabled">Aucun résultat pour le moment.</p>
+{% endif %}
+{% if page_obj.paginator.num_pages > 1 %}
+    <div class="fr-grid-row fr-grid-row--center"
+         hx-boost="true"
+         hx-target="#results-zone"
+         hx-swap="innerHTML"
+         hx-push-url="true">{% dsfr_pagination page_obj %}</div>
+{% endif %}
+{% if request.htmx %}
+    <p id="results-announcer"
+       hx-swap-oob="true"
+       role="status"
+       class="fr-sr-only">{{ results_count|default:0 }} résultat{{ results_count|pluralize:"s" }}</p>
+{% endif %}


### PR DESCRIPTION
## 📝 Description
🎸 When htmx swaps the results list, we need to better announce changes to user using assisting technologies

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
- use a h2 instead of a p for the results count (to respect heading hiearchy)
- add an empty live region container on full rendering page
- announce "X résultats trouvés" on swap with `hx-swap-oob="true"`
- focus management: `hx-on::after-settle` on `#results-zone` focuses the heading after swap, so keyboard/AT users land on the updated count

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [ ] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.