### PR TITLE
🔧(ingestion) control logging level with env variable

### DIFF
--- a/src/ingestion/api/config.py
+++ b/src/ingestion/api/config.py
@@ -17,6 +17,8 @@ class Settings(BaseSettings):
     web_base_url: str | None = None
     web_api_key: str | None = None
 
+    log_level: str = "INFO"
+
 
 class TestSettings(Settings):
     model_config = SettingsConfigDict(env_file=None)

--- a/src/ingestion/api/main.py
+++ b/src/ingestion/api/main.py
@@ -25,7 +25,7 @@ class _PlaintextFormatter(logging.Formatter):
 
 _handler = logging.StreamHandler()
 _handler.setFormatter(_PlaintextFormatter())
-logging.basicConfig(level=logging.INFO, handlers=[_handler])
+logging.basicConfig(level=get_settings().log_level.upper(), handlers=[_handler])
 
 
 def create_app():

--- a/src/ingestion/api/routes.py
+++ b/src/ingestion/api/routes.py
@@ -30,6 +30,10 @@ async def talentsoft_webhook(
     use_case: ArchiveOfferUseCase = Depends(get_archive_offer_use_case),
 ):
     body = await request.body()
+    logger.debug(
+        "Received TalentSoft webhook body",
+        extra={"body": body.decode(), "client_id": client_id},
+    )
     if not body:
         return {"status": "ok"}
 


### PR DESCRIPTION
## 📝 Description

https://github.com/betagouv/csplab/pull/590 added log details with the `status_id`. Log messages look like this:
```
INFO api.routes: Unhandled event type vacancy_update for reference 2026-2230814 and status_id None                
  client_id=ab2fcb9c-030b-478b-ac5f-21cdceadb89c 
```

To investigate why `status_id` is `None` I've added a `DEBUG` log line to see the webhook body. The logging level is controlled by an env variable.

## 🏷️ Type of change
- [ ] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [x] 🔧 Technical change

## 🔧 Changes
__List the main changes__

🛸 Required dependencies for this change (if applicable)

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
