### PR TITLE
🔧(tooling) disable password validators in dev mode

### DIFF
--- a/src/tycho/config/settings/dev.py
+++ b/src/tycho/config/settings/dev.py
@@ -46,3 +46,4 @@ SENTRY_DNS = "example.com"
 
 HUEY["immediate"] = False  # noqa: F405
 HUEY["consumer"]["periodic"] = False  # noqa: F405
+AUTH_PASSWORD_VALIDATORS = []


### PR DESCRIPTION
## 📝 Description
🎸 let devs use less than 14chars password when creating users

## 🏷️ Type of change
- [x] 🔧 Technical change

## 🏝️ How to test (if applicable)
* `bin/manage createsupersuser`
* use a 1-char pass

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
