### PR TITLE
✅(candidate-presentation) add main e2e tests for cv flow

### DIFF
--- a/src/tycho/presentation/templates/candidate/components/_opportunity_drawer.html
+++ b/src/tycho/presentation/templates/candidate/components/_opportunity_drawer.html
@@ -1,4 +1,7 @@
-<dialog class="csplab-drawer" data-drawer aria-labelledby="drawer-title">
+<dialog class="csplab-drawer"
+        data-drawer
+        data-testid="opportunity-drawer"
+        aria-labelledby="drawer-title">
     <div class="csplab-drawer__panel">
         <div class="fr-modal__header">
             <button type="button" class="fr-btn fr-btn--close" data-drawer-close>Fermer</button>

--- a/src/tycho/presentation/templates/candidate/components/_processing_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_processing_content.html
@@ -1,5 +1,6 @@
 {% load static %}
 <div class="fr-background-alt--blue-france"
+     data-testid="cv-processing"
      role="status"
      aria-live="polite"
      aria-busy="true"

--- a/src/tycho/presentation/templates/candidate/components/_results_content.html
+++ b/src/tycho/presentation/templates/candidate/components/_results_content.html
@@ -1,5 +1,6 @@
 {% load static dsfr_tags %}
-<div class="fr-pb-5w fr-background-alt--blue-france ">
+<div class="fr-pb-5w fr-background-alt--blue-france "
+     data-testid="cv-results">
     <div class="fr-container">{% dsfr_breadcrumb breadcrumb_data %}</div>
     <div class="fr-container">
         <!-- Header -->

--- a/src/tycho/presentation/templates/candidate/cv_upload.html
+++ b/src/tycho/presentation/templates/candidate/cv_upload.html
@@ -57,6 +57,7 @@
                         <form method="post"
                               enctype="multipart/form-data"
                               id="cv-upload-form"
+                              data-testid="cv-upload-form"
                               class="fr-stack-2w fr-mt-4w fr-mt-md-0">
                             {% csrf_token %}
                             {% include "components/file_upload.html" with field=form.cv_file dropzone_text="Glissez-déposez votre CV ou" %}

--- a/src/tycho/tests/candidate/presentation/e2e/conftest.py
+++ b/src/tycho/tests/candidate/presentation/e2e/conftest.py
@@ -20,3 +20,8 @@ def browser_context_args(browser_context_args: dict) -> dict:
         **browser_context_args,
         "locale": "fr-FR",
     }
+
+
+@pytest.fixture(scope="session")
+def _fast_polling(settings) -> None:
+    settings.CV_PROCESSING_POLL_INTERVAL = 1

--- a/src/tycho/tests/candidate/presentation/e2e/test_cv_upload_flow.py
+++ b/src/tycho/tests/candidate/presentation/e2e/test_cv_upload_flow.py
@@ -1,0 +1,46 @@
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from domain.value_objects.cv_processing_status import CVStatus
+from infrastructure.django_apps.candidate.models.cv_metadata import CVMetadataModel
+from tests.factories.offer_factory import OfferFactory
+from tests.utils.pdf_test_utils import create_minimal_valid_pdf
+
+
+@pytest.fixture(name="cv_pdf_path")
+def cv_pdf_path_fixture(tmp_path: Path) -> Path:
+    pdf_file = tmp_path / "cv.pdf"
+    pdf_file.write_bytes(create_minimal_valid_pdf())
+    return pdf_file
+
+
+@pytest.mark.e2e
+class TestCVUploadFlow:
+    def test_user_sees_results_after_processing_completes(
+        self, page: Page, live_server, cv_pdf_path: Path, db
+    ) -> None:
+        page.goto(f"{live_server.url}/candidate/cv-upload/")
+        form = page.get_by_test_id("cv-upload-form")
+        form.locator("input[data-file-input]").set_input_files(str(cv_pdf_path))
+        form.locator('button[type="submit"]:visible').click()
+        expect(page.get_by_test_id("cv-processing")).to_be_visible()
+
+        match = re.search(r"/candidate/cv/([0-9a-f-]+)/results/", page.url)
+        assert match is not None
+        cv_uuid = match.group(1)
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute"
+        ) as mock_execute:
+            mock_execute.return_value = [
+                (OfferFactory.create_entity(title="Offre e2e"), 0.9),
+            ]
+            CVMetadataModel.objects.filter(id=cv_uuid).update(
+                status=CVStatus.COMPLETED.value, search_query="dev"
+            )
+            expect(page.get_by_test_id("cv-results")).to_be_visible(timeout=10_000)

