### PR TITLE
🐛(storybook) fix storybook deploy workflow

### DIFF
--- a/.github/workflows/storybook_pages.yml
+++ b/.github/workflows/storybook_pages.yml
@@ -14,13 +14,14 @@ on:
       - "src/web/**"
       - ".github/workflows/storybook_pages.yml"
       - ".github/actions/**"
+  workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
 concurrency:
-  group: storybook-pages-${{ github.ref }}
+  group: storybook-pages-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## 📝 Description
🎸 Au merge de #647, github a créé deux runs simultanés qui se sont annulés et empéché le deploy du book.

## 🔧 Modifications

Cette PR essaye deux corrections :

- ajout de `workflow_dispatch` pour pouvoir déclencher le workflow sans commit depuis github
- ajout du nom de l'événement (push ou pull_request par ex) dans le groupe de concurrence

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
