### PR TITLE
⚡️(api-presentation) prevent DB dynamic inspection when using API schema for documentation purposes

### DIFF
--- a/.github/workflows/tycho.yml
+++ b/.github/workflows/tycho.yml
@@ -131,3 +131,5 @@ jobs:
         run: uv run playwright install --with-deps chromium
       - name: Test Tycho suite with coverage
         run: uv run pytest -m "e2e" .
+      - name: Generate schema
+        run: uv run python manage.py spectacular --file presentation/static/schema.yaml --validate

--- a/docs/updating_API_schema.md
+++ b/docs/updating_API_schema.md
@@ -1,0 +1,26 @@
+# Updating the API Schema
+
+## Why CI failed
+
+The route `api/schema/redoc` reads reads `presentation/static/api/schema.yaml` directly to prevent dynamic DB introspection. This file is static and must be regenerated manually whenever API endpoints change. CI fails when the file is out of sync with the codebase.
+
+## When to regenerate it
+
+Regenerate the schema whenever you:
+- Add or remove an endpoint
+- Change a serializer (fields, types, validators)
+- Change a view's HTTP methods or permissions
+- Add or modify `@extend_schema` decorators
+
+## How to regenerate
+
+Run this command from the project root:
+
+```bash
+python manage.py spectacular --file presentation/static/api/schema.yaml --validate
+```
+
+## Validation
+
+The `--validate` flag checks that the output is valid OpenAPI 3 before writing.
+If it reports errors, fix them before committing.

--- a/src/tycho/presentation/api/urls.py
+++ b/src/tycho/presentation/api/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
@@ -13,6 +12,5 @@ urlpatterns = [
     path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("health/huey/", HueyHealthView.as_view(), name="health_huey"),
-    path("schema/", SpectacularAPIView.as_view(), name="schema"),
     path("schema/redoc/", RedocView.as_view(), name="redoc"),
 ]

--- a/src/tycho/presentation/api/views.py
+++ b/src/tycho/presentation/api/views.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.urls import reverse_lazy
 from django.views.generic import TemplateView
 from drf_spectacular.utils import extend_schema
 from huey.contrib.djhuey import HUEY
@@ -16,7 +15,7 @@ class RedocView(TemplateView):
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(
-            title="ReDoc", schema_url=reverse_lazy("api:schema"), **kwargs
+            title="ReDoc", schema_url="/static/api/schema.yaml", **kwargs
         )
 
 

