### PR TITLE
✅(tooling) get all commits from the repo

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -115,6 +115,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/scalingo-deploy
         with:
           branch: main-ingestion

--- a/.github/workflows/ocr.yml
+++ b/.github/workflows/ocr.yml
@@ -89,6 +89,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/scalingo-deploy
         with:
           branch: main-ocr

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -160,6 +160,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/scalingo-deploy
         with:
           branch: main-web


### PR DESCRIPTION
## Problème

Après la fusion de #660 (suppression du `--force` sur les branches de déploiement), les jobs `deploy-*` échouent. La cause : `actions/checkout@v6` effectue un clone superficiel (`--depth=1`) par défaut. Avec un historique tronqué, git ne peut pas calculer les objets à envoyer lors du push, ce qui entraîne un rejet.

## Solution

Ajout de `fetch-depth: 0` sur l'étape `actions/checkout` des trois jobs de déploiement (`deploy-ocr`, `deploy-web`, `deploy-ingestion`). Cela force un clone complet uniquement pour ces jobs, ce qui permet à git de déterminer correctement que le push est un fast-forward et de l'accepter sans `--force`.

Les autres jobs du workflow conservent le clone superficiel par défaut pour ne pas impacter les temps d'exécution.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
