### PR TITLE
✅(web) recreate missing indexes

### DIFF
--- a/src/web/infrastructure/django_apps/ingestion/migrations/0025_fix_missing_indexes.py
+++ b/src/web/infrastructure/django_apps/ingestion/migrations/0025_fix_missing_indexes.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ingestion", "0024_alter_sourcemodel_id_alter_sourcemodel_source_id"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                """
+                DELETE FROM ingestion_rawdocument
+                WHERE id IN (
+                    SELECT id
+                    FROM (
+                        SELECT id,
+                               ROW_NUMBER() OVER (PARTITION BY external_id, document_type ORDER BY created_at DESC) AS rn
+                        FROM ingestion_rawdocument
+                    ) sub
+                    WHERE rn > 1
+                );
+                """,
+                "CREATE INDEX IF NOT EXISTS ingestion_rawdocument_externa_3ec9c2 ON ingestion_rawdocument(external_id);",
+                "CREATE UNIQUE INDEX IF NOT EXISTS unique_external_id_document_type ON ingestion_rawdocument(external_id, document_type);",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/src/web/infrastructure/django_apps/ingestion/migrations/0025_fix_missing_indexes.py
+++ b/src/web/infrastructure/django_apps/ingestion/migrations/0025_fix_missing_indexes.py
@@ -9,6 +9,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
+            elidable=True,
             sql=[
                 """
                 DELETE FROM ingestion_rawdocument

--- a/src/web/infrastructure/django_apps/shared/migrations/0032_fix_missing_indexes.py
+++ b/src/web/infrastructure/django_apps/shared/migrations/0032_fix_missing_indexes.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shared", "0031_offermodel_reference"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                """
+                DELETE FROM offers
+                WHERE id IN (
+                    SELECT id
+                    FROM (
+                        SELECT id,
+                               ROW_NUMBER() OVER (PARTITION BY external_id ORDER BY created_at DESC) AS rn
+                        FROM offers
+                    ) sub
+                    WHERE rn > 1
+                );
+                """,
+                "CREATE UNIQUE INDEX IF NOT EXISTS offers_externa_40a57b_uniq ON offers(external_id);",
+                "CREATE INDEX IF NOT EXISTS offers_externa_91aec4_idx ON offers(external_id);",
+                "CREATE INDEX IF NOT EXISTS concours_nor_ori_fd92de_idx ON concours(nor_original);",
+                "CREATE UNIQUE INDEX IF NOT EXISTS metiers_externa_467155_uniq ON metiers(external_id);",
+                "CREATE INDEX IF NOT EXISTS metiers_externa_310f85_idx ON metiers(external_id);",
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/src/web/infrastructure/django_apps/shared/migrations/0032_fix_missing_indexes.py
+++ b/src/web/infrastructure/django_apps/shared/migrations/0032_fix_missing_indexes.py
@@ -9,6 +9,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
+            elidable=True,
             sql=[
                 """
                 DELETE FROM offers


### PR DESCRIPTION
## 📝 Description

Voir bug décrit dans https://github.com/betagouv/csplab/issues/680

Recrée les index manquants en production. Supprime les doublons dans `offers` et `ingestion_rawdocument`.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)

```
scalingo --app csplab-web --addon ad-07371032-62eb-444a-8c04-10883ca203c8 backups-download -o dumps/
bin/restore-web-db
```

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
