### PR TITLE
🐛(ingestion-domain) set default values for source.id and source.source_id

### DIFF
--- a/src/web/infrastructure/django_apps/ingestion/models/source.py
+++ b/src/web/infrastructure/django_apps/ingestion/models/source.py
@@ -9,8 +9,8 @@ from domain.value_objects.source_type import SourceType
 class SourceModel(models.Model):
     objects: models.Manager = models.Manager()
 
-    id = models.UUIDField(primary_key=True)
-    source_id = models.UUIDField(unique=True)
+    id = models.UUIDField(primary_key=True, default=uuid4)
+    source_id = models.UUIDField(unique=True, default=uuid4)
     type = models.CharField(
         max_length=50, choices=[(st.value, st.value) for st in SourceType]
     )


### PR DESCRIPTION
## 📝 Description

Fixes [an exception](https://sentry.incubateur.net/organizations/betagouv/issues/282467/) where null values are inserted when trying to create a `Source` from Django Admin.

## 🏷️ Type of change
- [x] 🐛 Bug fix
- [ ] 🎢 New feature (non-breaking change that adds functionality)
- [ ] 🥁 Breaking change (a modification or feature that would cause existing functionality to stop working as expected) requiring a documentation update
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🔧 Technical change

## 🔧 Changes
__List the main changes__

🛸 Required dependencies for this change (if applicable)

## 🏝️ How to test (if applicable)
__Steps to reproduce or test__

## 📸 Screenshots (if applicable)

## ✅ Checklist
- [x] 💅 I have added or updated the appropriate tests.
- [x] 📝 I have updated or added the necessary documentation.
- [x] 🚀 I have considered the impact on performance, security, and user experience.
- [x] 👀 I have requested a review from a team member.
