### PR TITLE
✨(ingestion) store offer archived_at when archiving

### DIFF
--- a/src/ingestion/application/use_cases/archive_offer.py
+++ b/src/ingestion/application/use_cases/archive_offer.py
@@ -1,9 +1,22 @@
+from datetime import datetime, timezone
+
 from domain.gateways.archive_gateway import IArchiveGateway
+from domain.repositories.raw_offer_repository import IRawOfferRepository
 
 
 class ArchiveOfferUseCase:
-    def __init__(self, archive_gateway: IArchiveGateway) -> None:
+    def __init__(
+        self,
+        archive_gateway: IArchiveGateway,
+        raw_offer_repository: IRawOfferRepository,
+    ) -> None:
         self._archive_gateway = archive_gateway
+        self._raw_offer_repository = raw_offer_repository
 
     async def execute(self, reference: str, source_id: str) -> None:
         await self._archive_gateway.archive(reference=reference, source_id=source_id)
+        await self._raw_offer_repository.mark_as_archived(
+            reference=reference,
+            source_id=source_id,
+            archived_at=datetime.now(tz=timezone.utc),
+        )

--- a/src/ingestion/domain/entities/raw_offer.py
+++ b/src/ingestion/domain/entities/raw_offer.py
@@ -12,4 +12,6 @@ class RawOffer:
     error_msg: Optional[str] = None
     loaded_at: Optional[datetime] = None
     cleaned_at: Optional[datetime] = None
+    upsert_at: Optional[datetime] = None
+    archived_at: Optional[datetime] = None
     id: UUID = field(default_factory=uuid4)

--- a/src/ingestion/domain/repositories/raw_offer_repository.py
+++ b/src/ingestion/domain/repositories/raw_offer_repository.py
@@ -12,3 +12,6 @@ class IRawOfferRepository(Protocol):
     async def mark_as_upserted(
         self, reference: str, source_id: str, upsert_at: datetime
     ) -> None: ...
+    async def mark_as_archived(
+        self, reference: str, source_id: str, archived_at: datetime
+    ) -> None: ...

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -71,10 +71,14 @@ def _make_archive_gateway(
 
 def _make_archive_use_case(
     archive_gateway: IArchiveGateway | None,
+    raw_offer_repository: IRawOfferRepository | None,
 ) -> ArchiveOfferUseCase | None:
-    if archive_gateway is None:
+    if archive_gateway is None or raw_offer_repository is None:
         return None
-    return ArchiveOfferUseCase(archive_gateway=archive_gateway)
+    return ArchiveOfferUseCase(
+        archive_gateway=archive_gateway,
+        raw_offer_repository=raw_offer_repository,
+    )
 
 
 def _make_publish_offer_gateway(
@@ -149,6 +153,7 @@ class Container(containers.DeclarativeContainer):
         providers.Factory(
             _make_archive_use_case,
             archive_gateway=archive_gateway,
+            raw_offer_repository=raw_offer_repository,
         )
     )
 

--- a/src/ingestion/infrastructure/models/raw_offer.py
+++ b/src/ingestion/infrastructure/models/raw_offer.py
@@ -33,3 +33,4 @@ class RawOfferModel(SQLModel, table=True):  # type: ignore[call-arg]
     loaded_at: Optional[datetime] = None
     cleaned_at: Optional[datetime] = None
     upsert_at: Optional[datetime] = None
+    archived_at: Optional[datetime] = None

--- a/src/ingestion/infrastructure/raw_offer_repository.py
+++ b/src/ingestion/infrastructure/raw_offer_repository.py
@@ -100,3 +100,25 @@ class RawOfferRepository(IRawOfferRepository):
                     f" source_id={source_id}"
                 )
             session.commit()
+
+    async def mark_as_archived(
+        self, reference: str, source_id: str, archived_at: datetime
+    ) -> None:
+        await asyncio.to_thread(
+            self._mark_as_archived_sync, reference, source_id, archived_at
+        )
+
+    def _mark_as_archived_sync(
+        self, reference: str, source_id: str, archived_at: datetime
+    ) -> None:
+        now = datetime.now(tz=timezone.utc)
+        with Session(self._engine) as session:
+            session.execute(
+                update(RawOfferModel)
+                .where(
+                    col(RawOfferModel.reference) == reference,
+                    col(RawOfferModel.source_id) == source_id,
+                )
+                .values(archived_at=archived_at, updated_at=now)
+            )
+            session.commit()

--- a/src/ingestion/infrastructure/raw_offer_repository.py
+++ b/src/ingestion/infrastructure/raw_offer_repository.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import datetime, timezone
 
 from sqlalchemy import Engine, update
@@ -8,6 +9,8 @@ from sqlmodel import Session, col
 from domain.entities.raw_offer import RawOffer
 from domain.repositories.raw_offer_repository import IRawOfferRepository
 from infrastructure.models.raw_offer import RawOfferModel