--- a/src/tycho/presentation/static/api/schema.yaml
+++ b/src/tycho/presentation/static/api/schema.yaml
@@ -1,0 +1,544 @@
+openapi: 3.0.3
+info:
+  title: CSPLab API
+  version: 0.0.1
+  description: API for CSPLab
+paths:
+  /api/data/concours/upload/:
+    post:
+      operationId: data_concours_upload_create
+      description: |-
+        Permet d'uploader un fichier CSV contenant des données de concours GRECO afin de les importer dans le système.
+
+        **Format attendu :**
+        - Encodage : UTF-8
+        - Séparateur : point-virgule (`;`)
+
+        **Colonnes obligatoires :**
+        - `N° NOR` — identifiant unique de l'arrêté (utilisé comme clé d'upsert)
+        - `Corps`
+        - `Grade`
+        - `Ministère`
+
+        **Traitement :**
+        - Validation ligne par ligne selon le schéma `ConcoursRowSchema`
+        - Les lignes valides sont créées ou mises à jour (upsert par `N° NOR`)
+        - Les lignes invalides sont ignorées et remontées dans `validation_errors`
+
+        **Codes de retour :**
+        - `201 Created` — au moins une ligne valide a été traitée avec succès
+        - `400 Bad Request` — fichier absent, format invalide, ou aucune ligne valide
+        - `401 Unauthorized` — token JWT manquant ou invalide
+        - `500 Internal Server Error` — erreur inattendue côté serveur
+
+        **Authentification :** Token JWT requis.
+      summary: Upload et traitement d'un fichier CSV de concours GRECO
+      tags:
+      - concours
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Fichier CSV contenant les données de concours
+              required:
+              - file
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConcoursUploadResponse'
+              examples:
+                Success-FullImport:
+                  value:
+                    status: success
+                    message: Successfully processed 5185 valid concours records
+                    total_rows: 5185
+                    valid_rows: 5185
+                    invalid_rows: 0
+                    created: 5185
+                    updated: 0
+                    validation_errors: null
+                  summary: Toutes les lignes sont valides
+                  description: Aucune erreur de validation, toutes les lignes ont
+                    été importées.
+                Success-PartialImportWithErrors:
+                  value:
+                    status: success
+                    message: Successfully processed 5162 valid concours records
+                    total_rows: 5185
+                    valid_rows: 5162
+                    invalid_rows: 23
+                    created: 5100
+                    updated: 62
+                    validation_errors:
+                    - row: 4
+                      error: Le champ 'Corps' est requis
+                    - row: 17
+                      error: Le champ 'Grade' est requis
+                    - row: 156
+                      error: Le champ 'date_ouverture' doit être au format JJ/MM/AAAA
+                  summary: Import partiel avec des lignes invalides
+                  description: Certaines lignes ont échoué la validation mais les
+                    lignes valides ont quand même été persistées. Le champ `validation_errors`
+                    détaille chaque ligne rejetée.
+                Success-UpdateOnly:
+                  value:
+                    status: success
+                    message: Successfully processed 120 valid concours records
+                    total_rows: 120
+                    valid_rows: 120
+                    invalid_rows: 0
+                    created: 0
+                    updated: 120
+                    validation_errors: null
+                  summary: Mise à jour de concours existants
+                  description: Toutes les lignes correspondent à des enregistrements
+                    existants
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConcoursUpload400Error'
+              examples:
+                Error-NoFileProvided:
+                  value:
+                    error: No file provided
+                  summary: Aucun fichier dans la requête
+                  description: Le champ `file` est absent du corps de la requête multipart.
+                Error-WrongFileType:
+                  value:
+                    error: File must be a CSV
+                  summary: Fichier non CSV
+                  description: Le fichier uploadé n'a pas l'extension `.csv`.
+                Error-NoValidRows:
+                  value:
+                    error: No valid rows found
+                    validation_errors:
+                    - row: 1
+                      error: Le champ 'N° NOR' est requis
+                    - row: 2
+                      error: Le champ 'Corps' est requis
+                    - row: 3
+                      error: Le champ 'Grade' doit être >= 1
+                  summary: Aucune ligne valide après validation
+                  description: Toutes les lignes ont échoué la validation. Aucune
+                    donnée n'a été persistée.
+                Error-MalformedCSV:
+                  value:
+                    error: CSV parsing error
+                  summary: Fichier CSV mal formé
+                  description: Le fichier ne peut pas être parsé,vérifiez le séparateur
+                    (`;`) et l'encodage (UTF-8).
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+              examples:
+                Error-InvalidToken:
+                  value:
+                    detail: Le jeton fourni n'est pas valide.
+                    code: token_not_valid
+                    messages:
+                    - token_class: AccessToken
+                      token_type: access
+                      message: Token is invalid or expired
+                  summary: Token JWT invalide ou expiré
+                  description: Le token dans le header `Authorization` est invalide
+                    ou expiré.
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerError'
+              examples:
+                Error-UnexpectedServerError:
+                  value:
+                    error: Unexpected error
+                  summary: Erreur serveur inattendue
+                  description: Une erreur inattendue s'est produite côté serveur.
+          description: ''
+  /api/data/offers/:
+    get:
+      operationId: data_offers_list
+      description: |2
+
+        # API de consultation des offres d'emploi de la Fonction Publique
+
+        Cette API retourne la liste de offres correspondant à une recherche selon les 2
+        critères suivants :
+
+        - Candidature active / archivée
+        - Référence externe de la candidature contient une chaîne de caractère spécifique
+
+        Cette API est à l’usage exclusif des personnes autorisées.
+
+        # Permissions
+
+        L’utilisation de cette API nécessite un token d’autorisation spécifique à chaque
+        utilisateur.
+
+        # Limitations
+
+        L’interrogation de cette API est limitée à 120 appels par minute et par utilisateur.
+      summary: Liste des offres
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - offres
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedListOffersResponseList'
+              examples:
+                Success-ActiveOffers:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - external_id: Versant_FPE-2026-999999
+                      title: Responsable de la Division des Affaires Financières H/F
+                      organization: Ecole Nationale Supérieure de Techniques Avancées
+                        (ENSTA)
+                      contract_type: TITULAIRE_CONTRACTUEL
+                      category: A
+                      publication_date: '2026-04-17T14:44:49.873000+00:00'
+                      offer_url: https://test.com/offre-emploi/2026-999999/
+                      archived_at: null
+                  summary: Liste des offres d'emploi actives
+                  description: Les offres d'emploi sans date d'archivagesont retournées
+                    paginées
+                Success-ArchivedOffers:
+                  value:
+                    count: 123
+                    next: http://api.example.org/accounts/?page=4
+                    previous: http://api.example.org/accounts/?page=2
+                    results:
+                    - external_id: Versant_FPE-2026-999999
+                      title: Responsable de la Division des Affaires Financières H/F
+                      organization: Ecole Nationale Supérieure de Techniques Avancées
+                        (ENSTA)
+                      contract_type: TITULAIRE_CONTRACTUEL
+                      category: A
+                      publication_date: '2026-04-17T14:44:49.873000+00:00'
+                      offer_url: https://test.com/offre-emploi/2026-999999/
+                      archived_at: '2026-05-17T12:42:42.873000+00:00'
+                  summary: Liste des offres d'emploi archivées
+                  description: Les offres d'emploi avec une date d'archivagesont retournées
+                    paginées
+          description: ''
+        '400':
+          description: No response body
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+              examples:
+                Error-InvalidToken:
+                  value:
+                    detail: Le jeton fourni n'est pas valide.
+                    code: token_not_valid
+                    messages:
+                    - token_class: AccessToken
+                      token_type: access
+                      message: Token is invalid or expired
+                  summary: Token JWT invalide ou expiré
+                  description: Le token dans le header `Authorization` est invalide
+                    ou expiré.
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerError'
+              examples:
+                Error-UnexpectedServerError:
+                  value:
+                    error: Unexpected error
+                  summary: Erreur serveur inattendue
+                  description: Une erreur inattendue s'est produite côté serveur.
+          description: ''
+  /api/token/:
+    post:
+      operationId: token_create
+      description: |-
+        Takes a set of user credentials and returns an access and refresh JSON web
+        token pair to prove the authentication of those credentials.
+      tags:
+      - token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenObtainPair'
+          description: ''
+  /api/token/refresh/:
+    post:
+      operationId: token_refresh_create
+      description: |-
+        Takes a refresh type JSON web token and returns an access type JSON web
+        token if the refresh token is valid.
+      tags:
+      - token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenRefresh'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenRefresh'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TokenRefresh'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenRefresh'
+          description: ''
+components:
+  schemas:
+    ConcoursUpload400Error:
+      oneOf:
+      - $ref: '#/components/schemas/FileError'
+      - $ref: '#/components/schemas/NoValidRowsError'
+    ConcoursUploadResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        message:
+          type: string
+        total_rows:
+          type: integer
+        valid_rows:
+          type: integer
+        invalid_rows:
+          type: integer
+        created:
+          type: integer
+        updated:
+          type: integer
+        validation_errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          nullable: true
+      required:
+      - created
+      - invalid_rows
+      - message
+      - status
+      - total_rows
+      - updated
+      - valid_rows
+      - validation_errors
+    FileError:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+      - error
+    ListOffersResponse:
+      type: object
+      properties:
+        external_id:
+          type: string
+        title:
+          type: string
+        organization:
+          type: string
+        contract_type:
+          type: string
+          nullable: true
+        category:
+          type: string
+          nullable: true
+        publication_date:
+          type: string
+          format: date-time
+        offer_url:
+          type: string
+          nullable: true
+        archived_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - archived_at
+      - category
+      - contract_type
+      - external_id
+      - offer_url
+      - organization
+      - publication_date
+      - title
+    NoValidRowsError:
+      type: object
+      properties:
+        error:
+          type: string
+        validation_errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+      required:
+      - error
+      - validation_errors
+    PaginatedListOffersResponseList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ListOffersResponse'
+    ServerError:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+      - error
+    TokenError:
+      type: object
+      properties:
+        detail:
+          type: string
+        code:
+          type: string
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenErrorMessage'
+      required:
+      - code
+      - detail
+      - messages
+    TokenErrorMessage:
+      type: object
+      properties:
+        token_class:
+          type: string
+        token_type:
+          type: string
+        message:
+          type: string
+      required:
+      - message
+      - token_class
+      - token_type
+    TokenObtainPair:
+      type: object
+      properties:
+        username:
+          type: string
+          writeOnly: true
+        password:
+          type: string
+          writeOnly: true
+        access:
+          type: string
+          readOnly: true
+        refresh:
+          type: string
+          readOnly: true
+      required:
+      - access
+      - password
+      - refresh
+      - username
+    TokenRefresh:
+      type: object
+      properties:
+        access:
+          type: string
+          readOnly: true
+        refresh:
+          type: string
+          writeOnly: true
+      required:
+      - access
+      - refresh
+    ValidationError:
+      type: object
+      properties:
+        row:
+          type: integer
+        error:
+          type: string
+      required:
+      - error
+      - row
+  securitySchemes:
+    jwtAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+tags:
+- name: token
+  description: Gestion de l'authentification
+- name: concours
+  description: Ingestion des concours par import de fichiers CSV
+- name: offres
+  description: Offres d'emploi de la Fonction Publique

