### PR TITLE
✨(tooling) add storybook publishing workflow

### DIFF
--- a/.github/workflows/storybook_pages.yml
+++ b/.github/workflows/storybook_pages.yml
@@ -1,0 +1,101 @@
+name: Storybook Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "src/web/**"
+      - ".github/workflows/storybook_pages.yml"
+      - ".github/actions/**"
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, labeled, closed]
+    paths:
+      - "src/web/**"
+      - ".github/workflows/storybook_pages.yml"
+      - ".github/actions/**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: storybook-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-stable:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/web
+    env:
+      STORYBOOK_BASE_URL: /${{ github.event.repository.name }}/
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          lock-file-path: src/web/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter csplab-frontend build-storybook
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: src/web/presentation/frontend/storybook-static
+          force: false
+          clean-exclude: pr-*
+
+  deploy-preview:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'storybook')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/web
+    env:
+      STORYBOOK_BASE_URL: /${{ github.event.repository.name }}/pr-${{ github.event.number }}/
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          lock-file-path: src/web/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter csplab-frontend build-storybook
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: src/web/presentation/frontend/storybook-static
+          target-folder: pr-${{ github.event.number }}
+          force: false
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-${context.issue.number}/`
+            const marker = '<!-- storybook-preview -->'
+            const body = `${marker}\n📖 Storybook de prévisualisation : ${url}`
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+            })
+            const previous = comments.find(comment => comment.body.includes(marker))
+            if (previous) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: previous.id, body })
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body })
+            }
+
+  cleanup-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+      - name: Remove preview folder
+        run: |
+          git rm -rf --ignore-unmatch "pr-${{ github.event.number }}"
+          git diff --cached --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: remove Storybook preview for PR #${{ github.event.number }}"
+          git push

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -33,21 +33,6 @@ jobs:
       - name: Build frontend
         run: pnpm run build
 
-  storybook-web:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./src/web
-    steps:
-      - uses: actions/checkout@v5
-      - uses: ./.github/actions/setup-pnpm-node
-        with:
-          lock-file-path: src/web/pnpm-lock.yaml
-      - name: Install frontend dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build Storybook
-        run: pnpm --filter csplab-frontend build-storybook
-
   lint-web:
     needs: build-web
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📝 Description
🎸 Proposition de workflow de publication de storybook pour deux cas d'usages :
1. une version stable avec URL permanente, déployée après merge sur`main` => référence partagée du design system
2. Une preview par PR : à chaque ouverture/mise à jour de PR **avec le label storybook**, un book isolé est publié sur une URL dédiée et le lien est posté en commentaire. L'équipe produit peut ainsi preview et valider des changements visuels avant merge sans installer le book en local.

Tout est publié sur une seule branche `gh-pages` qui contient les assets compilé. GitHub pages sert cette branche statiquement.
```
gh-pages/index.html, assets... =>   storybook de main
gh-pages/pr-7/ => preview de la PR #7
gh-pages/pr-12/ => preview de la PR #12
```

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [ ] 👀 J’ai demandé une revue à une personne de l’équipe.