+
+logger = logging.getLogger(__name__)
 
 
 class RawOfferRepository(IRawOfferRepository):
@@ -113,7 +116,7 @@ class RawOfferRepository(IRawOfferRepository):
     ) -> None:
         now = datetime.now(tz=timezone.utc)
         with Session(self._engine) as session:
-            session.execute(
+            result = session.execute(
                 update(RawOfferModel)
                 .where(
                     col(RawOfferModel.reference) == reference,
@@ -121,4 +124,10 @@ class RawOfferRepository(IRawOfferRepository):
                 )
                 .values(archived_at=archived_at, updated_at=now)
             )
+            if result.rowcount == 0:  # type: ignore[attr-defined]
+                logger.warning(
+                    "RawOffer not found when archiving: reference=%s, source_id=%s",
+                    reference,
+                    source_id,
+                )
             session.commit()

--- a/src/ingestion/migrations/versions/20260606_0000_add_archived_at_to_raw_offers.py
+++ b/src/ingestion/migrations/versions/20260606_0000_add_archived_at_to_raw_offers.py
@@ -1,0 +1,29 @@
+"""add archived_at to raw_offers
+
+Revision ID: 8d711cbbc883
+Revises: 3f8a92d1c04e
+Create Date: 2026-06-06 00:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8d711cbbc883"
+down_revision: Union[str, None] = "3f8a92d1c04e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "raw_offers",
+        sa.Column("archived_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("raw_offers", "archived_at")

--- a/src/ingestion/tests/integration/test_archive_offer_use_case.py
+++ b/src/ingestion/tests/integration/test_archive_offer_use_case.py
@@ -1,4 +1,6 @@
 import json
+from datetime import datetime
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -34,3 +36,18 @@ async def test_execute_raises_on_error_response(
     httpx_mock.add_response(method="POST", url=ARCHIVE_URL, status_code=500)
     with pytest.raises(httpx.HTTPStatusError):
         await archive_offer_use_case.execute(REFERENCE, source_id=SOURCE_ID)
+
+
+@pytest.mark.asyncio
+async def test_execute_marks_offer_as_archived_in_repository(
+    archive_offer_use_case: ArchiveOfferUseCase,
+    mock_raw_offer_repository: MagicMock,
+    httpx_mock: HTTPXMock,
+):
+    httpx_mock.add_response(method="POST", url=ARCHIVE_URL, status_code=200)
+    await archive_offer_use_case.execute(REFERENCE, source_id=SOURCE_ID)
+
+    call_kwargs = mock_raw_offer_repository.mark_as_archived.call_args.kwargs
+    assert call_kwargs["reference"] == REFERENCE
+    assert call_kwargs["source_id"] == SOURCE_ID
+    assert isinstance(call_kwargs["archived_at"], datetime)

--- a/src/ingestion/tests/integration/test_raw_offer_repository.py
+++ b/src/ingestion/tests/integration/test_raw_offer_repository.py
@@ -271,6 +271,56 @@ async def test_mark_as_upserted_raises_when_row_not_found(repository, db_engine)
 
 
 # ---------------------------------------------------------------------------
+# mark_as_archived
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_as_archived_sets_archived_at(repository, db_engine):
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=SOURCE_ID))
+
+    archived_at = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await repository.mark_as_archived(REFERENCE, SOURCE_ID, archived_at)
+
+    saved = _fetch(db_engine, REFERENCE, SOURCE_ID)
+    assert saved.archived_at is not None
+    assert saved.archived_at.replace(tzinfo=timezone.utc) == archived_at
+
+
+@pytest.mark.asyncio
+async def test_mark_as_archived_updates_updated_at(repository, db_engine):
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=SOURCE_ID))
+    before = _fetch(db_engine, REFERENCE, SOURCE_ID)
+
+    archived_at = datetime.now(tz=timezone.utc)
+    await repository.mark_as_archived(REFERENCE, SOURCE_ID, archived_at)
+
+    after = _fetch(db_engine, REFERENCE, SOURCE_ID)
+    assert after.updated_at >= before.updated_at
+
+
+@pytest.mark.asyncio
+async def test_mark_as_archived_does_not_affect_other_rows(repository, db_engine):
+    other_source_id = str(uuid4())
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=SOURCE_ID))
+    await repository.upsert(RawOffer(reference=REFERENCE, source_id=other_source_id))
+
+    await repository.mark_as_archived(
+        REFERENCE, SOURCE_ID, datetime.now(tz=timezone.utc)
+    )
+
+    other = _fetch(db_engine, REFERENCE, other_source_id)
+    assert other.archived_at is None
+
+
+@pytest.mark.asyncio
+async def test_mark_as_archived_is_noop_when_row_not_found(repository, db_engine):
+    await repository.mark_as_archived(
+        "UNKNOWN-REF", SOURCE_ID, datetime.now(tz=timezone.utc)
+    )
+
+
+# ---------------------------------------------------------------------------
 # Uniqueness
 # ---------------------------------------------------------------------------
 

--- a/src/ingestion/tests/presentation/test_webhook_archive.py
+++ b/src/ingestion/tests/presentation/test_webhook_archive.py
@@ -36,7 +36,25 @@ async def test_vacancy_deleted_calls_archive(talentsoft_client, httpx_mock: HTTP
     requests = httpx_mock.get_requests()
     assert len(requests) == 1
     body = json.loads(requests[0].content)
+    assert body["reference"] == REFERENCE
     assert body["source_id"] == SOURCE_ID
+
+
+@pytest.mark.asyncio
+async def test_vacancy_deleted_marks_offer_as_archived_in_repository(
+    talentsoft_client, httpx_mock: HTTPXMock
+):
+    httpx_mock.add_response(method="POST", url=ARCHIVE_URL, status_code=200)
+    payload = {
+        "event_type": TalentsoftEventType.VACANCY_DELETED,
+        "reference": REFERENCE,
+    }
+    make_signed_request(talentsoft_client, payload)
+
+    mock_repo = talentsoft_client.app.state.mock_raw_offer_repository
+    call_kwargs = mock_repo.mark_as_archived.call_args.kwargs
+    assert call_kwargs["reference"] == REFERENCE
+    assert call_kwargs["source_id"] == SOURCE_ID
 
 
 @pytest.mark.asyncio

--- a/src/ingestion/tests/shared_fixtures.py
+++ b/src/ingestion/tests/shared_fixtures.py
@@ -22,7 +22,6 @@ from infrastructure.external_gateways.talentsoft_client import (
     TalentsoftConfig,
     TalentsoftFrontClient,
 )
-from infrastructure.external_gateways.web_archive_gateway import WebArchiveGateway
 from infrastructure.external_gateways.web_sources_gateway import WebSourcesGateway
 from infrastructure.raw_offer_repository import RawOfferRepository
 from infrastructure.sources_repository import SourcesRepository
@@ -95,6 +94,7 @@ def setup_talentsoft_front_in_container(
     mock_repo.upsert = AsyncMock()
     mock_repo.mark_as_cleaned = AsyncMock()
     mock_repo.mark_as_upserted = AsyncMock()
+    mock_repo.mark_as_archived = AsyncMock()
     container.raw_offer_repository.override(providers.Object(mock_repo))
 
     return mock_repo
@@ -172,14 +172,24 @@ def load_sources_use_case(sources_repository: SourcesRepository) -> LoadSourcesU
 
 
 @pytest.fixture
-def archive_offer_use_case() -> ArchiveOfferUseCase:
-    return ArchiveOfferUseCase(
-        archive_gateway=WebArchiveGateway(
-            client=httpx.AsyncClient(),
-            base_url=WEB_BASE_URL,
-            api_key=WEB_API_KEY,
-        ),
+def mock_raw_offer_repository() -> MagicMock:
+    mock_repo = MagicMock()
+    mock_repo.upsert = AsyncMock()
+    mock_repo.mark_as_archived = AsyncMock()
+    mock_repo.mark_as_cleaned = AsyncMock()
+    return mock_repo
+
+
+@pytest.fixture
+def archive_offer_use_case(mock_raw_offer_repository: MagicMock) -> ArchiveOfferUseCase:
+    container = Container()
+    container.config.from_dict(
+        {"web_base_url": WEB_BASE_URL, "web_api_key": WEB_API_KEY, "database_url": None}
     )
+    container.raw_offer_repository.override(providers.Object(mock_raw_offer_repository))
+    use_case = container.archive_offer_use_case()
+    assert use_case is not None
+    return use_case
 
 
 @pytest.fixture


### PR DESCRIPTION
## 📝 Description

### Contexte

Lors de l'archivage d'une offre (événement `vacancy_deleted` ou changement de statut non diffusé), le service appelait l'API externe mais ne
conservait aucune trace dans la base de données locale.

### Changements

- Ajout d'un champ `archived_at` (nullable, timestamp) sur la table `raw_offers`, l'entité domaine `RawOffer` et le modèle SQLModel
- Migration Alembic correspondante (`8d711cbbc883`)
- Nouveau protocole `mark_as_archived` sur `IRawOfferRepository` et son implémentation — sans erreur si la ligne n'existe pas (une offre peut
être archivée avant d'avoir été ingérée)
- `ArchiveOfferUseCase` appelle désormais `mark_as_archived` après l'appel à la gateway externe ; le conteneur DI lui injecte le repository en
plus de la gateway

### Tests

- Tests d'intégration sur le repository : valeur persistée, `updated_at` mis à jour, isolation entre lignes, no-op si la ligne est absente
- Test sur le use case vérifiant l'appel au repository après l'archivage
- Test de présentation vérifiant que le webhook `vacancy_deleted` déclenche bien `mark_as_archived` avec la bonne référence et le bon
`source_id`

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
