### PR TITLE
✅(candidate-presentation) add secondary e2e tests

### DIFF
--- a/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
+++ b/src/tycho/tests/candidate/presentation/e2e/test_results_interaction.py
@@ -142,6 +142,42 @@ class TestResultsDrawer:
 
 
 @pytest.mark.e2e
+class TestResultsPersistence:
+    def test_user_refreshes_results_page_and_state_persists(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        offer_entity = OfferFactory.create_entity(title="Offre e2e refresh")
+        OfferModel.from_entity(offer_entity).save()
+
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute"
+        ) as mock_execute:
+            mock_execute.return_value = [(offer_entity, 0.9)]
+
+            page.goto(f"{live_server.url}{results_url}")
+            results = page.get_by_test_id("cv-results")
+            expect(results).to_be_visible()
+            expect(results).to_contain_text("Offre e2e refresh")
+
+            page.reload()
+
+            expect(page.get_by_test_id("cv-results")).to_be_visible()
+            expect(page.get_by_test_id("cv-results")).to_contain_text(
+                "Offre e2e refresh"
+            )
+
+
+@pytest.mark.e2e
 class TestResultsFilters:
     def test_user_narrows_results_by_selecting_category_filter(
         self, page: Page, live_server, transactional_db

--- a/src/tycho/tests/candidate/presentation/e2e/test_results_states.py
+++ b/src/tycho/tests/candidate/presentation/e2e/test_results_states.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from playwright.sync_api import Page, expect
+
+from domain.value_objects.cv_processing_status import CVStatus
+from infrastructure.django_apps.candidate.models.cv_metadata import CVMetadataModel
+from tests.factories.cv_metadata_factory import CVMetadataFactory
+
+
+@pytest.mark.e2e
+class TestResultsEmptyAndFailedStates:
+    def test_user_sees_no_results_state_when_matching_returns_empty(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.COMPLETED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+
+        with patch(
+            "application.candidate.usecases.match_cv_to_opportunities."
+            "MatchCVToOpportunitiesUsecase.execute"
+        ) as mock_execute:
+            mock_execute.return_value = []
+
+            page.goto(f"{live_server.url}{results_url}")
+
+            expect(
+                page.get_by_text(
+                    "nous n'avons pas trouvé d'opportunité",
+                    exact=False,
+                )
+            ).to_be_visible()
+            expect(page.get_by_test_id("cv-results")).not_to_be_visible()
+
+    def test_user_is_redirected_to_upload_when_cv_status_is_failed(
+        self, page: Page, live_server, transactional_db
+    ) -> None:
+        cv_metadata = CVMetadataFactory.create_entity(
+            status=CVStatus.FAILED, search_query="dev"
+        )
+        CVMetadataModel.from_entity(cv_metadata).save()
+
+        results_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.id}
+        )
+        upload_url = reverse("candidate:cv_upload")
+
+        page.goto(f"{live_server.url}{results_url}")
+
+        expect(page).to_have_url(f"{live_server.url}{upload_url}")
+        expect(
+            page.get_by_text(
+                "Une erreur est survenue lors du traitement",
+                exact=False,
+            )
+        ).to_be_visible()


### PR DESCRIPTION
## 📝 Description
🎸 Add more secondary e2e tests :
- add e2e test for results page hard refresh persistence
- add e2e tests for no-results and failed-status states

## 🏷️ Type of change
- [x] 🎢 New feature (non-breaking change that adds functionality)

## 🏝️ How to test (if applicable)
run `make test-e2e`2

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.
