### PR TITLE
♻️(ocr) Replace deprecated Pydantic Config with SettingsConfigDict

### DIFF
--- a/src/ocr/api/config.py
+++ b/src/ocr/api/config.py
@@ -1,27 +1,25 @@
 import os
 
 from pydantic import HttpUrl
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env")
+
     api_key: str
     sentry_dsn: HttpUrl | None = None
     sentry_profiles_sample_rate: float | None = 0.1
     sentry_traces_sample_rate: float | None = 0.1
 
-    class Config:
-        env_file = ".env"
-
 
 class TestSettings(Settings):
+    model_config = SettingsConfigDict(env_file=None)
+
     api_key: str = "test-api-key-for-development"
     sentry_dsn: HttpUrl | None = None
     sentry_profiles_sample_rate: float | None = 0.0
     sentry_traces_sample_rate: float | None = 0.0
-
-    class Config:
-        env_file = None  # Don't load from .env in tests
 
 
 def get_settings() -> Settings:


### PR DESCRIPTION
## 📝 Description
src/ocr/api/config.py:7: PydanticDeprecatedSince20: Support for class-based config is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0

## 🏷️ Type of change
- [ ] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [x] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
__List the main changes__

🛸 Required dependencies for this change (if applicable)

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
