### PR TITLE
🐛(ingestion-presentation) remove updated_before arg from archive_offers task

### DIFF
--- a/src/tycho/presentation/ingestion/tasks.py
+++ b/src/tycho/presentation/ingestion/tasks.py
@@ -167,7 +167,7 @@ def archive_offers_periodic(reload=False):
 
 
 @db_task()
-def archive_offers(updated_after: datetime, updated_before: datetime):
+def archive_offers(updated_after: datetime):
     container = create_ingestion_container()
     logger = container.logger_service()
     usecase = container.archive_offers_usecase()

--- a/src/tycho/tests/ingestion/presentation/tasks/test_archive_offers.py
+++ b/src/tycho/tests/ingestion/presentation/tasks/test_archive_offers.py
@@ -27,5 +27,5 @@ def test_periodic_task_does_not_call_usecase(usecase):
 
 def test_task_calls_usecase(usecase):
     updated_after = datetime(2026, 1, 1)
-    archive_offers.call_local(updated_after=updated_after, updated_before=None)
+    archive_offers.call_local(updated_after=updated_after)
     usecase.execute.assert_called_once_with(updated_after)


### PR DESCRIPTION
## 📝 Description
🎸 task `archived_offers` required `updated_before` datetime which is not passed to usecase.
Command `archive_offers` calls `archive_offers` without this datetime, nor periotic task `archive_offers_periodic`. So that task always fails.

## 🏷️ Type of change
- [x] 🐛 Bug fix

## 🔧 Changes
remove `updated_before` from args in task

💡 talentsoft back api handles only one date when filtering vacancies. We keep the datetime `updated_after`

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [ ] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