--- a/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
+++ b/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
@@ -1,0 +1,117 @@
+import re
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from playwright.sync_api import Page, expect
+
+from domain.value_objects.cv_processing_status import CVStatus
+from infrastructure.django_apps.candidate.models.cv_metadata import CVMetadataModel
+from infrastructure.django_apps.shared.models.offer import OfferModel
+from tests.factories.concours_factory import ConcoursFactory
+from tests.factories.cv_metadata_factory import CVMetadataFactory
+from tests.factories.offer_factory import OfferFactory
+
+
+@pytest.mark.e2e
+class TestResultsDrawer:
+    def test_user_opens_offer_drawer_and_closes_it_with_close_button(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        offer_entity = OfferFactory.create_entity(title="Offre e2e drawer")
+        OfferModel.from_entity(offer_entity).save()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute"
+        ) as mock_execute:
+            mock_execute.return_value = [(offer_entity, 0.9)]
+
+            page.goto(f"{live_server.url}{results_url}")
+            expect(page.get_by_test_id("cv-results")).to_be_visible()
+
+            page.locator("[data-drawer-open]").first.click()
+
+            drawer = page.get_by_test_id("opportunity-drawer")
+            expect(drawer).to_be_visible()
+            expect(drawer).to_contain_text("Offre e2e drawer")
+
+            drawer.locator("[data-drawer-close]").click()
+            expect(drawer).not_to_be_visible()
+
+    def test_user_closes_drawer_with_browser_back_navigation(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        offer_entity = OfferFactory.create_entity(title="Offre e2e back-nav")
+        OfferModel.from_entity(offer_entity).save()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute"
+        ) as mock_execute:
+            mock_execute.return_value = [(offer_entity, 0.9)]
+
+            page.goto(f"{live_server.url}{results_url}")
+            expect(page.get_by_test_id("cv-results")).to_be_visible()
+
+            page.locator("[data-drawer-open]").first.click()
+            drawer = page.get_by_test_id("opportunity-drawer")
+            expect(drawer).to_be_visible()
+
+            page.go_back()
+
+            expect(drawer).not_to_be_visible()
+            expect(page).to_have_url(re.compile(re.escape(results_url) + r"/?$"))
+
+    def test_user_opens_concours_drawer_and_closes_it_with_close_button(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        concours_model = ConcoursFactory.create_model(
+            corps="Corps e2e drawer", grade="Grade e2e drawer"
+        )
+        concours_entity = concours_model.to_entity()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute"
+        ) as mock_execute:
+            mock_execute.return_value = [(concours_entity, 0.9)]
+
+            page.goto(f"{live_server.url}{results_url}")
+            expect(page.get_by_test_id("cv-results")).to_be_visible()
+
+            page.locator("[data-drawer-open]").first.click()
+
+            drawer = page.get_by_test_id("opportunity-drawer")
+            expect(drawer).to_be_visible()
+            expect(drawer).to_contain_text("Corps e2e drawer")
+
+            drawer.locator("[data-drawer-close]").click()
+            expect(drawer).not_to_be_visible()

--- a/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
+++ b/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
@@ -1,16 +1,40 @@
 import re
+from functools import partial
 from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 
