### PR TITLE
✨(ingestion) clean a raw offer after loading it

### DIFF
--- a/src/ingestion/api/routes.py
+++ b/src/ingestion/api/routes.py
@@ -6,8 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import ValidationError
 
 from api.talentsoft import verify_talentsoft_signature
+from application.pipelines.ingest_offer_pipeline import IngestOfferPipeline
 from application.use_cases.archive_offer import ArchiveOfferUseCase
-from application.use_cases.save_raw_offer import SaveRawOfferUseCase
 from domain.repositories.sources_repository import ISourcesRepository
 from domain.value_objects.source import Source
 from domain.value_objects.webhook_event import (
@@ -17,7 +17,7 @@ from domain.value_objects.webhook_event import (
 )
 from infrastructure.di.container import (
     Container,
-    get_save_raw_offer_use_case,
+    get_ingest_offer_pipeline,
 )
 from presentation.dtos.talentsoft_webhook import TalentsoftWebhookPayload
 
@@ -44,8 +44,8 @@ async def talentsoft_webhook(
         Provide[Container.archive_offer_use_case]
     ),
     repository: ISourcesRepository = Depends(Provide[Container.sources_repository]),
-    save_raw_offer_use_case: SaveRawOfferUseCase | None = Depends(
-        get_save_raw_offer_use_case
+    ingest_offer_pipeline: IngestOfferPipeline | None = Depends(
+        get_ingest_offer_pipeline
     ),
 ):
     body = await request.body()
@@ -69,12 +69,12 @@ async def talentsoft_webhook(
         return await _handle_archive(event, client_id, source.source_id, use_case)
 
     if should_save_raw_offer(event):
-        if save_raw_offer_use_case is None:
+        if ingest_offer_pipeline is None:
             raise HTTPException(
                 status_code=500, detail="Talentsoft client or database not configured"
             )
-        return await _handle_save_raw_offer(
-            event, client_id, source.source_id, save_raw_offer_use_case
+        return await _handle_ingest_offer(
+            event, client_id, source.source_id, ingest_offer_pipeline
         )
 
     logger.info(
@@ -114,13 +114,13 @@ async def _handle_archive(
     return _OK
 
 
-async def _handle_save_raw_offer(
+async def _handle_ingest_offer(
     event: WebhookEvent,
     client_id: str,
     source_id: str,
-    use_case: SaveRawOfferUseCase,
+    pipeline: IngestOfferPipeline,
 ) -> dict:
-    await use_case.execute(reference=event.reference, source_id=source_id)
+    await pipeline.execute(reference=event.reference, source_id=source_id)
     logger.info(
         "Handled event type %s for reference %s",
         event.event_type,

--- a/src/ingestion/application/pipelines/ingest_offer_pipeline.py
+++ b/src/ingestion/application/pipelines/ingest_offer_pipeline.py
@@ -1,0 +1,36 @@
+import logging
+from datetime import datetime, timezone
+from typing import cast
+
+from application.use_cases.clean_raw_offer import CleanRawOfferUseCase
+from application.use_cases.save_raw_offer import SaveRawOfferUseCase
+from domain.repositories.raw_offer_repository import IRawOfferRepository
+
+logger = logging.getLogger(__name__)
+
+
+class IngestOfferPipeline:
+    def __init__(
+        self,
+        save_raw_offer: SaveRawOfferUseCase,
+        clean_raw_offer: CleanRawOfferUseCase,
+        raw_offer_repository: IRawOfferRepository,
+    ) -> None:
+        self._save_raw_offer = save_raw_offer
+        self._clean_raw_offer = clean_raw_offer
+        self._raw_offer_repository = raw_offer_repository
+
+    async def execute(self, reference: str, source_id: str) -> None:
+        raw_offer = await self._save_raw_offer.execute(reference, source_id)
+        if raw_offer is None:
+            return
+
+        try:
+            self._clean_raw_offer.execute(raw_offer)
+            await self._raw_offer_repository.mark_as_cleaned(
+                cast(str, raw_offer.reference),
+                cast(str, raw_offer.source_id),
+                datetime.now(tz=timezone.utc),
+            )
+        except Exception:
+            logger.exception("Failed to clean raw offer for reference %s", reference)

--- a/src/ingestion/application/use_cases/clean_raw_offer.py
+++ b/src/ingestion/application/use_cases/clean_raw_offer.py
@@ -1,0 +1,11 @@
+from domain.entities.offer import Offer
+from domain.entities.raw_offer import RawOffer
+from domain.gateways.offers_cleaner import IOffersCleaner
+
+
+class CleanRawOfferUseCase:
+    def __init__(self, offers_cleaner: IOffersCleaner) -> None:
+        self._offers_cleaner = offers_cleaner
+
+    def execute(self, raw_offer: RawOffer) -> Offer:
+        return self._offers_cleaner.clean(raw_offer)

--- a/src/ingestion/application/use_cases/save_raw_offer.py
+++ b/src/ingestion/application/use_cases/save_raw_offer.py
@@ -18,27 +18,37 @@ class SaveRawOfferUseCase:
         self._offers_gateway = offers_gateway
         self._raw_offer_repository = raw_offer_repository
 
-    async def execute(self, reference: str, source_id: str) -> None:
+    async def execute(self, reference: str, source_id: str) -> RawOffer | None:
         error_msg: str | None = None
         loaded_at: datetime | None = None
         data: dict[str, Any] | None = None
+        gateway_error: Exception | None = None
+
         try:
             offer = await self._offers_gateway.get_detail(reference)
             loaded_at = datetime.now(tz=timezone.utc)
             data = offer.data
         except Exception as e:
             error_msg = str(e)
-            raise
-        finally:
-            try:
-                await self._raw_offer_repository.upsert(
-                    RawOffer(
-                        reference=reference,
-                        source_id=source_id,
-                        data=data,
-                        error_msg=error_msg,
-                        loaded_at=loaded_at,
-                    )
-                )
-            except Exception:
-                logger.exception("Failed to save raw offer for reference %s", reference)
+            gateway_error = e
+
+        raw_offer = RawOffer(
+            reference=reference,
+            source_id=source_id,
+            data=data,
+            error_msg=error_msg,
+            loaded_at=loaded_at,
+        )
+
+        try:
+            await self._raw_offer_repository.upsert(raw_offer)
+        except Exception:
+            logger.exception("Failed to save raw offer for reference %s", reference)
+            if gateway_error is not None:
+                raise gateway_error from None
+            return None
+
+        if gateway_error is not None:
+            raise gateway_error from None
+
+        return raw_offer

--- a/src/ingestion/domain/entities/offer.py
+++ b/src/ingestion/domain/entities/offer.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from pydantic import HttpUrl
+
+from domain.value_objects.category import Category
+from domain.value_objects.contract_type import ContractType
+from domain.value_objects.limit_date import LimitDate
+from domain.value_objects.localisation import Localisation
+from domain.value_objects.verse import Verse
+
+
+@dataclass
+class Offer:
+    reference: str
+    source_id: str
+    external_id: str
+    title: str
+    profile: str
+    mission: str
+    organization: str
+    verse: Optional[Verse]
+    category: Optional[Category]
+    contract_type: Optional[ContractType]
+    offer_url: Optional[HttpUrl]
+    localisation: Optional[Localisation]
+    publication_date: datetime
+    beginning_date: Optional[LimitDate]
+    family_code: Optional[str] = None
+    id: UUID = field(default_factory=uuid4)

--- a/src/ingestion/domain/exceptions/offer_errors.py
+++ b/src/ingestion/domain/exceptions/offer_errors.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+
+
+class InvalidLimitDateError(ValueError):
+    def __init__(self, limit_date: datetime):
+        super().__init__(f"Invalid limit date: {limit_date}")

--- a/src/ingestion/domain/gateways/offers_cleaner.py
+++ b/src/ingestion/domain/gateways/offers_cleaner.py
@@ -1,0 +1,8 @@
+from typing import Protocol
+
+from domain.entities.offer import Offer
+from domain.entities.raw_offer import RawOffer
+
+
+class IOffersCleaner(Protocol):
+    def clean(self, raw_offer: RawOffer) -> Offer: ...

--- a/src/ingestion/domain/repositories/raw_offer_repository.py
+++ b/src/ingestion/domain/repositories/raw_offer_repository.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Protocol
 
 from domain.entities.raw_offer import RawOffer
@@ -5,3 +6,6 @@ from domain.entities.raw_offer import RawOffer
 
 class IRawOfferRepository(Protocol):
     async def upsert(self, offer: RawOffer) -> None: ...
+    async def mark_as_cleaned(
+        self, reference: str, source_id: str, cleaned_at: datetime
+    ) -> None: ...

--- a/src/ingestion/domain/value_objects/area.py
+++ b/src/ingestion/domain/value_objects/area.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class GeographicalArea(Enum):
+    AFRIQUE = "AF"
+    EUROPE = "EU"
+    ASIE = "AS"
+    AMERIQUE = "AM"
+    OCEANIE = "OC"
+    ANTARTIQUE = "AN"
+
+    def __str__(self):
+        return self.value

--- a/src/ingestion/domain/value_objects/category.py
+++ b/src/ingestion/domain/value_objects/category.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class Category(Enum):
+    APLUS = "APLUS"
+    A = "A"
+    B = "B"
+    C = "C"
+    HORS_CATEGORIE = "HORS_CATEGORIE"
+
+    def __str__(self):
+        return self.value

--- a/src/ingestion/domain/value_objects/contract_type.py
+++ b/src/ingestion/domain/value_objects/contract_type.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class ContractType(Enum):
+    TITULAIRE_CONTRACTUEL = "TITULAIRE_CONTRACTUEL"
+    CONTRACTUELS = "CONTRACTUELS"
+    TERRITORIAL = "TERRITORIAL"
+
+    def __str__(self):
+        return self.value

--- a/src/ingestion/domain/value_objects/country.py
+++ b/src/ingestion/domain/value_objects/country.py
@@ -1,0 +1,5 @@
+class Country(str):
+    """ISO 3166-1 alpha-3 country code."""
+
+    def __str__(self) -> str:
+        return super().__str__()

--- a/src/ingestion/domain/value_objects/department.py
+++ b/src/ingestion/domain/value_objects/department.py
@@ -1,0 +1,131 @@
+from typing import ClassVar
+
+from pydantic import BaseModel, field_validator
+
+
+class Department(BaseModel):
+    code: str
+
+    NAMES: ClassVar[dict[str, str]] = {
+        "01": "Ain",
+        "02": "Aisne",
+        "03": "Allier",
+        "04": "Alpes-de-Haute-Provence",
+        "05": "Hautes-Alpes",
+        "06": "Alpes-Maritimes",
+        "07": "Ardèche",
+        "08": "Ardennes",
+        "09": "Ariège",
+        "10": "Aube",
+        "11": "Aude",
+        "12": "Aveyron",
+        "13": "Bouches-du-Rhône",
+        "14": "Calvados",
+        "15": "Cantal",
+        "16": "Charente",
+        "17": "Charente-Maritime",
+        "18": "Cher",
+        "19": "Corrèze",
+        "21": "Côte-d'Or",
+        "22": "Côtes-d'Armor",
+        "23": "Creuse",
+        "24": "Dordogne",
+        "25": "Doubs",
+        "26": "Drôme",
+        "27": "Eure",
+        "28": "Eure-et-Loir",
+        "29": "Finistère",
+        "2A": "Corse-du-Sud",
+        "2B": "Haute-Corse",
+        "30": "Gard",
+        "31": "Haute-Garonne",
+        "32": "Gers",
+        "33": "Gironde",
+        "34": "Hérault",
+        "35": "Ille-et-Vilaine",
+        "36": "Indre",
+        "37": "Indre-et-Loire",
+        "38": "Isère",
+        "39": "Jura",
+        "40": "Landes",
+        "41": "Loir-et-Cher",
+        "42": "Loire",
+        "43": "Haute-Loire",
+        "44": "Loire-Atlantique",
+        "45": "Loiret",
+        "46": "Lot",
+        "47": "Lot-et-Garonne",
+        "48": "Lozère",
+        "49": "Maine-et-Loire",
+        "50": "Manche",
+        "51": "Marne",
+        "52": "Haute-Marne",
+        "53": "Mayenne",
+        "54": "Meurthe-et-Moselle",
+        "55": "Meuse",
+        "56": "Morbihan",
+        "57": "Moselle",
+        "58": "Nièvre",
+        "59": "Nord",
+        "60": "Oise",
+        "61": "Orne",
+        "62": "Pas-de-Calais",
+        "63": "Puy-de-Dôme",
+        "64": "Pyrénées-Atlantiques",
+        "65": "Hautes-Pyrénées",
+        "66": "Pyrénées-Orientales",
+        "67": "Bas-Rhin",
+        "68": "Haut-Rhin",
+        "69": "Rhône",
+        "70": "Haute-Saône",
+        "71": "Saône-et-Loire",
+        "72": "Sarthe",
+        "73": "Savoie",
+        "74": "Haute-Savoie",
+        "75": "Paris",
+        "76": "Seine-Maritime",
+        "77": "Seine-et-Marne",
+        "78": "Yvelines",
+        "79": "Deux-Sèvres",
+        "80": "Somme",
+        "81": "Tarn",
+        "82": "Tarn-et-Garonne",
+        "83": "Var",
+        "84": "Vaucluse",
+        "85": "Vendée",
+        "86": "Vienne",
+        "87": "Haute-Vienne",
+        "88": "Vosges",
+        "89": "Yonne",
+        "90": "Territoire de Belfort",
+        "91": "Essonne",
+        "92": "Hauts-de-Seine",
+        "93": "Seine-Saint-Denis",
+        "94": "Val-de-Marne",
+        "95": "Val-d'Oise",
+        "971": "Guadeloupe",
+        "972": "Martinique",
+        "973": "Guyane",
+        "974": "La Réunion",
+        "975": "Saint-Pierre-et-Miquelon",
+        "976": "Mayotte",
+        "986": "Wallis-et-Futuna",
+        "987": "Polynésie française",
+        "988": "Nouvelle-Calédonie",
+    }
+
+    VALID_CODES: ClassVar[set[str]] = set(NAMES.keys()) | {"SPM", "WLF"}
+
+    @field_validator("code")
+    @classmethod
+    def validate_department_code(cls, v: str) -> str:
+        if v not in cls.VALID_CODES:
+            raise ValueError(f"Invalid French department code: {v}")
+        return v
+
+    def __str__(self) -> str:
+        return self.code
+
+    @property
+    def name(self) -> str:
+        return self.NAMES.get(self.code, self.code)

--- a/src/ingestion/domain/value_objects/limit_date.py
+++ b/src/ingestion/domain/value_objects/limit_date.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from domain.exceptions.offer_errors import InvalidLimitDateError
+
+
+@dataclass(frozen=True)
+class LimitDate:
+    value: datetime
+
+    def __post_init__(self):
+        if not isinstance(self.value, datetime):
+            raise InvalidLimitDateError(self.value)
+
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) > self.value

--- a/src/ingestion/domain/value_objects/localisation.py
+++ b/src/ingestion/domain/value_objects/localisation.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from domain.value_objects.area import GeographicalArea
+from domain.value_objects.country import Country
+from domain.value_objects.department import Department
+from domain.value_objects.region import Region
+
+
+@dataclass(frozen=True)
+class Localisation:
+    area: GeographicalArea
+    country: Country
+    region: Region
+    department: Department
+
+    def __str__(self):
+        return f"{self.country} - {self.region.code} - {self.department.code}"

--- a/src/ingestion/domain/value_objects/region.py
+++ b/src/ingestion/domain/value_objects/region.py
@@ -1,0 +1,44 @@
+from typing import ClassVar
+
+from pydantic import BaseModel, field_validator
+
+
+class Region(BaseModel):
+    code: str
+
+    NAMES: ClassVar[dict[str, str]] = {
+        "11": "Île-de-France",
+        "24": "Centre-Val de Loire",
+        "27": "Bourgogne-Franche-Comté",
+        "28": "Normandie",
+        "32": "Hauts-de-France",
+        "44": "Grand Est",
+        "52": "Pays de la Loire",
+        "53": "Bretagne",
+        "75": "Nouvelle-Aquitaine",
+        "76": "Occitanie",
+        "84": "Auvergne-Rhône-Alpes",
+        "93": "Provence-Alpes-Côte d'Azur",
+        "94": "Corse",
+        "01": "Guadeloupe",
+        "02": "Martinique",
+        "03": "Guyane",
+        "04": "La Réunion",
+        "06": "Mayotte",
+    }
+
+    VALID_CODES: ClassVar[set[str]] = set(NAMES.keys()) | {"DOM", "TOM"}
+
+    @field_validator("code")
+    @classmethod
+    def validate_region_code(cls, v: str) -> str:
+        if v not in cls.VALID_CODES:
+            raise ValueError(f"Invalid French region INSEE code: {v}")
+        return v
+
+    def __str__(self) -> str:
+        return self.code
+
+    @property
+    def name(self) -> str:
+        return self.NAMES.get(self.code, self.code)

--- a/src/ingestion/domain/value_objects/verse.py
+++ b/src/ingestion/domain/value_objects/verse.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class Verse(Enum):
+    FPT = "FPT"
+    FPE = "FPE"
+    FPH = "FPH"
+
+    def __str__(self):
+        return self.value

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -6,7 +6,9 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, Query
 from sqlalchemy import Engine
 
+from application.pipelines.ingest_offer_pipeline import IngestOfferPipeline
 from application.use_cases.archive_offer import ArchiveOfferUseCase
+from application.use_cases.clean_raw_offer import CleanRawOfferUseCase
 from application.use_cases.load_sources import LoadSourcesUseCase
 from application.use_cases.save_raw_offer import SaveRawOfferUseCase
 from domain.gateways.archive_gateway import IArchiveGateway
@@ -21,6 +23,7 @@ from infrastructure.external_gateways.talentsoft_client import (
 )
 from infrastructure.external_gateways.web_archive_gateway import WebArchiveGateway
 from infrastructure.external_gateways.web_sources_gateway import WebSourcesGateway
+from infrastructure.gateways.offers_cleaner import OffersCleaner
 from infrastructure.raw_offer_repository import RawOfferRepository
 from infrastructure.sources_repository import SourcesRepository
 from infrastructure.talentsoft_client_repository import TalentsoftClientRepository
@@ -134,6 +137,13 @@ class Container(containers.DeclarativeContainer):
         repository=sources_repository,
     )
 
+    offers_cleaner = providers.Singleton(OffersCleaner)
+
+    clean_raw_offer_use_case = providers.Factory(
+        CleanRawOfferUseCase,
+        offers_cleaner=offers_cleaner,
+    )
+
 
 def run_database_migrations(database_url: str) -> None:
     run_migrations(database_url)
@@ -155,7 +165,7 @@ def register_talentsoft_front_client(
 
 
 @inject
-def get_save_raw_offer_use_case(
+def get_ingest_offer_pipeline(
     client_id: str = Query(...),
     sources_repository: ISourcesRepository = Depends(
         Provide[Container.sources_repository]
@@ -166,7 +176,7 @@ def get_save_raw_offer_use_case(
     raw_offer_repository: IRawOfferRepository | None = Depends(
         Provide[Container.raw_offer_repository]
     ),
-) -> SaveRawOfferUseCase | None:
+) -> IngestOfferPipeline | None:
     if raw_offer_repository is None:
         return None
     source = sources_repository.get_by_client_id_back(client_id)
@@ -175,7 +185,13 @@ def get_save_raw_offer_use_case(
     client = client_repository.get(source.client_id_front)
     if client is None:
         return None
-    return SaveRawOfferUseCase(
+    save_use_case = SaveRawOfferUseCase(
         offers_gateway=client,
+        raw_offer_repository=raw_offer_repository,
+    )
+    clean_use_case = CleanRawOfferUseCase(offers_cleaner=OffersCleaner())
+    return IngestOfferPipeline(
+        save_raw_offer=save_use_case,
+        clean_raw_offer=clean_use_case,
         raw_offer_repository=raw_offer_repository,
     )

--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -1,0 +1,202 @@
+import logging
+from datetime import datetime
+from typing import List, Optional, cast
+
+from pydantic import HttpUrl, ValidationError
+
+from domain.entities.offer import Offer
+from domain.entities.raw_offer import RawOffer
+from domain.value_objects.area import GeographicalArea
+from domain.value_objects.category import Category
+from domain.value_objects.contract_type import ContractType
+from domain.value_objects.country import Country
+from domain.value_objects.department import Department
+from domain.value_objects.limit_date import LimitDate
+from domain.value_objects.localisation import Localisation
+from domain.value_objects.region import Region
+from domain.value_objects.verse import Verse
+from infrastructure.external_gateways.dtos.talentsoft_dtos import TalentsoftDetailOffer
+
+logger = logging.getLogger(__name__)
+
+_TALENTSOFT_TO_AREA: dict[str, GeographicalArea] = {
+    "_TS_CO_GeographicalArea_Afrique": GeographicalArea.AFRIQUE,
+    "_TS_CO_GeographicalArea_AmriquesCaraibe": GeographicalArea.AMERIQUE,
+    "_TS_CO_GeographicalArea_Asie": GeographicalArea.ASIE,
+    "_TS_CO_GeographicalArea_Europe": GeographicalArea.EUROPE,
+    "_TS_CO_GeographicalArea_MoyenOrientAfriqueduNord": GeographicalArea.AFRIQUE,
+    "_TS_CO_GeographicalArea_Ocanie": GeographicalArea.OCEANIE,
+}
+
+
+class OffersCleaner:
+    def clean(self, raw_offer: RawOffer) -> Offer:
+        if not raw_offer.data:
+            raise ValueError(f"RawOffer {raw_offer.reference} has no data to clean")
+        if not raw_offer.source_id:
+            raise ValueError(f"RawOffer {raw_offer.reference} has no source_id")
+
+        talentsoft_offer = TalentsoftDetailOffer.model_validate(raw_offer.data)
+        return self._map_talentsoft_to_offer(talentsoft_offer, raw_offer)
+
+    def _map_talentsoft_to_offer(
+        self, talentsoft_offer: TalentsoftDetailOffer, raw_offer: RawOffer
+    ) -> Offer:
+        ts_verse = (
+            talentsoft_offer.salaryRange.clientCode
+            if talentsoft_offer.salaryRange
+            else "UNK"
+        )
+        verse = self._map_verse(ts_verse, talentsoft_offer.reference)
+
+        contract_type = self._map_contract_type(
+            talentsoft_offer.contractType.clientCode
+            if talentsoft_offer.contractType
+            else None
+        )
+
+        localisation = self._map_localisation_from_arrays(
+            talentsoft_offer.geographicalLocation,
+            talentsoft_offer.country,
+            talentsoft_offer.region,
+            talentsoft_offer.department,
+        )
+
+        offer_url = self._parse_url(talentsoft_offer.offerUrl)
+        publication_date = self._parse_publication_date(
+            talentsoft_offer.startPublicationDate
+        )
+        beginning_date = self._parse_beginning_date(talentsoft_offer.beginningDate)
+
+        category = self._parse_category(
+            talentsoft_offer.customFields.description.customCodeTable1.clientCode
+            if talentsoft_offer.customFields
+            and talentsoft_offer.customFields.description
+            and talentsoft_offer.customFields.description.customCodeTable1
+            else None
+        )
+
+        family_code_value = None
+        if talentsoft_offer.offerFamilyCategory:
+            family_code_value = talentsoft_offer.offerFamilyCategory.clientCode
+
+        return Offer(
+            reference=raw_offer.reference,
+            source_id=cast(str, raw_offer.source_id),  # guaranteed by clean()
+            external_id=f"{ts_verse}-{talentsoft_offer.reference}"
+            if ts_verse
+            else talentsoft_offer.reference,
+            verse=verse,
+            title=talentsoft_offer.title,
+            profile=talentsoft_offer.description2 or "",
+            mission=talentsoft_offer.description1 or "",
+            category=category,
+            contract_type=contract_type,
+            organization=talentsoft_offer.organisationName,
+            offer_url=offer_url,
+            localisation=localisation,
+            publication_date=publication_date,
+            beginning_date=beginning_date,
+            family_code=family_code_value,
+        )
+
+    def _map_verse(self, verse_str: Optional[str], reference: str) -> Optional[Verse]:
+        if not verse_str:
+            return None
+        verse_upper = verse_str.upper()
+        if "FPT" in verse_upper:
+            return Verse.FPT
+        elif "FPH" in verse_upper or "APHP" in reference.upper():
+            return Verse.FPH
+        elif "FPE" in verse_upper:
+            return Verse.FPE
+        return None
+
+    def _map_contract_type(
+        self, contract_type_str: Optional[str]
+    ) -> Optional[ContractType]:
+        if not contract_type_str:
+            return None
+
+        contract_upper = contract_type_str.upper()
+        if "TITULAIRE" in contract_upper:
+            return ContractType.TITULAIRE_CONTRACTUEL
+        elif "CONTRACTUEL" in contract_upper:
+            return ContractType.CONTRACTUELS
+        elif "TERRITORIAL" in contract_upper:
+            return ContractType.TERRITORIAL
+
+        return None
+
+    def _map_localisation_from_arrays(
+        self, areas: List, countries: List, regions: List, departments: List
+    ) -> Optional[Localisation]:
+        area_code = areas[0].clientCode if areas else None
+        country_code = countries[0].clientCode if countries else None
+        region_code = regions[0].clientCode if regions else None
+        department_code = departments[0].clientCode if departments else None
+
+        if not country_code or not region_code or not department_code or not area_code:
+            return None
+
+        area = _TALENTSOFT_TO_AREA.get(area_code)
+        if area is None:
+            return None
+
+        if region_code.startswith("_TS_CO_Region_"):
+            insee_region_code = region_code.replace("_TS_CO_Region_", "")
+        elif region_code.startswith("R"):
+            insee_region_code = region_code.lstrip("R")
+        else:
+            insee_region_code = region_code
+
+        if department_code.startswith("_TS_CO_Department_NouvelleCaldonie988"):
+            insee_department_code = "988"
+        else:
+            insee_department_code = department_code
+
+        try:
+            return Localisation(
+                area=area,
+                country=Country(country_code),
+                region=Region(code=insee_region_code),
+                department=Department(code=insee_department_code),
+            )
+        except (ValueError, ValidationError) as e:
+            logger.warning(
+                "Invalid localisation for region=%s department=%s: %s",
+                region_code,
+                department_code,
+                e,
+            )
+            return None
+
+    def _parse_url(self, url_str: str) -> Optional[HttpUrl]:
+        try:
+            return HttpUrl(url_str)
+        except Exception:
+            return None
+
+    def _parse_publication_date(self, date_str: str) -> datetime:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+
+    def _parse_beginning_date(self, date_str: Optional[str]) -> Optional[LimitDate]:
+        if not date_str:
+            return None
+
+        try:
+            parsed_date = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            return LimitDate(value=parsed_date)
+        except (ValueError, TypeError, AttributeError):
+            return None
+
+    def _parse_category(self, category_code: Optional[str]) -> Optional[Category]:
+        if category_code in ["CAT-AEF", "CAT-ESD", "CAT-ES"]:
+            return Category.APLUS
+        elif category_code == "CAT-A":
+            return Category.A
+        elif category_code == "CAT-B":
+            return Category.B
+        elif category_code == "CAT-C":
+            return Category.C
+        return None

--- a/src/ingestion/infrastructure/raw_offer_repository.py
+++ b/src/ingestion/infrastructure/raw_offer_repository.py
@@ -1,15 +1,16 @@
 import asyncio
 from datetime import datetime, timezone
 
-from sqlalchemy import Engine
+from sqlalchemy import Engine, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlmodel import Session
+from sqlmodel import Session, col
 
 from domain.entities.raw_offer import RawOffer
+from domain.repositories.raw_offer_repository import IRawOfferRepository
 from infrastructure.models.raw_offer import RawOfferModel
 
 
-class RawOfferRepository:
+class RawOfferRepository(IRawOfferRepository):
     def __init__(self, engine: Engine) -> None:
         self._engine = engine
 
@@ -44,4 +45,31 @@ class RawOfferRepository:
                 )
             )
             session.execute(stmt)
+            session.commit()
+
+    async def mark_as_cleaned(
+        self, reference: str, source_id: str, cleaned_at: datetime
+    ) -> None:
+        await asyncio.to_thread(
+            self._mark_as_cleaned_sync, reference, source_id, cleaned_at
+        )
+
+    def _mark_as_cleaned_sync(
+        self, reference: str, source_id: str, cleaned_at: datetime
+    ) -> None:
+        now = datetime.now(tz=timezone.utc)
+        with Session(self._engine) as session:
+            result = session.execute(
+                update(RawOfferModel)
+                .where(
+                    col(RawOfferModel.reference) == reference,
+                    col(RawOfferModel.source_id) == source_id,
+                )
+                .values(cleaned_at=cleaned_at, updated_at=now)
+            )
+            if result.rowcount == 0:  # type: ignore[attr-defined]
+                raise ValueError(
+                    f"RawOffer not found for reference={reference},"
+                    f" source_id={source_id}"
+                )
             session.commit()

--- a/src/ingestion/tests/integration/test_clean_raw_offer_use_case.py
+++ b/src/ingestion/tests/integration/test_clean_raw_offer_use_case.py
@@ -1,0 +1,187 @@
+"""Integration tests for CleanRawOfferUseCase wired with the real OffersCleaner."""
+
+import datetime
+
+import pytest
+
+from application.use_cases.clean_raw_offer import CleanRawOfferUseCase
+from domain.entities.offer import Offer
+from domain.entities.raw_offer import RawOffer
+from domain.value_objects.category import Category
+from domain.value_objects.contract_type import ContractType
+from domain.value_objects.limit_date import LimitDate
+from domain.value_objects.verse import Verse
+from infrastructure.gateways.offers_cleaner import OffersCleaner
+from tests.factories.talentsoft_factories import (
+    TalentsoftCodedObjectFactory,
+    TalentsoftCustomCodeTableFactory,
+    TalentsoftCustomFieldsFactory,
+    TalentsoftDescriptionCustomFieldsFactory,
+    TalentsoftDetailOfferFactory,
+)
+
+REFERENCE = "2024-OFFER-001"
+SOURCE_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def use_case() -> CleanRawOfferUseCase:
+    return CleanRawOfferUseCase(offers_cleaner=OffersCleaner())
+
+
+def _raw_offer(**kwargs) -> RawOffer:
+    offer_dto = TalentsoftDetailOfferFactory.build(reference=REFERENCE, **kwargs)
+    return RawOffer(
+        reference=REFERENCE,
+        source_id=SOURCE_ID,
+        data=offer_dto.model_dump(),
+    )
+
+
+def test_execute_returns_offer_with_reference_and_source_id(use_case):
+    result = use_case.execute(_raw_offer())
+
+    assert isinstance(result, Offer)
+    assert result.reference == REFERENCE
+    assert result.source_id == SOURCE_ID
+
+
+def test_execute_maps_title_and_organization(use_case):
+    raw = _raw_offer(title="DIRECTEUR GÉNÉRAL", organisationName="Mairie de Lyon")
+
+    result = use_case.execute(raw)
+
+    assert result.title == "DIRECTEUR GÉNÉRAL"
+    assert result.organization == "Mairie de Lyon"
+
+
+@pytest.mark.parametrize(
+    "salary_range_code, expected_verse",
+    [
+        ("Versant_FPT", Verse.FPT),
+        ("Versant_FPH", Verse.FPH),
+        ("Versant_FPE", Verse.FPE),
+    ],
+)
+def test_execute_maps_verse(use_case, salary_range_code, expected_verse):
+    salary_range = TalentsoftCodedObjectFactory.build(clientCode=salary_range_code)
+    result = use_case.execute(_raw_offer(salaryRange=salary_range))
+
+    assert result.verse == expected_verse
+
+
+@pytest.mark.parametrize(
+    "contract_code, expected",
+    [
+        ("TITULAIRE_CDI", ContractType.TITULAIRE_CONTRACTUEL),
+        ("CONTRACTUEL_CDD", ContractType.CONTRACTUELS),
+        ("TERRITORIAL_TIT", ContractType.TERRITORIAL),
+        ("INCONNU", None),
+        (None, None),
+    ],
+)
+def test_execute_maps_contract_type(use_case, contract_code, expected):
+    contract_type = (
+        TalentsoftCodedObjectFactory.build(clientCode=contract_code)
+        if contract_code
+        else None
+    )
+    result = use_case.execute(_raw_offer(contractType=contract_type))
+
+    assert result.contract_type == expected
+
+
+@pytest.mark.parametrize(
+    "category_code, expected_category",
+    [
+        ("CAT-AEF", Category.APLUS),
+        ("CAT-ESD", Category.APLUS),
+        ("CAT-ES", Category.APLUS),
+        ("CAT-A", Category.A),
+        ("CAT-B", Category.B),
+        ("CAT-C", Category.C),
+        ("UNKNOWN", None),
+    ],
+)
+def test_execute_maps_category(use_case, category_code, expected_category):
+    raw = _raw_offer(
+        customFields=TalentsoftCustomFieldsFactory.build(
+            description=TalentsoftDescriptionCustomFieldsFactory.build(
+                customCodeTable1=TalentsoftCustomCodeTableFactory.build(
+                    clientCode=category_code
+                )
+            )
+        )
+    )
+
+    result = use_case.execute(raw)
+
+    assert result.category == expected_category
+
+
+def test_execute_maps_localisation(use_case):
+    raw = _raw_offer(
+        geographicalLocation=[
+            TalentsoftCodedObjectFactory.build(
+                clientCode="_TS_CO_GeographicalArea_Europe",
+                type="offerGeographicalLocation",
+            )
+        ],
+        country=[
+            TalentsoftCodedObjectFactory.build(clientCode="FRA", type="offerCountry")
+        ],
+        region=[
+            TalentsoftCodedObjectFactory.build(clientCode="R11", type="offerRegion")
+        ],
+        department=[
+            TalentsoftCodedObjectFactory.build(clientCode="75", type="offerDepartment")
+        ],
+    )
+
+    result = use_case.execute(raw)
+
+    assert result.localisation is not None
+    assert result.localisation.area.value == "EU"
+    assert str(result.localisation.country) == "FRA"
+    assert result.localisation.region.code == "11"
+    assert result.localisation.department.code == "75"
+
+
+def test_execute_returns_none_localisation_when_missing(use_case):
+    raw = _raw_offer(geographicalLocation=[], country=[], region=[], department=[])
+
+    result = use_case.execute(raw)
+
+    assert result.localisation is None
+
+
+def test_execute_raises_when_raw_offer_has_no_data(use_case):
+    raw = RawOffer(reference=REFERENCE, source_id=SOURCE_ID, data=None)
+
+    with pytest.raises(ValueError, match="no data"):
+        use_case.execute(raw)
+
+
+def test_execute_external_id_uses_salary_range_client_code_as_prefix(use_case):
+    salary_range = TalentsoftCodedObjectFactory.build(clientCode="Versant_FPT")
+    result = use_case.execute(_raw_offer(salaryRange=salary_range))
+
+    assert result.external_id == f"Versant_FPT-{REFERENCE}"
+
+
+def test_execute_sets_beginning_date_when_present(use_case):
+    raw = _raw_offer(beginningDate="2025-09-01T00:00:00Z")
+
+    result = use_case.execute(raw)
+
+    assert result.beginning_date == LimitDate(
+        value=datetime.datetime(2025, 9, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    )
+
+
+def test_execute_sets_none_beginning_date_when_absent(use_case):
+    raw = _raw_offer(beginningDate=None)
+
+    result = use_case.execute(raw)
+
+    assert result.beginning_date is None

--- a/src/ingestion/tests/integration/test_raw_offer_repository.py
+++ b/src/ingestion/tests/integration/test_raw_offer_repository.py
@@ -168,6 +168,57 @@ async def test_upsert_does_not_overwrite_cleaned_at_on_conflict(repository, db_e
 
 
 # ---------------------------------------------------------------------------
+# mark_as_cleaned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_as_cleaned_sets_cleaned_at(repository, db_engine):
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=SOURCE_ID))
+
+    cleaned_at = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await repository.mark_as_cleaned(REFERENCE, SOURCE_ID, cleaned_at)
+
+    saved = _fetch(db_engine, REFERENCE, SOURCE_ID)
+    assert saved.cleaned_at is not None
+    assert saved.cleaned_at.replace(tzinfo=timezone.utc) == cleaned_at
+
+
+@pytest.mark.asyncio
+async def test_mark_as_cleaned_updates_updated_at(repository, db_engine):
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=SOURCE_ID))
+    before = _fetch(db_engine, REFERENCE, SOURCE_ID)
+
+    cleaned_at = datetime.now(tz=timezone.utc)
+    await repository.mark_as_cleaned(REFERENCE, SOURCE_ID, cleaned_at)
+
+    after = _fetch(db_engine, REFERENCE, SOURCE_ID)
+    assert after.updated_at >= before.updated_at
+
+
+@pytest.mark.asyncio
+async def test_mark_as_cleaned_does_not_affect_other_rows(repository, db_engine):
+    other_source_id = str(uuid4())
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=SOURCE_ID))
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=other_source_id))
+
+    await repository.mark_as_cleaned(
+        REFERENCE, SOURCE_ID, datetime.now(tz=timezone.utc)
+    )
+
+    other = _fetch(db_engine, REFERENCE, other_source_id)
+    assert other.cleaned_at is None
+
+
+@pytest.mark.asyncio
+async def test_mark_as_cleaned_raises_when_row_not_found(repository, db_engine):
+    with pytest.raises(ValueError, match="RawOffer not found"):
+        await repository.mark_as_cleaned(
+            "UNKNOWN-REF", SOURCE_ID, datetime.now(tz=timezone.utc)
+        )
+
+
+# ---------------------------------------------------------------------------
 # Uniqueness
 # ---------------------------------------------------------------------------
 

--- a/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
+++ b/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
@@ -1,0 +1,350 @@
+import pytest
+from pydantic import ValidationError
+
+from domain.entities.raw_offer import RawOffer
+from domain.value_objects.category import Category
+from domain.value_objects.contract_type import ContractType
+from domain.value_objects.verse import Verse
+from infrastructure.gateways.offers_cleaner import OffersCleaner
+from tests.factories.talentsoft_factories import (
+    TalentsoftCodedObjectFactory,
+    TalentsoftCustomCodeTableFactory,
+    TalentsoftCustomFieldsFactory,
+    TalentsoftDescriptionCustomFieldsFactory,
+    TalentsoftDetailOfferFactory,
+)
+
+REFERENCE = "2024-OFFER-001"
+SOURCE_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def cleaner() -> OffersCleaner:
+    return OffersCleaner()
+
+
+def _make_raw_offer(reference: str = REFERENCE, **offer_kwargs) -> RawOffer:
+    offer_dto = TalentsoftDetailOfferFactory.build(reference=reference, **offer_kwargs)
+    return RawOffer(
+        reference=reference,
+        source_id=SOURCE_ID,
+        data=offer_dto.model_dump(),
+    )
+
+
+def test_clean_returns_offer_with_correct_reference(cleaner):
+    raw_offer = _make_raw_offer()
+
+    offer = cleaner.clean(raw_offer)
+
+    assert REFERENCE in offer.external_id
+
+
+def test_clean_raises_when_no_data(cleaner):
+    raw_offer = RawOffer(reference=REFERENCE, source_id=SOURCE_ID, data=None)
+
+    with pytest.raises(ValueError, match="no data"):
+        cleaner.clean(raw_offer)
+
+
+def test_clean_raises_on_invalid_data(cleaner):
+    raw_offer = RawOffer(
+        reference=REFERENCE, source_id=SOURCE_ID, data={"invalid": "data"}
+    )
+
+    with pytest.raises(ValidationError):
+        cleaner.clean(raw_offer)
+
+
+@pytest.mark.parametrize(
+    "salary_range_client_code, expected_verse",
+    [
+        ("Versant_FPT", Verse.FPT),
+        ("Versant_FPH", Verse.FPH),
+        ("Versant_FPE", Verse.FPE),
+        (None, None),
+    ],
+)
+def test_clean_maps_verse_from_salary_range(
+    cleaner, salary_range_client_code, expected_verse
+):
+    salary_range = (
+        TalentsoftCodedObjectFactory.build(clientCode=salary_range_client_code)
+        if salary_range_client_code
+        else None
+    )
+    raw_offer = _make_raw_offer(salaryRange=salary_range)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.verse == expected_verse
+
+
+def test_clean_maps_verse_fph_from_aphp_reference(cleaner):
+    raw_offer = _make_raw_offer(reference="APHP-2024-001")
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.verse == Verse.FPH
+
+
+@pytest.mark.parametrize(
+    "category_code, expected_category",
+    [
+        ("CAT-AEF", Category.APLUS),
+        ("CAT-ESD", Category.APLUS),
+        ("CAT-ES", Category.APLUS),
+        ("CAT-A", Category.A),
+        ("CAT-B", Category.B),
+        ("CAT-C", Category.C),
+        ("UNKNOWN", None),
+    ],
+)
+def test_clean_maps_category_from_custom_fields(
+    cleaner, category_code, expected_category
+):
+    offer_dto_kwargs = {
+        "customFields": TalentsoftCustomFieldsFactory.build(
+            description=TalentsoftDescriptionCustomFieldsFactory.build(
+                customCodeTable1=TalentsoftCustomCodeTableFactory.build(
+                    clientCode=category_code
+                )
+            )
+        )
+    }
+    raw_offer = _make_raw_offer(**offer_dto_kwargs)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.category == expected_category
+
+
+@pytest.mark.parametrize(
+    "area, country, region, department, "
+    "expected_area, expected_region, expected_department",
+    [
+        (
+            "_TS_CO_GeographicalArea_Europe",
+            "FRA",
+            "R24",
+            "41",
+            "EU",
+            "24",
+            "41",
+        ),
+        (
+            "_TS_CO_GeographicalArea_Europe",
+            "FRA",
+            "R11",
+            "75",
+            "EU",
+            "11",
+            "75",
+        ),
+        (
+            "_TS_CO_GeographicalArea_Afrique",
+            "FRA",
+            "_TS_CO_Region_DOM",
+            "971",
+            "AF",
+            "DOM",
+            "971",
+        ),
+        (
+            "_TS_CO_GeographicalArea_AmriquesCaraibe",
+            "FRA",
+            "_TS_CO_Region_TOM",
+            "987",
+            "AM",
+            "TOM",
+            "987",
+        ),
+        (
+            "_TS_CO_GeographicalArea_Ocanie",
+            "FRA",
+            "R84",
+            "_TS_CO_Department_NouvelleCaldonie988",
+            "OC",
+            "84",
+            "988",
+        ),
+    ],
+)
+def test_clean_maps_geographical_area(
+    cleaner,
+    area,
+    country,
+    region,
+    department,
+    expected_area,
+    expected_region,
+    expected_department,
+):
+    raw_offer = _make_raw_offer(
+        geographicalLocation=[
+            TalentsoftCodedObjectFactory.build(
+                clientCode=area, type="offerGeographicalLocation"
+            )
+        ],
+        country=[
+            TalentsoftCodedObjectFactory.build(clientCode=country, type="offerCountry")
+        ],
+        region=[
+            TalentsoftCodedObjectFactory.build(clientCode=region, type="offerRegion")
+        ],
+        department=[
+            TalentsoftCodedObjectFactory.build(
+                clientCode=department, type="offerDepartment"
+            )
+        ],
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is not None
+    assert offer.localisation.area.value == expected_area
+    assert offer.localisation.region.code == expected_region
+    assert offer.localisation.department.code == expected_department
+
+
+def test_clean_returns_none_localisation_when_area_missing(cleaner):
+    raw_offer = _make_raw_offer(
+        geographicalLocation=[],
+        country=[
+            TalentsoftCodedObjectFactory.build(clientCode="FRA", type="offerCountry")
+        ],
+        region=[
+            TalentsoftCodedObjectFactory.build(clientCode="R24", type="offerRegion")
+        ],
+        department=[
+            TalentsoftCodedObjectFactory.build(clientCode="41", type="offerDepartment")
+        ],
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is None
+
+
+def test_clean_maps_title_and_organization(cleaner):
+    offer_dto = TalentsoftDetailOfferFactory.build(
+        reference=REFERENCE,
+        title="INGÉNIEUR LOGICIEL",
+        organisationName="Mairie de Paris",
+    )
+    raw_offer = RawOffer(
+        reference=REFERENCE, source_id=SOURCE_ID, data=offer_dto.model_dump()
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.title == "INGÉNIEUR LOGICIEL"
+    assert offer.organization == "Mairie de Paris"
+
+
+def test_clean_external_id_uses_salary_range_client_code_as_prefix(cleaner):
+    salary_range = TalentsoftCodedObjectFactory.build(clientCode="Versant_FPT")
+    raw_offer = _make_raw_offer(reference=REFERENCE, salaryRange=salary_range)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.external_id == f"Versant_FPT-{REFERENCE}"
+
+
+@pytest.mark.parametrize(
+    "contract_code, expected",
+    [
+        ("TITULAIRE_CODE", ContractType.TITULAIRE_CONTRACTUEL),
+        ("CONTRACTUEL_CDD", ContractType.CONTRACTUELS),
+        ("TERRITORIAL_TIT", ContractType.TERRITORIAL),
+        ("UNKNOWN_TYPE", None),
+        (None, None),
+    ],
+)
+def test_clean_maps_contract_type(cleaner, contract_code, expected):
+
+    contract_type = (
+        TalentsoftCodedObjectFactory.build(clientCode=contract_code)
+        if contract_code
+        else None
+    )
+    raw_offer = _make_raw_offer(contractType=contract_type)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.contract_type == expected
+
+
+def test_clean_returns_none_url_on_invalid_offer_url(cleaner):
+    raw_offer = _make_raw_offer(offerUrl="not-a-valid-url")
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.offer_url is None
+
+
+def test_clean_returns_none_beginning_date_on_invalid_format(cleaner):
+    raw_offer = _make_raw_offer(beginningDate="not-a-date")
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.beginning_date is None
+
+
+def test_clean_returns_none_beginning_date_when_absent(cleaner):
+    raw_offer = _make_raw_offer(beginningDate=None)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.beginning_date is None
+
+
+def test_clean_maps_raw_region_code_without_prefix(cleaner):
+    raw_offer = _make_raw_offer(
+        geographicalLocation=[
+            TalentsoftCodedObjectFactory.build(
+                clientCode="_TS_CO_GeographicalArea_Europe",
+                type="offerGeographicalLocation",
+            )
+        ],
+        country=[
+            TalentsoftCodedObjectFactory.build(clientCode="FRA", type="offerCountry")
+        ],
+        region=[
+            TalentsoftCodedObjectFactory.build(clientCode="11", type="offerRegion")
+        ],
+        department=[
+            TalentsoftCodedObjectFactory.build(clientCode="75", type="offerDepartment")
+        ],
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is not None
+    assert offer.localisation.region.code == "11"
+
+
+def test_clean_returns_none_localisation_on_invalid_region_code(cleaner):
+    raw_offer = _make_raw_offer(
+        geographicalLocation=[
+            TalentsoftCodedObjectFactory.build(
+                clientCode="_TS_CO_GeographicalArea_Europe",
+                type="offerGeographicalLocation",
+            )
+        ],
+        country=[
+            TalentsoftCodedObjectFactory.build(clientCode="FRA", type="offerCountry")
+        ],
+        region=[
+            TalentsoftCodedObjectFactory.build(
+                clientCode="INVALID_REGION", type="offerRegion"
+            )
+        ],
+        department=[
+            TalentsoftCodedObjectFactory.build(clientCode="75", type="offerDepartment")
+        ],
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is None

--- a/src/ingestion/tests/unit/test_clean_raw_offer_use_case.py
+++ b/src/ingestion/tests/unit/test_clean_raw_offer_use_case.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from application.use_cases.clean_raw_offer import CleanRawOfferUseCase
+from domain.entities.offer import Offer
+from domain.entities.raw_offer import RawOffer
+from domain.gateways.offers_cleaner import IOffersCleaner
+from tests.factories.talentsoft_factories import TalentsoftDetailOfferFactory
+
+REFERENCE = "2024-OFFER-001"
+SOURCE_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def raw_offer_with_data() -> RawOffer:
+    offer_dto = TalentsoftDetailOfferFactory.build(reference=REFERENCE)
+    return RawOffer(
+        reference=REFERENCE,
+        source_id=SOURCE_ID,
+        data=offer_dto.model_dump(),
+    )
+
+
+@pytest.fixture
+def mock_offers_cleaner():
+    cleaner = MagicMock(spec=IOffersCleaner)
+    return cleaner
+
+
+@pytest.fixture
+def use_case(mock_offers_cleaner) -> CleanRawOfferUseCase:
+    return CleanRawOfferUseCase(offers_cleaner=mock_offers_cleaner)
+
+
+def test_execute_calls_offers_cleaner(
+    use_case, mock_offers_cleaner, raw_offer_with_data
+):
+    mock_offers_cleaner.clean.return_value = MagicMock(spec=Offer)
+
+    use_case.execute(raw_offer_with_data)
+
+    mock_offers_cleaner.clean.assert_called_once_with(raw_offer_with_data)
+
+
+def test_execute_returns_cleaned_offer(
+    use_case, mock_offers_cleaner, raw_offer_with_data
+):
+    expected_offer = MagicMock(spec=Offer)
+    mock_offers_cleaner.clean.return_value = expected_offer
+
+    result = use_case.execute(raw_offer_with_data)
+
+    assert result is expected_offer
+
+
+def test_execute_propagates_cleaner_errors(
+    use_case, mock_offers_cleaner, raw_offer_with_data
+):
+    mock_offers_cleaner.clean.side_effect = ValueError("Invalid offer data")
+
+    with pytest.raises(ValueError, match="Invalid offer data"):
+        use_case.execute(raw_offer_with_data)

--- a/src/ingestion/tests/unit/test_ingest_offer_pipeline.py
+++ b/src/ingestion/tests/unit/test_ingest_offer_pipeline.py
@@ -1,0 +1,121 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from application.pipelines.ingest_offer_pipeline import IngestOfferPipeline
+from application.use_cases.clean_raw_offer import CleanRawOfferUseCase
+from application.use_cases.save_raw_offer import SaveRawOfferUseCase
+from domain.entities.raw_offer import RawOffer
+from infrastructure.exceptions.exceptions import ExternalApiError
+
+REFERENCE = "2024-OFFER-001"
+SOURCE_ID = "11111111-2222-3333-4444-555555555555"
+RAW_OFFER = RawOffer(
+    reference=REFERENCE,
+    source_id=SOURCE_ID,
+    data={"reference": REFERENCE},
+)
+
+
+@pytest.fixture
+def mock_save_use_case():
+    use_case = MagicMock(spec=SaveRawOfferUseCase)
+    use_case.execute = AsyncMock(return_value=RAW_OFFER)
+    return use_case
+
+
+@pytest.fixture
+def mock_clean_use_case():
+    return MagicMock(spec=CleanRawOfferUseCase)
+
+
+@pytest.fixture
+def mock_raw_offer_repository():
+    repo = MagicMock()
+    repo.mark_as_cleaned = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def pipeline(
+    mock_save_use_case, mock_clean_use_case, mock_raw_offer_repository
+) -> IngestOfferPipeline:
+    return IngestOfferPipeline(
+        save_raw_offer=mock_save_use_case,
+        clean_raw_offer=mock_clean_use_case,
+        raw_offer_repository=mock_raw_offer_repository,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_calls_save_then_clean(
+    pipeline, mock_save_use_case, mock_clean_use_case
+):
+    await pipeline.execute(reference=REFERENCE, source_id=SOURCE_ID)
+
+    mock_save_use_case.execute.assert_awaited_once_with(REFERENCE, SOURCE_ID)
+    mock_clean_use_case.execute.assert_called_once_with(RAW_OFFER)
+
+
+@pytest.mark.asyncio
+async def test_execute_marks_as_cleaned_on_success(
+    pipeline, mock_clean_use_case, mock_raw_offer_repository
+):
+    await pipeline.execute(reference=REFERENCE, source_id=SOURCE_ID)
+
+    mock_clean_use_case.execute.assert_called_once_with(RAW_OFFER)
+    mock_raw_offer_repository.mark_as_cleaned.assert_awaited_once()
+    call_args = mock_raw_offer_repository.mark_as_cleaned.call_args
+    assert call_args[0][0] == REFERENCE
+    assert call_args[0][1] == SOURCE_ID
+
+
+@pytest.mark.asyncio
+async def test_execute_skips_clean_when_save_returns_none(
+    pipeline, mock_save_use_case, mock_clean_use_case, mock_raw_offer_repository
+):
+    mock_save_use_case.execute.return_value = None
+
+    await pipeline.execute(reference=REFERENCE, source_id=SOURCE_ID)
+
+    mock_clean_use_case.execute.assert_not_called()
+    mock_raw_offer_repository.mark_as_cleaned.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_propagates_save_error(
+    pipeline, mock_save_use_case, mock_clean_use_case, mock_raw_offer_repository
+):
+    mock_save_use_case.execute.side_effect = ExternalApiError(
+        message="API down", api_name="Talentsoft"
+    )
+
+    with pytest.raises(ExternalApiError):
+        await pipeline.execute(reference=REFERENCE, source_id=SOURCE_ID)
+
+    mock_clean_use_case.execute.assert_not_called()
+    mock_raw_offer_repository.mark_as_cleaned.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_raise_when_clean_fails(
+    pipeline, mock_save_use_case, mock_clean_use_case, mock_raw_offer_repository
+):
+    mock_clean_use_case.execute.side_effect = ValueError("Bad data")
+
+    with patch("application.pipelines.ingest_offer_pipeline.logger") as mock_logger:
+        await pipeline.execute(reference=REFERENCE, source_id=SOURCE_ID)
+        mock_logger.exception.assert_called_once()
+
+    mock_raw_offer_repository.mark_as_cleaned.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_raise_when_mark_as_cleaned_fails(
+    pipeline, mock_clean_use_case, mock_raw_offer_repository
+):
+    mock_raw_offer_repository.mark_as_cleaned.side_effect = RuntimeError("DB down")
+
+    with patch("application.pipelines.ingest_offer_pipeline.logger") as mock_logger:
+        await pipeline.execute(reference=REFERENCE, source_id=SOURCE_ID)
+        mock_logger.exception.assert_called_once()

--- a/src/ingestion/tests/unit/test_save_raw_offer_use_case.py
+++ b/src/ingestion/tests/unit/test_save_raw_offer_use_case.py
@@ -39,8 +39,7 @@ def use_case(mock_offers_gateway, mock_raw_offer_repository) -> SaveRawOfferUseC
 async def test_execute_calls_offers_gateway(
     use_case, mock_offers_gateway, mock_raw_offer_repository
 ):
-    offer = GATEWAY_OFFER
-    mock_offers_gateway.get_detail.return_value = offer
+    mock_offers_gateway.get_detail.return_value = GATEWAY_OFFER
 
     await use_case.execute(reference=REFERENCE, source_id=SOURCE_ID)
 
@@ -48,11 +47,26 @@ async def test_execute_calls_offers_gateway(
 
 
 @pytest.mark.asyncio
+async def test_execute_returns_raw_offer_on_success(
+    use_case, mock_offers_gateway, mock_raw_offer_repository
+):
+    mock_offers_gateway.get_detail.return_value = GATEWAY_OFFER
+
+    result = await use_case.execute(reference=REFERENCE, source_id=SOURCE_ID)
+
+    assert result is not None
+    assert result.reference == REFERENCE
+    assert result.source_id == SOURCE_ID
+    assert result.loaded_at is not None
+    assert result.error_msg is None
+    assert result.data == GATEWAY_OFFER.data
+
+
+@pytest.mark.asyncio
 async def test_execute_upserts_raw_offer_with_data_on_success(
     use_case, mock_offers_gateway, mock_raw_offer_repository
 ):
-    offer = GATEWAY_OFFER
-    mock_offers_gateway.get_detail.return_value = offer
+    mock_offers_gateway.get_detail.return_value = GATEWAY_OFFER
 
     await use_case.execute(reference=REFERENCE, source_id=SOURCE_ID)
 
@@ -62,7 +76,7 @@ async def test_execute_upserts_raw_offer_with_data_on_success(
     assert saved.source_id == SOURCE_ID
     assert saved.loaded_at is not None
     assert saved.error_msg is None
-    assert saved.data == offer.data
+    assert saved.data == GATEWAY_OFFER.data
 
 
 @pytest.mark.asyncio
@@ -99,14 +113,14 @@ async def test_execute_re_raises_original_error_when_upsert_also_fails(
 
 
 @pytest.mark.asyncio
-async def test_execute_does_not_raise_when_upsert_fails_after_success(
+async def test_execute_returns_none_when_upsert_fails_after_success(
     use_case, mock_offers_gateway, mock_raw_offer_repository
 ):
-    offer = GATEWAY_OFFER
-    mock_offers_gateway.get_detail.return_value = offer
+    mock_offers_gateway.get_detail.return_value = GATEWAY_OFFER
     mock_raw_offer_repository.upsert.side_effect = RuntimeError("DB unavailable")
 
-    # Should not raise — the upsert error is swallowed and logged
     with patch("application.use_cases.save_raw_offer.logger") as mock_logger:
-        await use_case.execute(reference=REFERENCE, source_id=SOURCE_ID)
+        result = await use_case.execute(reference=REFERENCE, source_id=SOURCE_ID)
         mock_logger.exception.assert_called_once()
+
+    assert result is None

--- a/src/ingestion/tests/unit/test_value_objects.py
+++ b/src/ingestion/tests/unit/test_value_objects.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from domain.exceptions.offer_errors import InvalidLimitDateError
+from domain.value_objects.area import GeographicalArea
+from domain.value_objects.country import Country
+from domain.value_objects.department import Department
+from domain.value_objects.limit_date import LimitDate
+from domain.value_objects.localisation import Localisation
+from domain.value_objects.region import Region
+
+
+class TestLimitDate:
+    def test_valid_datetime_is_accepted(self):
+        dt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        ld = LimitDate(value=dt)
+        assert ld.value == dt
+
+    def test_raises_invalid_limit_date_error_when_not_datetime(self):
+        with pytest.raises(InvalidLimitDateError):
+            LimitDate(value="not-a-datetime")  # type: ignore[arg-type]
+
+    def test_is_expired_returns_true_when_in_past(self):
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        assert LimitDate(value=past).is_expired() is True
+
+    def test_is_expired_returns_false_when_in_future(self):
+        future = datetime.now(timezone.utc) + timedelta(days=1)
+        assert LimitDate(value=future).is_expired() is False
+
+
+class TestRegion:
+    def test_str_returns_code(self):
+        assert str(Region(code="11")) == "11"
+
+    def test_name_returns_human_readable(self):
+        assert Region(code="11").name == "Île-de-France"
+
+    def test_name_returns_code_for_unknown(self):
+        # DOM and TOM are valid codes but have no name entry
+        assert Region(code="DOM").name == "DOM"
+
+    def test_invalid_code_raises(self):
+        with pytest.raises(ValueError, match="Invalid French region INSEE code"):
+            Region(code="INVALID")
+
+
+class TestGeographicalArea:
+    def test_str_returns_value(self):
+        assert str(GeographicalArea.EUROPE) == "EU"
+
+    def test_all_values_accessible(self):
+        assert GeographicalArea.AFRIQUE.value == "AF"
+        assert GeographicalArea.ASIE.value == "AS"
+        assert GeographicalArea.AMERIQUE.value == "AM"
+        assert GeographicalArea.OCEANIE.value == "OC"
+        assert GeographicalArea.ANTARTIQUE.value == "AN"
+
+
+class TestLocalisation:
+    def test_str_returns_formatted_string(self):
+        localisation = Localisation(
+            area=GeographicalArea.EUROPE,
+            country=Country("FRA"),
+            region=Region(code="11"),
+            department=Department(code="75"),
+        )
+        assert str(localisation) == "FRA - 11 - 75"
+
+
+class TestDepartment:
+    def test_str_returns_code(self):
+        assert str(Department(code="75")) == "75"
+
+    def test_name_returns_human_readable(self):
+        assert Department(code="75").name == "Paris"
+
+    def test_name_returns_code_for_unknown_valid(self):
+        # SPM is valid but has no entry in NAMES
+        assert Department(code="SPM").name == "SPM"
+
+    def test_invalid_code_raises(self):
+        with pytest.raises(ValueError, match="Invalid French department code"):
+            Department(code="INVALID")


### PR DESCRIPTION
## 📝 Description

ℹ️ Cette PR reprend de nombreuses classes de `web` (DTOs, tests et `OffersCleaner`)

- Nettoie un `RawOffer` en `Offer` au sein d'une nouvelle pipeline
- N'enregistre pas encore l'offre
- Ne transmet pas encore l'offre à `web`

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications

Ajout d'un `CleanRawOfferUseCase` qui transforme une `RawOffer` en entité `Offer`, orchestré après `SaveRawOfferUseCase` via un nouveau `IngestOfferPipeline`.

## Changements

**Domaine**
- Entité `Offer` avec `reference` et `source_id`
- Objets valeur : `Verse`, `Category`, `ContractType`, `GeographicalArea`, `Country`, `Region`, `Department`, `LimitDate`, `Localisation`
- Protocole `IOffersCleaner`
- Exception `InvalidLimitDateError`

**Application**
- `CleanRawOfferUseCase` — prend une `RawOffer`, retourne une `Offer` 
- `IngestOfferPipeline` — enchaîne Save → Clean → `mark_as_cleaned` ; les erreurs de nettoyage sont loguées sans être propagées

**Infrastructure**
- `OffersCleaner` — mappe le DTO `TalentsoftDetailOffer` vers `Offer` (porté depuis `src/web`)
- `RawOfferRepository.mark_as_cleaned` — UPDATE via ORM, lève `ValueError` si la ligne est introuvable

## Tests

Tests unitaires pour les nouveaux use cases et le pipeline. Tests d'intégration pour `OffersCleaner` et `RawOfferRepository.mark_as_cleaned`.
Couverture : **97%**.

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
