### PR TITLE
🐛(candidate) make sure drawer opens after filtering occured

### DIFF
--- a/src/tycho/presentation/static/js/drawer.js
+++ b/src/tycho/presentation/static/js/drawer.js
@@ -43,6 +43,7 @@ class DrawerHandler {
   setupHtmxListeners() {
     document.body.addEventListener('htmx:beforeRequest', (e) => this.handleBeforeRequest(e));
     document.body.addEventListener('htmx:afterSwap', (e) => this.handleAfterSwap(e));
+    document.body.addEventListener('htmx:afterSettle', (e) => this.handleAfterSettle(e));
   }
 
   setupClose() {
@@ -100,6 +101,14 @@ class DrawerHandler {
       this.triggerElement.focus();
     }
     this.triggerElement = null;
+  }
+
+  /**
+   * @param {CustomEvent} e
+   */
+  handleAfterSettle(e) {
+    if (e.detail?.target === this.body) return;
+    this.markTriggers();
   }
 }
 


### PR DESCRIPTION
## 📝 Description
🎸 Fix #365

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
- Added a handleAfterSettle listener on htmx:afterSettle. Whenever HTMX settles content outside the drawer body (e.g., filter results), markTriggers() re-runs and processes any new [data-drawer-open] links. Swaps into the drawer body are skipped to avoid unnecessary reprocessing.

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
