### PR TITLE
🐛(metiers) fix !N! displayed as-is in conditions_particulieres and description

### DIFF
--- a/src/web/infrastructure/gateways/ingestion/metier_cleaner.py
+++ b/src/web/infrastructure/gateways/ingestion/metier_cleaner.py
@@ -82,21 +82,22 @@ class MetierCleaner(IDocumentCleaner[Metier]):
 
         return entities, errors
 
+    @staticmethod
+    def _split_commentaires(items) -> List[str]:
+        result = []
+        if items:
+            for item in items:
+                if item.commentaire:
+                    result.extend(
+                        s.strip()
+                        for s in item.commentaire.split("!N!")
+                        if s.strip()
+                    )
+        return result
+
     def _dto_to_entity(self, document: IngresMetiersDocument) -> Metier:
+        activites = self._split_commentaires(document.competences.activitesDeLEr)
 
-        # Extraction des activités
-        activites = []
-        if document.competences.activitesDeLEr:
-            for activite in document.competences.activitesDeLEr:
-                if activite.commentaire:
-                    activites_list = [
-                        act.strip()
-                        for act in activite.commentaire.split("!N!")
-                        if act.strip()
-                    ]
-                    activites.extend(activites_list)
-
-        # Extraction des versants
         versants = []
         if document.definitions.fonctionPublique.PFE == "1":
             versants.append(Verse.FPE)
@@ -105,21 +106,20 @@ class MetierCleaner(IDocumentCleaner[Metier]):
         if document.definitions.fonctionPublique.FPH == "1":
             versants.append(Verse.FPH)
 
-        # Extraction des conditions particulières
-        conditions_particulieres = []
-        if document.competences.conditionsParticulieresDExerciceDAcces:
-            for (
-                condition
-            ) in document.competences.conditionsParticulieresDExerciceDAcces:
-                if condition.commentaire:
-                    conditions_particulieres.append(condition.commentaire)
+        conditions_particulieres = self._split_commentaires(
+            document.competences.conditionsParticulieresDExerciceDAcces
+        )
+
+        raw_description = (
+            document.definitions.definitionSynthetiqueDeLEr.definition or ""
+        )
+        description = raw_description.replace("!N!", "\n")
 
         return Metier(
             id=uuid4(),
             external_id=document.identifiant,
             libelle=document.definitions.libelles.libelleLong,
-            description=document.definitions.definitionSynthetiqueDeLEr.definition
-            or "",
+            description=description,
             domaine_fonctionnel_code=document.definitions.domaineFonctionnel_Famille.codeDomaineFonctionnel,
             versants=versants,
             activites=activites,

--- a/src/web/infrastructure/gateways/ingestion/metier_cleaner.py
+++ b/src/web/infrastructure/gateways/ingestion/metier_cleaner.py
@@ -84,14 +84,12 @@ class MetierCleaner(IDocumentCleaner[Metier]):
 
     @staticmethod
     def _split_commentaires(items) -> List[str]:
-        result = []
+        result: list[str] = []
         if items:
             for item in items:
                 if item.commentaire:
                     result.extend(
-                        s.strip()
-                        for s in item.commentaire.split("!N!")
-                        if s.strip()
+                        s.strip() for s in item.commentaire.split("!N!") if s.strip()
                     )
         return result
 

--- a/src/web/tests/infrastructure/ingestion/test_metier_cleaner.py
+++ b/src/web/tests/infrastructure/ingestion/test_metier_cleaner.py
@@ -13,7 +13,6 @@ from tests.factories.ingestion.ingres_metiers_factories import (
     IngresMetiersDocumentFactory,
 )
 
-
 DATE_EFFET = "2023-01-01T00:00:00Z"
 
 
@@ -71,9 +70,7 @@ def test_conditions_particulieres_are_split_on_newline_markers(cleaner):
         dateEffet=DATE_EFFET,
         commentaire="Condition A.!N!Condition B.!N!Condition C.",
     )
-    document = _make_document(
-        competences=_competences_with_conditions([condition])
-    )
+    document = _make_document(competences=_competences_with_conditions([condition]))
 
     metier = cleaner._dto_to_entity(document)
 
@@ -95,9 +92,7 @@ def test_conditions_particulieres_multiple_entries_are_flattened(cleaner):
             commentaire="Condition C.",
         ),
     ]
-    document = _make_document(
-        competences=_competences_with_conditions(conditions)
-    )
+    document = _make_document(competences=_competences_with_conditions(conditions))
 
     metier = cleaner._dto_to_entity(document)
 
@@ -109,9 +104,7 @@ def test_conditions_particulieres_multiple_entries_are_flattened(cleaner):
 
 
 def test_conditions_particulieres_empty_when_none(cleaner):