+from domain.value_objects.category import Category
 from domain.value_objects.cv_processing_status import CVStatus
 from infrastructure.django_apps.candidate.models.cv_metadata import CVMetadataModel
 from infrastructure.django_apps.shared.models.offer import OfferModel
 from tests.factories.concours_factory import ConcoursFactory
 from tests.factories.cv_metadata_factory import CVMetadataFactory
 from tests.factories.offer_factory import OfferFactory
+
+
+def fake_execute_filter_by_category(offer_a, offer_b, *, cv_metadata, filters, limit):
+    if filters and "category" in filters:
+        return [(offer_a, 0.9)]
+    return [(offer_a, 0.9), (offer_b, 0.8)]
+
+
+def fake_execute_filter_by_category_and_versant(
+    offer_a_fpe, offer_a_fpt, offer_b_fpe, *, cv_metadata, filters, limit
+):
+    has_cat = bool(filters and "category" in filters)
+    has_versant = bool(filters and "verse" in filters)
+    if has_cat and has_versant:
+        return [(offer_a_fpe, 0.9)]
+    if has_cat:
+        return [(offer_a_fpe, 0.9), (offer_a_fpt, 0.85)]
+    return [
+        (offer_a_fpe, 0.9),
+        (offer_a_fpt, 0.85),
+        (offer_b_fpe, 0.8),
+    ]
 
 
 @pytest.mark.e2e
@@ -115,3 +139,123 @@ class TestResultsDrawer:
 
             drawer.locator("[data-drawer-close]").click()
             expect(drawer).not_to_be_visible()
+
+
+@pytest.mark.e2e
+class TestResultsFilters:
+    def test_user_narrows_results_by_selecting_category_filter(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        offer_a = OfferFactory.create_entity(title="Offre alpha", category=Category.A)
+        offer_b = OfferFactory.create_entity(title="Offre beta", category=Category.B)
+        OfferModel.from_entity(offer_a).save()
+        OfferModel.from_entity(offer_b).save()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute",
+            side_effect=partial(fake_execute_filter_by_category, offer_a, offer_b),
+        ):
+            page.goto(f"{live_server.url}{results_url}")
+            results = page.get_by_test_id("cv-results")
+            expect(results).to_contain_text("Offre alpha")
+            expect(results).to_contain_text("Offre beta")
+
+            page.locator("label:has(#desktop-filter-category-a)").click()
+
+            expect(results).to_contain_text("Offre alpha")
+            expect(results).not_to_contain_text("Offre beta")
+            expect(page).to_have_url(re.compile(r"filter-category=a"))
+
+    def test_user_lands_on_filtered_results_via_deep_link(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        offer_a = OfferFactory.create_entity(
+            title="Offre alpha deep", category=Category.A
+        )
+        offer_b = OfferFactory.create_entity(
+            title="Offre beta deep", category=Category.B
+        )
+        OfferModel.from_entity(offer_a).save()
+        OfferModel.from_entity(offer_b).save()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute",
+            side_effect=partial(fake_execute_filter_by_category, offer_a, offer_b),
+        ):
+            page.goto(f"{live_server.url}{results_url}?filter-category=a")
+
+            results = page.get_by_test_id("cv-results")
+            expect(results).to_be_visible()
+            expect(results).to_contain_text("Offre alpha deep")
+            expect(results).not_to_contain_text("Offre beta deep")
+            expect(page.locator("#desktop-filter-category-a")).to_be_checked()
+
+    def test_user_combines_category_and_versant_filters(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        offer_a_fpe = OfferFactory.create_entity(
+            title="Offre alpha FPE", category=Category.A
+        )
+        offer_a_fpt = OfferFactory.create_entity(
+            title="Offre alpha FPT", category=Category.A
+        )
+        offer_b_fpe = OfferFactory.create_entity(
+            title="Offre beta FPE", category=Category.B
+        )
+        OfferModel.from_entity(offer_a_fpe).save()
+        OfferModel.from_entity(offer_a_fpt).save()
+        OfferModel.from_entity(offer_b_fpe).save()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute",
+            side_effect=partial(
+                fake_execute_filter_by_category_and_versant,
+                offer_a_fpe,
+                offer_a_fpt,
+                offer_b_fpe,
+            ),
+        ):
+            page.goto(f"{live_server.url}{results_url}")
+            results = page.get_by_test_id("cv-results")
+            expect(results).to_contain_text("Offre alpha FPE")
+            expect(results).to_contain_text("Offre alpha FPT")
+            expect(results).to_contain_text("Offre beta FPE")
+
+            page.locator("label:has(#desktop-filter-category-a)").click()
+            expect(page).to_have_url(re.compile(r"filter-category=a"))
+            expect(results).not_to_contain_text("Offre beta FPE")
+
+            page.locator("label:has(#desktop-filter-versant-FPE)").click()
+            expect(page).to_have_url(re.compile(r"filter-versant=FPE"))
+            expect(results).to_contain_text("Offre alpha FPE")
+            expect(results).not_to_contain_text("Offre alpha FPT")

