### PR TITLE
✨(ingestion) create a shared Talensoft front client

### DIFF
--- a/src/ingestion/api/routes.py
+++ b/src/ingestion/api/routes.py
@@ -1,9 +1,10 @@
 import logging
-from collections.abc import AsyncGenerator
+from typing import Callable, TypeVar
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import ValidationError
+from starlette.datastructures import State
 
 from api.config import Settings, get_settings
 from api.talentsoft import verify_talentsoft_signature
@@ -27,24 +28,44 @@ public_router = APIRouter()
 
 _OK = {"status": "ok"}
 
+_T = TypeVar("_T")
 
-async def get_load_offer_details_use_case(
+
+def _state_setdefault(state: State, key: str, factory: Callable[[], _T]) -> _T:
+    if not hasattr(state, key):
+        setattr(state, key, factory())
+    return getattr(state, key)
+
+
+def get_load_offer_details_use_case(
+    request: Request,
     settings: Settings = Depends(get_settings),
-) -> AsyncGenerator[LoadOfferDetailsUseCase | None, None]:
+) -> LoadOfferDetailsUseCase | None:
     if (
         not settings.talentsoft_front_client_id
         or not settings.talentsoft_front_client_secret
         or not settings.talentsoft_front_base_url
     ):
-        yield None
-    else:
+        return None
+
+    base_url = settings.talentsoft_front_base_url
+    client_id = settings.talentsoft_front_client_id
+    client_secret = settings.talentsoft_front_client_secret
+
+    def _make_client() -> TalentsoftFrontClient:
         config = TalentsoftConfig(
-            base_url=settings.talentsoft_front_base_url,
-            client_id=settings.talentsoft_front_client_id,
-            client_secret=settings.talentsoft_front_client_secret,
+            base_url=base_url,
+            client_id=client_id,
+            client_secret=client_secret,
         )
-        async with TalentsoftFrontClient(config=config, logger=logger) as client:
-            yield LoadOfferDetailsUseCase(talentsoft_client=client)
+        return TalentsoftFrontClient(config=config, logger=logger)
+
+    client = _state_setdefault(
+        request.app.state,
+        "talentsoft_front_client",
+        _make_client,
+    )
+    return LoadOfferDetailsUseCase(talentsoft_client=client)
 
 
 @public_router.get("/health")

--- a/src/ingestion/infrastructure/gateways/async_http_client.py
+++ b/src/ingestion/infrastructure/gateways/async_http_client.py
@@ -6,15 +6,10 @@ import httpx
 class AsyncHttpClient:
     def __init__(self, timeout: int = 120):
         self.timeout = timeout
-        self._client: Optional[httpx.AsyncClient] = None
-
-    def _ensure_client(self) -> httpx.AsyncClient:
-        if self._client is None:
-            self._client = httpx.AsyncClient(timeout=self.timeout)
-        return self._client
+        self._client: Optional[httpx.AsyncClient] = httpx.AsyncClient(timeout=timeout)
 
     async def __aenter__(self) -> Self:
-        self._ensure_client()
+        self._client = httpx.AsyncClient(timeout=self.timeout)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -28,7 +23,9 @@ class AsyncHttpClient:
         headers: Optional[Dict[str, str]] = None,
         data: Optional[Dict[str, Any]] = None,
     ) -> httpx.Response:
-        return await self._ensure_client().post(url=url, headers=headers, data=data)
+        if not self._client:
+            raise RuntimeError("Client not initialized.")
+        return await self._client.post(url=url, headers=headers, data=data)
 
     async def get(
         self,
@@ -36,4 +33,6 @@ class AsyncHttpClient:
         headers: Optional[Dict[str, str]] = None,
         params: Optional[Mapping[str, int | str]] = None,
     ) -> httpx.Response:
-        return await self._ensure_client().get(url=url, headers=headers, params=params)
+        if not self._client:
+            raise RuntimeError("Client not initialized.")
+        return await self._client.get(url=url, headers=headers, params=params)

--- a/src/ingestion/infrastructure/gateways/async_http_client.py
+++ b/src/ingestion/infrastructure/gateways/async_http_client.py
@@ -8,8 +8,13 @@ class AsyncHttpClient:
         self.timeout = timeout
         self._client: Optional[httpx.AsyncClient] = None
 
+    def _ensure_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self.timeout)
+        return self._client
+
     async def __aenter__(self) -> Self:
-        self._client = httpx.AsyncClient(timeout=self.timeout)
+        self._ensure_client()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -23,9 +28,7 @@ class AsyncHttpClient:
         headers: Optional[Dict[str, str]] = None,
         data: Optional[Dict[str, Any]] = None,
     ) -> httpx.Response:
-        if not self._client:
-            raise RuntimeError("Client not initialized.")
-        return await self._client.post(url=url, headers=headers, data=data)
+        return await self._ensure_client().post(url=url, headers=headers, data=data)
 
     async def get(
         self,
@@ -33,6 +36,4 @@ class AsyncHttpClient:
         headers: Optional[Dict[str, str]] = None,
         params: Optional[Mapping[str, int | str]] = None,
     ) -> httpx.Response:
