### PR TITLE
🐛(frontend) fix fonts for Storybook and local development

### DIFF
--- a/src/web/config/settings/dev.py
+++ b/src/web/config/settings/dev.py
@@ -62,3 +62,4 @@ SECURE_CSP["connect-src"] = [  # noqa: F405
 ]
 SECURE_CSP["style-src"] = ["'self'", "'unsafe-inline'"]  # noqa: F405
 SECURE_CSP["style-src-elem"] = ["'self'", "'unsafe-inline'"]  # noqa: F405
+SECURE_CSP["font-src"] = [*SECURE_CSP["font-src"], "http://localhost:5173"]  # noqa: F405

--- a/src/web/presentation/frontend/.storybook/main.ts
+++ b/src/web/presentation/frontend/.storybook/main.ts
@@ -7,7 +7,6 @@ const config: StorybookConfig = {
     '../src/**/*.mdx',
     '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
-  staticDirs: [{ from: '../../static', to: '/static' }],
   framework: {
     name: '@storybook/vue3-vite',
     options: {
@@ -30,9 +29,7 @@ const config: StorybookConfig = {
     },
   ],
   viteFinal: async (config) => {
-    if (process.env.STORYBOOK_BASE_URL) {
-      config.base = process.env.STORYBOOK_BASE_URL
-    }
+    config.base = process.env.STORYBOOK_BASE_URL ?? '/'
     return config
   },
 }

--- a/src/web/presentation/frontend/src/styles/fonts.css
+++ b/src/web/presentation/frontend/src/styles/fonts.css
@@ -4,8 +4,8 @@
   font-style: normal;
   font-weight: 300;
   src:
-    url(/static/fonts/Marianne-Light.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Light.woff) format('woff');
+    url('../../../static/fonts/Marianne-Light.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Light.woff') format('woff');
 }
 
 @font-face {
@@ -14,8 +14,8 @@
   font-style: italic;
   font-weight: 300;
   src:
-    url(/static/fonts/Marianne-Light_Italic.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Light_Italic.woff) format('woff');
+    url('../../../static/fonts/Marianne-Light_Italic.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Light_Italic.woff') format('woff');
 }
 
 @font-face {
@@ -24,8 +24,8 @@
   font-style: normal;
   font-weight: 400;
   src:
-    url(/static/fonts/Marianne-Regular.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Regular.woff) format('woff');
+    url('../../../static/fonts/Marianne-Regular.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Regular.woff') format('woff');
 }
 
 @font-face {
@@ -34,8 +34,8 @@
   font-style: italic;
   font-weight: 400;
   src:
-    url(/static/fonts/Marianne-Regular_Italic.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Regular_Italic.woff) format('woff');
+    url('../../../static/fonts/Marianne-Regular_Italic.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Regular_Italic.woff') format('woff');
 }
 
 @font-face {
@@ -44,8 +44,8 @@
   font-style: normal;
   font-weight: 500;
   src:
-    url(/static/fonts/Marianne-Medium.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Medium.woff) format('woff');
+    url('../../../static/fonts/Marianne-Medium.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Medium.woff') format('woff');
 }
 
 @font-face {
@@ -54,8 +54,8 @@
   font-style: italic;
   font-weight: 500;
   src:
-    url(/static/fonts/Marianne-Medium_Italic.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Medium_Italic.woff) format('woff');
+    url('../../../static/fonts/Marianne-Medium_Italic.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Medium_Italic.woff') format('woff');
 }
 
 @font-face {
@@ -64,8 +64,8 @@
   font-style: normal;
   font-weight: 700;
   src:
-    url(/static/fonts/Marianne-Bold.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Bold.woff) format('woff');
+    url('../../../static/fonts/Marianne-Bold.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Bold.woff') format('woff');
 }
 
 @font-face {
@@ -74,6 +74,6 @@
   font-style: italic;
   font-weight: 700;
   src:
-    url(/static/fonts/Marianne-Bold_Italic.woff2) format('woff2'),
-    url(/static/fonts/Marianne-Bold_Italic.woff) format('woff');
+    url('../../../static/fonts/Marianne-Bold_Italic.woff2') format('woff2'),
+    url('../../../static/fonts/Marianne-Bold_Italic.woff') format('woff');
 }

--- a/src/web/presentation/frontend/vite.config.ts
+++ b/src/web/presentation/frontend/vite.config.ts
@@ -7,7 +7,8 @@ import { defineConfig } from 'vite'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/static/frontend/' : '/',
   plugins: [vue(), tailwindcss()],
   resolve: {
     alias: {
@@ -24,10 +25,10 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    origin: 'http://localhost:5173',
     proxy: {
       '/api': 'http://localhost:8000',
       '/ats': 'http://localhost:8000',
-      '/static': 'http://localhost:8000',
     },
   },
   test: {
@@ -42,4 +43,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
## 📝 Description
Corrige le chargement des fonts Marianne pour le storybook (local et prod) et l'ats (local et prod)

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