--- a/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
+++ b/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
@@ -259,3 +259,46 @@ class TestResultsFilters:
             expect(page).to_have_url(re.compile(r"filter-versant=FPE"))
             expect(results).to_contain_text("Offre alpha FPE")
             expect(results).not_to_contain_text("Offre alpha FPT")
+
+
+@pytest.mark.e2e
+class TestResultsPagination:
+    def test_user_navigates_to_page_2_via_dsfr_pagination(
+        self, page: Page, live_server, transactional_db, settings
+    ) -> None:
+        settings.CV_RESULTS_PER_PAGE = 3
+
+        offers = [
+            OfferFactory.create_entity(title=f"Offre paginée {i}") for i in range(5)
+        ]
+        for offer in offers:
+            OfferModel.from_entity(offer).save()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute"
+        ) as mock_execute:
+            mock_execute.return_value = [
+                (offer, 0.9 - i * 0.05) for i, offer in enumerate(offers)
+            ]
+
+            page.goto(f"{live_server.url}{results_url}")
+            results = page.get_by_test_id("cv-results")
+            expect(results).to_be_visible()
+            expect(results).to_contain_text("Offre paginée 0")
+            expect(results).not_to_contain_text("Offre paginée 4")
+
+            page.locator('a.fr-pagination__link[title="Page 2"]').click()
+
+            expect(page).to_have_url(re.compile(r"page=2"))
+            expect(results).to_contain_text("Offre paginée 4")
+            expect(results).not_to_contain_text("Offre paginée 0")

--- a/src/tycho/tests/utils/pdf_test_utils.py
+++ b/src/tycho/tests/utils/pdf_test_utils.py
@@ -1,14 +1,7 @@
-"""PDF utilities for testing."""
-
 import pymupdf
 
 
 def create_minimal_valid_pdf() -> bytes:
-    """Create a minimal valid PDF for testing.
-
-    Returns:
-        bytes: A valid PDF document as bytes
-    """
     doc = pymupdf.open()
     page = doc.new_page()
 
@@ -24,14 +17,6 @@ def create_minimal_valid_pdf() -> bytes:
 
 
 def create_large_pdf(size_mb: int = 6) -> bytes:
-    """Create a large PDF for testing size limits.
-
-    Args:
-        size_mb: Target size in MB
-
-    Returns:
-        bytes: A large PDF document as bytes
-    """
     doc = pymupdf.open()
 
     target_size = size_mb * 1024 * 1024


### PR DESCRIPTION
## 📝 Description
🎸 Add e2e tests to cover our main happy path cv upload flow. More tests tackling more specific behaviour are comming.

## 🏷️ Type of change
- [x] 🎢 New feature (non-breaking change that adds functionality)
- [ ] ♻️ Refactoring
- [x] 🔧 Technical change

## 🔧 Changes
- add e2e test for cv upload happy path
- add e2e test for offer drawer open and close
- add e2e test for filtering
- add e2e test for results pagination

## 🏝️ How to test (if applicable)
Run `make test-e2e`

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.
