### PR TITLE
✨(ingestion) lock periodic API log tasks to single execution

### DIFF
--- a/src/web/presentation/ingestion/tasks.py
+++ b/src/web/presentation/ingestion/tasks.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 from huey import crontab
-from huey.contrib.djhuey import db_periodic_task, db_task
+from huey.contrib.djhuey import db_periodic_task, db_task, lock_task
 
 from application.ingestion.interfaces.load_documents_input import LoadDocumentsInput
 from application.ingestion.interfaces.load_operation_type import LoadOperationType
@@ -170,6 +170,7 @@ def load_documents(kwargs, usecase_name):
 
 
 @db_periodic_task(crontab(hour="3", minute="0"))
+@lock_task("aggregate-api-logs-periodic")
 def aggregate_api_logs_periodic():
     aggregate_api_logs(target_date=date.today() - timedelta(days=1))
 
@@ -194,6 +195,7 @@ def aggregate_api_logs(target_date: date):
 
 
 @db_periodic_task(crontab(hour="4", minute="0"))
+@lock_task("purge-api-logs-periodic")
 def purge_api_logs_periodic():
     purge_api_logs()
 


### PR DESCRIPTION
## 📝 Description

Corrige [cette exception](https://sentry.incubateur.net/organizations/betagouv/issues/287322/), les tâches périodiques liées à l'aggrégation de logs API doivent être exécutées 1 seule fois, même si on a plusieurs workers qui travaillent.

Revoit #743

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
