### PR TITLE
✨(web) add reference column to offers

### DIFF
--- a/src/web/domain/entities/offer.py
+++ b/src/web/domain/entities/offer.py
@@ -27,6 +27,7 @@ class Offer(IEntity):
     localisation: Optional[Localisation]
     publication_date: datetime
     beginning_date: Optional[LimitDate]
+    reference: str
     family_code: Optional[str] = None
     source_id: UUID = field(default_factory=uuid4)
     processing: bool = False

--- a/src/web/infrastructure/django_apps/shared/migrations/0030_offermodel_reference.py
+++ b/src/web/infrastructure/django_apps/shared/migrations/0030_offermodel_reference.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shared", "0029_populate_offer_source_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="offermodel",
+            name="reference",
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+        migrations.RunSQL(
+            sql="""
+                UPDATE offers
+                SET reference = CASE
+                    WHEN external_id LIKE '%-%'
+                        THEN SUBSTRING(external_id FROM POSITION('-' IN external_id) + 1)
+                    ELSE external_id
+                END
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+            elidable=True,
+        ),
+        migrations.AlterField(
+            model_name="offermodel",
+            name="reference",
+            field=models.CharField(max_length=100),
+        ),
+        migrations.AddConstraint(
+            model_name="offermodel",
+            constraint=models.UniqueConstraint(
+                fields=["reference", "source_id"],
+                name="offers_reference_source_id_unique",
+            ),
+        ),
+    ]

--- a/src/web/infrastructure/django_apps/shared/migrations/0031_offermodel_reference.py
+++ b/src/web/infrastructure/django_apps/shared/migrations/0031_offermodel_reference.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="offermodel",
             name="reference",
-            field=models.CharField(max_length=100),
+            field=models.CharField(max_length=100, null=False, blank=False),
         ),
         migrations.AddConstraint(
             model_name="offermodel",

--- a/src/web/infrastructure/django_apps/shared/migrations/0031_offermodel_reference.py
+++ b/src/web/infrastructure/django_apps/shared/migrations/0031_offermodel_reference.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("shared", "0029_populate_offer_source_id"),
+        ("shared", "0030_alter_offermodel_source_id_not_null"),
     ]
 
     operations = [

--- a/src/web/infrastructure/django_apps/shared/models/offer.py
+++ b/src/web/infrastructure/django_apps/shared/models/offer.py
@@ -28,6 +28,7 @@ class OfferModel(models.Model):
 
     id = models.UUIDField(primary_key=True)
     external_id = models.CharField(max_length=100, unique=True)
+    reference = models.CharField(max_length=100)
     verse = models.CharField(
         max_length=20, choices=VERSE_CHOICES, null=True, blank=True
     )
@@ -73,6 +74,12 @@ class OfferModel(models.Model):
         indexes = [
             models.Index(fields=["external_id"]),
         ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["reference", "source_id"],
+                name="offers_reference_source_id_unique",
+            ),
+        ]
 
     def to_entity(self) -> Offer:
         # Build localisation if both region and department are present
@@ -110,6 +117,7 @@ class OfferModel(models.Model):
             localisation=localisation,
             publication_date=self.publication_date,
             beginning_date=beginning_date,
+            reference=self.reference,
             processing=self.processing,
             processed_at=self.processed_at,
             archived_at=self.archived_at,
@@ -147,6 +155,7 @@ class OfferModel(models.Model):
         return cls(
             id=offer.id,
             external_id=offer.external_id,
+            reference=offer.reference,
             verse=offer.verse.value if offer.verse else None,
             title=offer.title,
             profile=offer.profile,

--- a/src/web/infrastructure/django_apps/shared/models/offer.py
+++ b/src/web/infrastructure/django_apps/shared/models/offer.py
@@ -28,7 +28,7 @@ class OfferModel(models.Model):
 
     id = models.UUIDField(primary_key=True)
     external_id = models.CharField(max_length=100, unique=True)
-    reference = models.CharField(max_length=100)
+    reference = models.CharField(max_length=100, null=False, blank=False)
     verse = models.CharField(
         max_length=20, choices=VERSE_CHOICES, null=True, blank=True
     )

--- a/src/web/infrastructure/gateways/ingestion/offers_cleaner.py
+++ b/src/web/infrastructure/gateways/ingestion/offers_cleaner.py
@@ -150,6 +150,7 @@ class OffersCleaner(IDocumentCleaner[Offer]):
             external_id=f"{ts_verse}-{talentsoft_offer.reference}"
             if ts_verse
             else talentsoft_offer.reference,
+            reference=talentsoft_offer.reference,
             verse=verse,
             title=talentsoft_offer.title,
             profile=talentsoft_offer.description2 or "",

--- a/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
+++ b/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
@@ -73,6 +73,7 @@ class PostgresOffersRepository(IOffersRepository):
                         updated = OfferModel.objects.bulk_update(
                             models_to_update,
                             fields=[
+                                "reference",
                                 "verse",
                                 "title",
                                 "profile",
@@ -119,7 +120,7 @@ class PostgresOffersRepository(IOffersRepository):
     def get_by_reference_and_source_id(self, reference: str, source_id: UUID) -> Offer:
         try:
             offer_model = OfferModel.objects.get(
-                external_id__endswith=f"-{reference}", source_id=source_id
+                reference=reference, source_id=source_id
             )
             return offer_model.to_entity()
         except OfferModel.DoesNotExist as e:

--- a/src/web/presentation/ingestion/mappers.py
+++ b/src/web/presentation/ingestion/mappers.py
@@ -46,6 +46,7 @@ class OfferInputMapper(IToDomainMapper[dict, Offer]):
 
         return Offer(
             external_id=f"{data['identification']['versant']}-{data['identification']['reference']}",
+            reference=data["identification"]["reference"],
             title=data["titre"],
             profile=data["description"]["profil"],
             mission=data["description"]["mission"],

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -55,6 +55,8 @@ class ConcoursUploadResponseSerializer(serializers.Serializer):
 
 class ListOffersResponseSerializer(serializers.Serializer):
     external_id = serializers.CharField()
+    reference = serializers.CharField()
+    source_id = serializers.CharField(allow_null=True)
     title = serializers.CharField()
     organization = serializers.CharField()
     contract_type = serializers.CharField(allow_null=True)

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -56,7 +56,7 @@ class ConcoursUploadResponseSerializer(serializers.Serializer):
 class ListOffersResponseSerializer(serializers.Serializer):
     external_id = serializers.CharField()
     reference = serializers.CharField()
-    source_id = serializers.CharField(allow_null=True)
+    source_id = serializers.UUIDField()
     title = serializers.CharField()
     organization = serializers.CharField()
     contract_type = serializers.CharField(allow_null=True)

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -1112,6 +1112,11 @@ components:
       properties:
         external_id:
           type: string
+        reference:
+          type: string
+        source_id:
+          type: string
+          nullable: true
         title:
           type: string
         organization:
@@ -1140,6 +1145,8 @@ components:
       - offer_url
       - organization
       - publication_date
+      - reference
+      - source_id
       - title
     LocalisationInput:
       type: object

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -1116,7 +1116,7 @@ components:
           type: string
         source_id:
           type: string
-          nullable: true
+          format: uuid
         title:
           type: string
         organization:

--- a/src/web/tests/factories/offer_factory.py
+++ b/src/web/tests/factories/offer_factory.py
@@ -32,6 +32,7 @@ class OfferFactory:
         contract_type: ContractType | None = None,
         verse: Verse | None = None,
         external_id: str | None = None,
+        reference: str | None = None,
         profile: str | None = None,
         mission: str | None = None,
         organization: str | None = None,
@@ -60,8 +61,10 @@ class OfferFactory:
                 region=Region(code="11"),
                 department=Department(code=department),
             )
+        _external_id = external_id or f"OFFER_{uuid4().hex[:8]}"
         return Offer(
-            external_id=external_id or f"OFFER_{uuid4().hex[:8]}",
+            external_id=_external_id,
+            reference=reference or str(uuid4()),
             verse=verse or Verse.FPE,
             title=title or "Test Offer Title",
             profile=profile or "Test profile description",
@@ -82,6 +85,7 @@ class OfferFactory:
 
     @staticmethod
     def create_model(
+        reference: Optional[str] = None,
         external_id: Optional[str] = None,
         title: Optional[str] = None,
         profile: Optional[str] = None,
@@ -110,6 +114,7 @@ class OfferFactory:
             SourceFactory.create_model(source_id=source_id)
 
         offer = OfferFactory.create_entity(
+            reference=reference,
             external_id=external_id,
             verse=verse,
             title=title,

--- a/src/web/tests/ingestion/integration/test_archive_offer_by_reference.py
+++ b/src/web/tests/ingestion/integration/test_archive_offer_by_reference.py
@@ -54,9 +54,7 @@ def use_case(db, vector_repository):
 
 class TestArchiveOfferByReferenceUseCase:
     def test_archives_offer_by_reference(self, db, use_case, offers_repository):
-        OfferFactory.create_model(
-            external_id=f"Versant_FPE-{REFERENCE}", source_id=SOURCE_ID
-        )
+        OfferFactory.create_model(reference=REFERENCE, source_id=SOURCE_ID)
         use_case.execute(
             ArchiveOfferByReferenceInput(reference=REFERENCE, source_id=SOURCE_ID)
         )
@@ -65,7 +63,7 @@ class TestArchiveOfferByReferenceUseCase:
 
     def test_deletes_vectors_for_offer(self, db, use_case, vector_repository):
         offer = OfferFactory.create_model(
-            external_id=f"Versant_FPE-{REFERENCE}", source_id=SOURCE_ID
+            reference=REFERENCE, source_id=SOURCE_ID
         ).to_entity()
         use_case.execute(
             ArchiveOfferByReferenceInput(reference=REFERENCE, source_id=SOURCE_ID)

--- a/src/web/tests/ingestion/integration/test_clean_documents.py
+++ b/src/web/tests/ingestion/integration/test_clean_documents.py
@@ -161,6 +161,10 @@ def test_execute_updates_existing_offers_entities(db, raw_offer_setup):
     # First execution - create entity
     assert clean_documents_usecase.execute(document_type) == execute_results(created=1)
 
+    cleaned_offer = OfferModel.objects.first()
+    assert cleaned_offer is not None
+    assert cleaned_offer.reference == document.raw_data["reference"]
+
     # Second execution with same data - should not update
     assert clean_documents_usecase.execute(document_type) == execute_results()
 
@@ -377,6 +381,7 @@ def test_execute_clean_offers_with_category(
     cleaned_offer = OfferModel.objects.first()
     assert cleaned_offer is not None
     assert cleaned_offer.category == expected
+    assert cleaned_offer.reference == offer_dto.reference
 
 
 @pytest.mark.parametrize(
@@ -466,6 +471,7 @@ def test_execute_clean_offers_with_geographical_area(
 
     cleaned_offer = OfferModel.objects.first()
     assert cleaned_offer is not None
+    assert cleaned_offer.reference == offer_dto.reference
     assert cleaned_offer.area == expected_area
     assert cleaned_offer.country == expected_country
     assert cleaned_offer.region == expected_region

--- a/src/web/tests/ingestion/integration/test_clean_documents.py
+++ b/src/web/tests/ingestion/integration/test_clean_documents.py
@@ -161,8 +161,7 @@ def test_execute_updates_existing_offers_entities(db, raw_offer_setup):
     # First execution - create entity
     assert clean_documents_usecase.execute(document_type) == execute_results(created=1)
 
-    cleaned_offer = OfferModel.objects.first()
-    assert cleaned_offer is not None
+    cleaned_offer = OfferModel.objects.get()
     assert cleaned_offer.reference == document.raw_data["reference"]
 
     # Second execution with same data - should not update
@@ -378,8 +377,7 @@ def test_execute_clean_offers_with_category(
 
     assert result["created"] == 1
 
-    cleaned_offer = OfferModel.objects.first()
-    assert cleaned_offer is not None
+    cleaned_offer = OfferModel.objects.get()
     assert cleaned_offer.category == expected
     assert cleaned_offer.reference == offer_dto.reference
 
@@ -469,8 +467,7 @@ def test_execute_clean_offers_with_geographical_area(
 
     assert result["created"] == 1
 
-    cleaned_offer = OfferModel.objects.first()
-    assert cleaned_offer is not None
+    cleaned_offer = OfferModel.objects.get()
     assert cleaned_offer.reference == offer_dto.reference
     assert cleaned_offer.area == expected_area
     assert cleaned_offer.country == expected_country

--- a/src/web/tests/ingestion/presentation/views/test_list_offers.py
+++ b/src/web/tests/ingestion/presentation/views/test_list_offers.py
@@ -81,7 +81,7 @@ def test_call_without_arg(mock_container, authenticated_client):
     for result, offer in zip(data["results"], offers, strict=True):
         assert result["external_id"] == offer.external_id
         assert result["reference"] == offer.reference
-        assert result["source_id"] == offer.source_id
+        assert result["source_id"] == str(offer.source_id)
         assert result["title"] == offer.title
         assert result["organization"] == offer.organization
         assert result["contract_type"] == (

--- a/src/web/tests/ingestion/presentation/views/test_list_offers.py
+++ b/src/web/tests/ingestion/presentation/views/test_list_offers.py
@@ -80,6 +80,8 @@ def test_call_without_arg(mock_container, authenticated_client):
 
     for result, offer in zip(data["results"], offers, strict=True):
         assert result["external_id"] == offer.external_id
+        assert result["reference"] == offer.reference
+        assert result["source_id"] == offer.source_id
         assert result["title"] == offer.title
         assert result["organization"] == offer.organization
         assert result["contract_type"] == (

--- a/src/web/tests/ingestion/presentation/views/test_upsert_offers.py
+++ b/src/web/tests/ingestion/presentation/views/test_upsert_offers.py
@@ -120,6 +120,7 @@ def parse_offer_from_payload(payload: dict) -> Offer:
 
     return Offer(
         external_id=f"{versant}-{reference}",
+        reference=reference,
         title=payload["titre"],
         profile=payload["description"]["profil"],
         mission=payload["description"]["mission"],


### PR DESCRIPTION
## 📝 Description

Le champ `external_id` des offres est une concaténation du versant (`FPT-`, `FPH-`, `FPE-`) et de la référence TalentSoft. Ce PR extrait la référence dans un champ dédié afin de simplifier les lookups et d'enforcer une contrainte d'unicité métier.

### Changements

**Domaine**
- Ajout du champ `reference: str` (requis) sur l'entité `Offer`

**Infrastructure**
- Nouvelle colonne `reference` (NOT NULL) sur la table `offers`
- Contrainte d'unicité `(reference, source_id)`
- `get_by_reference_and_source_id` utilise désormais la colonne `reference` directement au lieu d'un filtre `external_id__endswith`
- `reference` inclus dans les champs mis à jour lors des upserts

**Migration**
- `0030` : ajout de la colonne (nullable), alimentation depuis `external_id` via `SUBSTRING`, passage en NOT NULL, ajout de la contrainte unique

**Nettoyage / ingestion**
- `OffersCleaner` et `OfferInputMapper` alimentent `reference` depuis la référence TalentSoft

**API**
- `reference` et `source_id` exposés dans la réponse du endpoint de listing des offres

**Tests**
- Assertions sur `reference` dans les tests d'intégration de nettoyage et de listing


## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