--- a/src/tycho/tests/shared/presentation/api/test_endpoints.py
+++ b/src/tycho/tests/shared/presentation/api/test_endpoints.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 import pytest
+import yaml
 from django.urls import reverse
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -38,9 +41,11 @@ class TestSchemaEndpoint:
         [
             ("api:health_huey", False),
             ("ingestion:concours_upload", True),
+            ("ingestion:offers_list, True"),
         ],
     )
-    def test_schema_path_visibility(self, api_client, name, expected_in_schema):
-        response = api_client.get(reverse("api:schema"))
-        assert response.status_code == status.HTTP_200_OK
-        assert (reverse(name) in response.data.get("paths", {})) == expected_in_schema
+    def tet_schema_path_visibility(self, name, expected_in_schema):
+        schema_path = Path("presentation/static/api/schema.yaml")
+        schema = yaml.safe_load(schema_path.read_text())
+        paths = schema.get("paths", {})
+        assert (reverse(name) in paths) == expected_in_schema

--- a/src/tycho/tests/shared/presentation/views/test_views.py
+++ b/src/tycho/tests/shared/presentation/views/test_views.py
@@ -33,4 +33,4 @@ class TestRedocView:
         assert response.status_code == status.HTTP_200_OK
         assertTemplateUsed(response, "api/redoc.html")
         assert response.context["title"] == "ReDoc"
-        assert response.context["schema_url"] == reverse("api:schema")
+        assert response.context["schema_url"] == "/static/api/schema.yaml"


### PR DESCRIPTION
## 📝 Description
🎸 `SpectacularAPIView` executes queries when introspecting DB to generate schema. We do not want these queries in production, it makes crash endpoint like `api/offers`


## 🏷️ Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Technical change

## 🔧 Changes
* generate static yaml file in dev mode
* let redoc reads it
* check if the static file is up to date in CI

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