-    document = _make_document(
-        competences=_competences_with_conditions(None)
-    )
+    document = _make_document(competences=_competences_with_conditions(None))
 
     metier = cleaner._dto_to_entity(document)
 

--- a/src/web/tests/infrastructure/ingestion/test_metier_cleaner.py
+++ b/src/web/tests/infrastructure/ingestion/test_metier_cleaner.py
@@ -1,0 +1,118 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from infrastructure.external_gateways.dtos.ingres_metiers_dtos import (
+    ConditionsParticulieresDExerciceDAcces,
+    DefinitionSynthetiqueDeLEr,
+)
+from infrastructure.gateways.ingestion.metier_cleaner import MetierCleaner
+from tests.factories.ingestion.ingres_metiers_factories import (
+    CompetencesFactory,
+    DefinitionsFactory,
+    IngresMetiersDocumentFactory,
+)
+
+
+DATE_EFFET = "2023-01-01T00:00:00Z"
+
+
+@pytest.fixture
+def cleaner() -> MetierCleaner:
+    return MetierCleaner(logger=MagicMock(), metier_repository=MagicMock())
+
+
+def _make_document(**kwargs):
+    return IngresMetiersDocumentFactory.build(**kwargs)
+
+
+def _definitions_with_description(description: str):
+    base = DefinitionsFactory.build()
+    return base.model_copy(
+        update={
+            "definitionSynthetiqueDeLEr": DefinitionSynthetiqueDeLEr(
+                definition=description
+            )
+        }
+    )
+
+
+def _competences_with_conditions(conditions):
+    base = CompetencesFactory.build()
+    return base.model_copy(
+        update={"conditionsParticulieresDExerciceDAcces": conditions}
+    )
+
+
+def test_description_newlines_are_replaced(cleaner):
+    document = _make_document(
+        definitions=_definitions_with_description(
+            "Première ligne.!N!Deuxième ligne.!N!Troisième ligne."
+        )
+    )
+
+    metier = cleaner._dto_to_entity(document)
+
+    assert metier.description == "Première ligne.\nDeuxième ligne.\nTroisième ligne."
+
+
+def test_description_without_newline_markers_is_unchanged(cleaner):
+    document = _make_document(
+        definitions=_definitions_with_description("Description simple sans saut.")
+    )
+
+    metier = cleaner._dto_to_entity(document)
+
+    assert metier.description == "Description simple sans saut."
+
+
+def test_conditions_particulieres_are_split_on_newline_markers(cleaner):
+    condition = ConditionsParticulieresDExerciceDAcces(
+        dateEffet=DATE_EFFET,
+        commentaire="Condition A.!N!Condition B.!N!Condition C.",
+    )
+    document = _make_document(
+        competences=_competences_with_conditions([condition])
+    )
+
+    metier = cleaner._dto_to_entity(document)
+
+    assert metier.conditions_particulieres == [
+        "Condition A.",
+        "Condition B.",
+        "Condition C.",
+    ]
+
+
+def test_conditions_particulieres_multiple_entries_are_flattened(cleaner):
+    conditions = [
+        ConditionsParticulieresDExerciceDAcces(
+            dateEffet=DATE_EFFET,
+            commentaire="Condition A.!N!Condition B.",
+        ),
+        ConditionsParticulieresDExerciceDAcces(
+            dateEffet=DATE_EFFET,
+            commentaire="Condition C.",
+        ),
+    ]
+    document = _make_document(
+        competences=_competences_with_conditions(conditions)
+    )
+
+    metier = cleaner._dto_to_entity(document)
+
+    assert metier.conditions_particulieres == [
+        "Condition A.",
+        "Condition B.",
+        "Condition C.",
+    ]
+
+
+def test_conditions_particulieres_empty_when_none(cleaner):
+    document = _make_document(
+        competences=_competences_with_conditions(None)
+    )
+
+    metier = cleaner._dto_to_entity(document)
+
+    assert metier.conditions_particulieres == []


### PR DESCRIPTION
## 📝 Description

Sur l'API `/api/v1/metiers/`, les sauts de ligne étaient affichés tels quels sous la forme `!N!` dans les champs `description` et `conditions_particulieres`.

### Solution

- `description` : remplacement de `!N!` par `\n`
- `conditions_particulieres` : découpage sur `!N!` en entrées distinctes (comme c'était déjà le cas pour `activites`)
- Extraction d'une méthode `_split_commentaires` pour factoriser la logique commune entre `activites` et `conditions_particulieres`

### Tests

Ajout de `tests/infrastructure/ingestion/test_metier_cleaner.py` couvrant les cas : remplacement des marqueurs, découpage en plusieurs entrées, aplatissement sur plusieurs commentaires, liste vide.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
