### PR TITLE
✨(shared) unarchive an offer received from load_offers

### DIFF
--- a/src/tycho/infrastructure/repositories/shared/postgres_offers_repository.py
+++ b/src/tycho/infrastructure/repositories/shared/postgres_offers_repository.py
@@ -85,6 +85,7 @@ class PostgresOffersRepository(IOffersRepository):
                                 "publication_date",
                                 "beginning_date",
                                 "updated_at",
+                                "archived_at",
                             ],
                         )
 

--- a/src/tycho/tests/shared/integration/repository/test_postgres_offers_repository.py
+++ b/src/tycho/tests/shared/integration/repository/test_postgres_offers_repository.py
@@ -156,6 +156,19 @@ class TestUpsertBatch:
         saved_offer = OfferModel.objects.get()
         assert OfferModel.to_entity(saved_offer) == entity
 
+    def test_upsert_unarchives_archived_offer(self, db, repository):
+        archived_offer = OfferFactory.create_model(archived_at=NOW)
+        assert archived_offer.archived_at is not None
+
+        entity = OfferModel.to_entity(archived_offer)
+        entity.archived_at = None
+
+        result = repository.upsert_batch([entity])
+        assert result == {"created": 0, "updated": 1, "errors": []}
+
+        archived_offer.refresh_from_db()
+        assert archived_offer.archived_at is None
+
 
 class TestGetPendingProcessing:
     def test_excluded_items(self, db, repository):


### PR DESCRIPTION
## 📝 Description
Previously, archived offers (archived_at set) would remain archived even when they reappeared in TalentSoft and were reloaded. This happened because archived_at was not included in the bulk_update fields list.

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
- PostgresOffersRepository.upsert_batch: Added archived_at to the bulk_update fields, allowing archived offers to be unarchived when reloaded with archived_at=None
- Tests: Added test_upsert_unarchives_archived_offer to verify the unarchive behavior

🛸 Required dependencies for this change (if applicable)

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
