### PR TITLE
🐛(project) ci, should keep notebook when storybook are deployed

### DIFF
--- a/.github/workflows/storybook_pages.yml
+++ b/.github/workflows/storybook_pages.yml
@@ -50,6 +50,7 @@ jobs:
           branch: gh-pages
           folder: ${{ runner.temp }}/ghpages-nojekyll
           force: false
+          clean-exclude: notebook
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
@@ -82,6 +83,7 @@ jobs:
           branch: gh-pages
           folder: ${{ runner.temp }}/ghpages-nojekyll
           force: false
+          clean-exclude: notebook
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages


### PR DESCRIPTION
## 📝 Description
Les notebooks ne sont plus deployés sur github pages après un déploiement de storybook.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
`clean-exclude: notebook` ajouté dans les deux jobs de storybooks (`deploy-stable` et `deploy-preview`)

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