-        if not self._client:
-            raise RuntimeError("Client not initialized.")
-        return await self._client.get(url=url, headers=headers, params=params)
+        return await self._ensure_client().get(url=url, headers=headers, params=params)

--- a/src/ingestion/tests/presentation/test_webhook_load_offer.py
+++ b/src/ingestion/tests/presentation/test_webhook_load_offer.py
@@ -162,3 +162,39 @@ async def test_other_event_type_does_not_call_talentsoft(
 
     assert response.status_code == 200
     assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_token_is_fetched_once_across_two_webhook_requests(
+    talentsoft_client, httpx_mock: HTTPXMock
+):
+    reference_2 = "2024-VACANCY-002"
+
+    _mock_token_response(httpx_mock)
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{DETAIL_OFFER_URL}?reference={REFERENCE}",
+        json=_detail_offer_payload(REFERENCE),
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{DETAIL_OFFER_URL}?reference={reference_2}",
+        json=_detail_offer_payload(reference_2),
+    )
+
+    response_1 = make_signed_request(
+        talentsoft_client, {"event_type": "vacancy_new", "reference": REFERENCE}
+    )
+    response_2 = make_signed_request(
+        talentsoft_client, {"event_type": "vacancy_new", "reference": reference_2}
+    )
+
+    assert response_1.status_code == 200
+    assert response_2.status_code == 200
+
+    requests = httpx_mock.get_requests()
+    # 1 token request + 2 detail requests.
+    # token is not fetched again on the second webhook call
+    assert len(requests) == 3
+    token_requests = [r for r in requests if str(r.url) == TOKEN_URL]
+    assert len(token_requests) == 1

--- a/src/ingestion/tests/unit/external_gateways/test_talentsoft_client.py
+++ b/src/ingestion/tests/unit/external_gateways/test_talentsoft_client.py
@@ -197,6 +197,44 @@ class TestGetDetailOffer:
             mock_post.assert_called_once()  # Token refresh called
 
     @pytest.mark.asyncio
+    async def test_token_is_fetched_once_when_client_is_shared_across_requests(
+        self, talentsoft_client
+    ):
+        response_data_1 = detail_offer_response()
+        response_data_2 = detail_offer_response()
+        token_response = {
+            "access_token": fake.uuid4(),
+            "token_type": fake.word(),
+            "expires_in": 3600,
+        }
+
+        talentsoft_client.cached_token = None
+
+        with (
+            patch.object(talentsoft_client, "get", new_callable=AsyncMock) as mock_get,
+            patch.object(
+                talentsoft_client, "post", new_callable=AsyncMock
+            ) as mock_post,
+        ):
+            mock_get.side_effect = [
+                mocked_response(return_value=response_data_1),
+                mocked_response(return_value=response_data_2),
+            ]
+            mock_post.return_value = mocked_response(return_value=token_response)
+
+            offer_1 = await talentsoft_client.get_detail(
+                reference=response_data_1["reference"]
+            )
+            offer_2 = await talentsoft_client.get_detail(
+                reference=response_data_2["reference"]
+            )
+
+        assert offer_1.reference == response_data_1["reference"]
+        assert offer_2.reference == response_data_2["reference"]
+        mock_post.assert_called_once()  # Token was fetched only once, not per request
+        assert mock_get.call_count == 2
+
+    @pytest.mark.asyncio
     async def test_get_detail_fails_after_max_retries_attempts(self, talentsoft_client):
         failed_response = mocked_response(status_code=500)
         failed_response.raise_for_status.side_effect = Exception(

--- a/src/ingestion/tests/unit/test_async_http_client.py
+++ b/src/ingestion/tests/unit/test_async_http_client.py
@@ -1,17 +1,28 @@
 import pytest
+from pytest_httpx import HTTPXMock
 
 from infrastructure.gateways.async_http_client import AsyncHttpClient
 
 
 @pytest.mark.asyncio
-async def test_post_without_context_manager_raises():
+async def test_post_without_context_manager_succeeds(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="POST", url="https://example.com")
     client = AsyncHttpClient()
-    with pytest.raises(RuntimeError, match="Client not initialized"):
-        await client.post("https://example.com")
+    response = await client.post("https://example.com")
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_get_without_context_manager_raises():
+async def test_get_without_context_manager_succeeds(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="GET", url="https://example.com")
     client = AsyncHttpClient()
-    with pytest.raises(RuntimeError, match="Client not initialized"):
+    response = await client.get("https://example.com")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_aclose_cleans_up_client(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="GET", url="https://example.com")
+    async with AsyncHttpClient() as client:
         await client.get("https://example.com")
+    assert client._client is None


### PR DESCRIPTION
## 📝 Description

Follow up of #592

Create a shared Talensoft front client to reuse the same access token accross requests. This avoids creating a token per webhook received.

## 🏷️ Type of change
- [ ] 🐛 Bug fix
- [x] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
__List the main changes__

🛸 Required dependencies for this change (if applicable)

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
