### PR TITLE
🐛(ingestion-infrastructure) isolate raw_docs in error and resume load_offers

### DIFF
--- a/src/tycho/infrastructure/external_gateways/external_document_gateway.py
+++ b/src/tycho/infrastructure/external_gateways/external_document_gateway.py
@@ -175,19 +175,29 @@ class ExternalDocumentGateway(IDocumentGateway):
         reference = external_id.split("-", 1)[-1]
 
         async with self.talentsoft_front_client:
+            now = datetime.now(timezone.utc)
             try:
                 raw_doc = await self.talentsoft_front_client.get_detail(reference)
+                raw_data = raw_doc.model_dump()
+                error_msg = None
+                processed_at = None
             except Exception as e:
                 self.logger.error(
                     "Failed to fetch detail %s %s: %s", document_type, external_id, e
                 )
-                raise
-            now = datetime.now(timezone.utc)
+                # QUICK Fix, do not raise anymore
+                # add error_msg
+                # set processed_at to exclude it from cleaning
+                raw_data = {}
+                error_msg = str(e)
+                processed_at = now
             return Document(
                 external_id=external_id,
-                raw_data=raw_doc.model_dump(),
+                raw_data=raw_data,
                 type=document_type,
                 created_at=now,
+                error_msg=error_msg,
+                processed_at=processed_at,
             )
 
     async def get_archived_documents_by_period(


### PR DESCRIPTION
## 📝 Description
🎸 see Issue #508

## 🏷️ Type of change
- [x] 🐛 Bug fix

## 🦺 QUICK FIX
* remove `raise` from `external_document_gateway` L188
* add `error_msg`
* set `processed_at` to exclude from cleaning offers => semantically confusing option, we'd better exclude RawDocuments with error_msg in `get_pending_processing` (postgres_document_repository) 

## ✅ Checklist
- [ ] 💅 I have added or updated the appropriate tests.
- [ ] 📝 I have updated or added the necessary documentation.
- [ ] 🚀 I have considered the impact on performance, security, and user experience.
- [ ] 👀 I have requested a review from a team member.
