### PR TITLE
✅(ingestion) autoclose worker thread connections in tests

### DIFF
--- a/src/tycho/tests/fixtures/shared_fixtures.py
+++ b/src/tycho/tests/fixtures/shared_fixtures.py
@@ -1,8 +1,10 @@
 import os
 
 import pytest
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.db import connections
 from faker import Faker
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import Distance, PayloadSchemaType, VectorParams
@@ -14,6 +16,15 @@ from infrastructure.gateways.shared.logger import LoggerService
 from infrastructure.repositories.shared.qdrant_repository import QdrantRepository
 
 fake = Faker()
+
+
+@pytest.fixture(autouse=True)
+async def close_worker_thread_connections():
+    yield
+    # async ORM calls (via sync_to_async) open a DB connection in a worker thread.
+    # close_all() runs in that same thread via sync_to_async, closing the connection
+    # before the test database is dropped at session teardown.
+    await sync_to_async(connections.close_all)()
 
 
 @pytest.fixture(name="api_client")


### PR DESCRIPTION
## 📝 Description

Fixes the warning

```
PytestWarning: Error when trying to teardown test databases: : OperationalError('database "test_tycho_gw6" is being accessed by other users\nDETAIL: There is 1 other session using the database
```

## 🏷️ Type of change
- [ ] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [x] 🔧 Technical change

## 🔧 Changes

Automatically closes worker thread connections opened during tests, before the database teardown. Async connections are opened by async processes in tests.

🛸 Required dependencies for this change (if applicable)

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
