### PR TITLE
✨(ingestion-presentation) accept token auth for upsert offer API

### DIFF
--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -188,6 +188,7 @@ class ArchiveOffersView(APIView):
     },
 )
 class OffersUpsertView(APIView):
+    authentication_classes = [JWTAuthentication, ApiKeyAuthentication]
     parser_classes = [JSONParser]
     serializer_class = UpsertOffersRequestSerializer
 

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -572,6 +572,7 @@ paths:
         required: true
       security:
       - jwtAuth: []
+      - ApiKeyAuth: []
       responses:
         '201':
           content:

--- a/src/web/tests/ingestion/presentation/views/test_upsert_offers.py
+++ b/src/web/tests/ingestion/presentation/views/test_upsert_offers.py
@@ -162,6 +162,16 @@ def test_unauthenticated_access(api_client):
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+def test_api_key_authentication(api_key_client, use_case):
+    use_case.execute.return_value = {"created": 1, "updated": 0, "errors": []}
+    response = api_key_client.post(
+        URL,
+        data=[MINIMAL_VALID_OFFER],
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
 def test_get_method_not_allowed(authenticated_client):
     response = authenticated_client.get(URL)
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED


### PR DESCRIPTION
## 📝 Description


Accepte une authentification par token pour l'API d'upsert des offres. Facilite l'intégration `ingestion` -> `web`.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
