### PR TITLE
🐛(web-ingestion) fix upsert offers payload in API

### DIFF
--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -196,7 +196,7 @@ class OffersUpsertView(APIView):
         logger = container.logger_service()
 
         # catch mini / maxi items number
-        serializer = UpsertOffersRequestSerializer(data={"offres": request.data})
+        serializer = UpsertOffersRequestSerializer(data=request.data)
         if not serializer.is_valid():
             logger.warning("OffersUpsertView: validation errors %s", serializer.errors)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -206,7 +206,7 @@ class OffersUpsertView(APIView):
         errors = []
         offer_mapper = OfferInputMapper()
 
-        for _, offer_data in enumerate(request.data):
+        for _, offer_data in enumerate(request.data["offres"]):
             serializer = OffersInputSerializer(data=offer_data)
             if not serializer.is_valid():
                 errors.append(

--- a/src/web/tests/ingestion/presentation/views/test_upsert_offers.py
+++ b/src/web/tests/ingestion/presentation/views/test_upsert_offers.py
@@ -179,7 +179,7 @@ def test_invalid_payload_returns_error_400(
 ):
     response = authenticated_client.post(
         URL,
-        data=[MINIMAL_VALID_OFFER] * num_offers,
+        data={"offres": [MINIMAL_VALID_OFFER] * num_offers},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -198,7 +198,7 @@ def test_valid_payload_returns_201_and_valid_offers_to_usecase(
     }
     response = authenticated_client.post(
         URL,
-        data=offers_payload,
+        data={"offres": offers_payload},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -235,7 +235,7 @@ def test_mixed_valid_invalid_offers_in_payload(authenticated_client, use_case):
     }
     response = authenticated_client.post(
         URL,
-        data=offers_payload,
+        data={"offres": offers_payload},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -257,6 +257,6 @@ def test_returns_error_500(authenticated_client, use_case):
     use_case.execute.side_effect = Exception("db error")
 
     response = authenticated_client.post(
-        URL, data=[MINIMAL_VALID_OFFER], content_type="application/json"
+        URL, data={"offres": [MINIMAL_VALID_OFFER]}, content_type="application/json"
     )
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## 📝 Description

### Contexte

L'implémentation de `OffersUpsertView` était incohérente avec sa propre documentation OpenAPI (voir #691). La vue attendait un tableau brut
`[offre1, offre2]` comme corps de requête, alors que le schéma documente `{"offres": [offre1, offre2]}`.

### Changements

#### `OffersUpsertView`
- Le serializer de validation reçoit désormais `request.data` directement (plus de double-enveloppe manuelle)
- L'itération sur les offres utilise `request.data["offres"]` au lieu de `request.data`

#### Tests
- Tous les appels `data=[...]` mis à jour en `data={"offres": [...]}` pour correspondre au format documenté

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
