### PR TITLE
💎(candidate-presentation) remove icon from cv analysis launch cta

### DIFF
--- a/src/web/presentation/templates/components/cv_upload_actions.html
+++ b/src/web/presentation/templates/components/cv_upload_actions.html
@@ -3,7 +3,7 @@
     <ul class="fr-btns-group fr-btns-group--icon-right fr-btns-group--inline-md">
         <li>
             <button type="submit"
-                    class="fr-btn fr-icon-arrow-right-line fr-btn--icon-right csplab-upload-btn"
+                    class="fr-btn csplab-upload-btn"
                     data-matomo-event="CVUpload|form_submitted">Lancer l'analyse</button>
         </li>
     </ul>


### PR DESCRIPTION
Revert outrageously added icon in previous iterations

<img width="405" height="82" alt="Capture d’écran 2026-05-13 à 14 16 31" src="https://github.com/user-attachments/assets/c4d3f09c-7cb6-4abb-944e-eec2c1743019" />