### PR TITLE
🐛(tycho:candidate) reflect active filters in UI on page load

### DIFF
--- a/src/tycho/presentation/candidate/filter_config.py
+++ b/src/tycho/presentation/candidate/filter_config.py
@@ -10,6 +10,11 @@ from presentation.candidate.formatters import (
 )
 from presentation.candidate.types import FilterOption
 
+FILTER_PARAM_LOCATION = "filter-location"
+FILTER_PARAM_CATEGORY = "filter-category"
+FILTER_PARAM_VERSANT = "filter-versant"
+FILTER_PARAM_OPPORTUNITY_TYPE = "filter-opportunity_type"
+
 EXCLUDED_CATEGORIES: frozenset[Category] = frozenset({Category.HORS_CATEGORIE})
 
 CATEGORY_FILTER_VALUE: dict[Category, str] = {

--- a/src/tycho/presentation/candidate/mappers.py
+++ b/src/tycho/presentation/candidate/mappers.py
@@ -15,6 +15,10 @@ from domain.value_objects.opportunity_type import OpportunityType
 from domain.value_objects.verse import Verse
 from presentation.candidate.filter_config import (
     CATEGORY_FILTER_VALUE,
+    FILTER_PARAM_CATEGORY,
+    FILTER_PARAM_LOCATION,
+    FILTER_PARAM_OPPORTUNITY_TYPE,
+    FILTER_PARAM_VERSANT,
     format_category_value,
     format_location_value,
 )
@@ -160,7 +164,7 @@ class ViewFiltersToUsecaseMapper(IToDomainMapper[QueryDict, IFilters]):
     def _map_departments(
         self, view_filters: QueryDict, usecase_filters: dict[str, Any]
     ) -> None:
-        departments = view_filters.getlist("filter-location")
+        departments = view_filters.getlist(FILTER_PARAM_LOCATION)
         if not departments:
             return
         department_objects = [
@@ -175,7 +179,7 @@ class ViewFiltersToUsecaseMapper(IToDomainMapper[QueryDict, IFilters]):
     def _map_categories(
         self, view_filters: QueryDict, usecase_filters: dict[str, Any]
     ) -> None:
-        categories = view_filters.getlist("filter-category")
+        categories = view_filters.getlist(FILTER_PARAM_CATEGORY)
         if not categories:
             return
         value_to_categories: dict[str, list[Category]] = {}
@@ -195,7 +199,7 @@ class ViewFiltersToUsecaseMapper(IToDomainMapper[QueryDict, IFilters]):
     def _map_versants(
         self, view_filters: QueryDict, usecase_filters: dict[str, Any]
     ) -> None:
-        versants = view_filters.getlist("filter-versant")
+        versants = view_filters.getlist(FILTER_PARAM_VERSANT)
         if not versants:
             return
         verse_objects = [
@@ -210,7 +214,7 @@ class ViewFiltersToUsecaseMapper(IToDomainMapper[QueryDict, IFilters]):
     def _map_opportunity_types(
         self, view_filters: QueryDict, usecase_filters: dict[str, Any]
     ) -> None:
-        opportunity_types = view_filters.getlist("filter-opportunity_type")
+        opportunity_types = view_filters.getlist(FILTER_PARAM_OPPORTUNITY_TYPE)
         if not opportunity_types:
             return
         type_mapping = {

--- a/src/tycho/presentation/candidate/presenters.py
+++ b/src/tycho/presentation/candidate/presenters.py
@@ -9,6 +9,10 @@ from domain.entities.concours import Concours
 from domain.entities.offer import Offer
 from domain.value_objects.opportunity_type import OpportunityType
 from presentation.candidate.filter_config import (
+    FILTER_PARAM_CATEGORY,
+    FILTER_PARAM_LOCATION,
+    FILTER_PARAM_OPPORTUNITY_TYPE,
+    FILTER_PARAM_VERSANT,
     get_all_departments_filter_options,
     get_category_filter_options,
     get_opportunity_type_filter_options,
@@ -62,19 +66,19 @@ class OpportunityListPresenter:
         return {
             "location_options": self._mark_checked(
                 get_all_departments_filter_options(),
-                params.getlist("filter-location"),
+                params.getlist(FILTER_PARAM_LOCATION),
             ),
             "category_options": self._mark_checked(
                 get_category_filter_options(),
-                params.getlist("filter-category"),
+                params.getlist(FILTER_PARAM_CATEGORY),
             ),
             "verse_options": self._mark_checked(
                 get_verse_filter_options(),
-                params.getlist("filter-versant"),
+                params.getlist(FILTER_PARAM_VERSANT),
             ),
             "opportunity_type_options": self._mark_checked(
                 get_opportunity_type_filter_options(),
-                params.getlist("filter-opportunity_type"),
+                params.getlist(FILTER_PARAM_OPPORTUNITY_TYPE),
             ),
             "opportunity_type_offer": OpportunityType.OFFER,
             "opportunity_type_concours": OpportunityType.CONCOURS,

--- a/src/tycho/presentation/candidate/presenters.py
+++ b/src/tycho/presentation/candidate/presenters.py
@@ -18,7 +18,7 @@ from presentation.candidate.mappers import (
     ConcoursToTemplateMapper,
     OfferToTemplateMapper,
 )
-from presentation.candidate.types import OpportunityCard
+from presentation.candidate.types import FilterOption, OpportunityCard
 
 
 class OpportunityListPresenter:
@@ -58,11 +58,41 @@ class OpportunityListPresenter:
         }
 
     def get_filter_options(self) -> dict[str, object]:
+        params = self._request.GET
         return {
-            "location_options": get_all_departments_filter_options(),
-            "category_options": get_category_filter_options(),
-            "verse_options": get_verse_filter_options(),
-            "opportunity_type_options": get_opportunity_type_filter_options(),
+            "location_options": self._mark_checked(
+                get_all_departments_filter_options(),
+                params.getlist("filter-location"),
+            ),
+            "category_options": self._mark_checked(
+                get_category_filter_options(),
+                params.getlist("filter-category"),
+            ),
+            "verse_options": self._mark_checked(
+                get_verse_filter_options(),
+                params.getlist("filter-versant"),
+            ),
+            "opportunity_type_options": self._mark_checked(
+                get_opportunity_type_filter_options(),
+                params.getlist("filter-opportunity_type"),
+            ),
             "opportunity_type_offer": OpportunityType.OFFER,
             "opportunity_type_concours": OpportunityType.CONCOURS,
         }
+
+    @staticmethod
+    def _mark_checked(
+        options: list[FilterOption],
+        active_values: list[str],
+    ) -> list[FilterOption]:
+        if not active_values:
+            return options
+        active_set = set(active_values)
+        return [
+            FilterOption(
+                value=opt["value"],
+                text=opt["text"],
+                checked=opt["value"] in active_set,
+            )
+            for opt in options
+        ]

--- a/src/tycho/presentation/candidate/types.py
+++ b/src/tycho/presentation/candidate/types.py
@@ -1,9 +1,10 @@
-from typing import TypedDict
+from typing import Required, TypedDict
 
 
-class FilterOption(TypedDict):
-    value: str
-    text: str
+class FilterOption(TypedDict, total=False):
+    value: Required[str]
+    text: Required[str]
+    checked: bool
 
 
 class _BaseCard(TypedDict):

--- a/src/tycho/presentation/templates/candidate/components/_filter_fieldset.html
+++ b/src/tycho/presentation/templates/candidate/components/_filter_fieldset.html
@@ -25,7 +25,8 @@
                                    id="{{ filter_prefix|default:'' }}{{ filter_name }}-{{ option.value }}"
                                    name="{{ filter_name }}"
                                    value="{{ option.value }}"
-                                   class="fr-sr-only">
+                                   class="fr-sr-only"
+                                   {% if option.checked %}checked{% endif %}>
                             {{ option.text }}
                         </label>
                     </li>

--- a/src/tycho/presentation/templates/candidate/components/_filters_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_filters_content.html
@@ -17,7 +17,9 @@
             <select class="fr-select"
                     id="{{ filter_prefix|default:'' }}filter-location"
                     name="filter-location">
-                {% for option in location_options %}<option value="{{ option.value }}">{{ option.text }}</option>{% endfor %}
+                {% for option in location_options %}
+                    <option value="{{ option.value }}" {% if option.checked %}selected{% endif %}>{{ option.text }}</option>
+                {% endfor %}
             </select>
         </div>
         <hr class="fr-hr fr-mb-2w">


### PR DESCRIPTION
## 📝 Description
Filters were correctly applied to results but not visually reflected in the UI on page load from URL params.

## 🏷️ Type of change
- [x] 🐛 Bug fix

## 🔧 Changes
- Presenter reads `request.GET` to mark active filter options (`checked`/`selected`)
- Unified pattern for all filter types via `_mark_checked`
- Extracted filter param names as shared constants

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.
