### PR TITLE
✨(ingestion) type Offer.source_id as UUID and send source_id in publish payload

### DIFF
--- a/src/ingestion/application/use_cases/publish_offer.py
+++ b/src/ingestion/application/use_cases/publish_offer.py
@@ -1,5 +1,6 @@
 from domain.entities.offer import Offer
 from domain.gateways.publish_offer_gateway import IPublishOfferGateway
+from domain.gateways.publish_offer_input import PublishOfferInput
 
 
 class PublishOfferUseCase:
@@ -7,4 +8,6 @@ class PublishOfferUseCase:
         self._gateway = publish_offer_gateway
 
     async def execute(self, offer: Offer) -> None:
-        await self._gateway.publish(offer)
+        await self._gateway.publish(
+            PublishOfferInput(source_id=offer.source_id, offer=offer)
+        )

--- a/src/ingestion/domain/entities/offer.py
+++ b/src/ingestion/domain/entities/offer.py
@@ -15,7 +15,7 @@ from domain.value_objects.verse import Verse
 @dataclass
 class Offer:
     reference: str
-    source_id: str
+    source_id: UUID
     external_id: str
     title: str
     profile: str

--- a/src/ingestion/domain/gateways/publish_offer_gateway.py
+++ b/src/ingestion/domain/gateways/publish_offer_gateway.py
@@ -1,7 +1,7 @@
 from typing import Protocol
 
-from domain.entities.offer import Offer
+from domain.gateways.publish_offer_input import PublishOfferInput
 
 
 class IPublishOfferGateway(Protocol):
-    async def publish(self, offer: Offer) -> None: ...
+    async def publish(self, input: PublishOfferInput) -> None: ...

--- a/src/ingestion/domain/gateways/publish_offer_input.py
+++ b/src/ingestion/domain/gateways/publish_offer_input.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from domain.entities.offer import Offer
+
+
+@dataclass
+class PublishOfferInput:
+    source_id: UUID
+    offer: Offer

--- a/src/ingestion/infrastructure/external_gateways/web_publish_offer_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/web_publish_offer_gateway.py
@@ -1,5 +1,6 @@
 from domain.entities.offer import Offer
 from domain.gateways.publish_offer_gateway import IPublishOfferGateway
+from domain.gateways.publish_offer_input import PublishOfferInput
 from infrastructure.external_gateways.base_web_gateway import BaseWebGateway
 from infrastructure.external_gateways.dtos.offer_upsert_payload import (
     OfferUpsertPayload,
@@ -7,10 +8,13 @@ from infrastructure.external_gateways.dtos.offer_upsert_payload import (
 
 
 class WebPublishOfferGateway(BaseWebGateway, IPublishOfferGateway):
-    async def publish(self, offer: Offer) -> None:
+    async def publish(self, input: PublishOfferInput) -> None:
         await self._post(
             "/offres/creer_modifier/",
-            json={"offres": [self._serialize(offer)]},
+            json={
+                "source_id": str(input.source_id),
+                "offres": [self._serialize(input.offer)],
+            },
         )
 
     def _serialize(self, offer: Offer) -> dict:

--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 from typing import List, Optional, cast
+from uuid import UUID
 
 from pydantic import HttpUrl, ValidationError
 
@@ -82,7 +83,7 @@ class OffersCleaner:
 
         return Offer(
             reference=raw_offer.reference,
-            source_id=cast(str, raw_offer.source_id),  # guaranteed by clean()
+            source_id=UUID(cast(str, raw_offer.source_id)),
             external_id=f"{ts_verse}-{talentsoft_offer.reference}"
             if ts_verse
             else talentsoft_offer.reference,

--- a/src/ingestion/tests/integration/test_clean_raw_offer_use_case.py
+++ b/src/ingestion/tests/integration/test_clean_raw_offer_use_case.py
@@ -1,6 +1,5 @@
-"""Integration tests for CleanRawOfferUseCase wired with the real OffersCleaner."""
-
 import datetime
+from uuid import UUID
 
 import pytest
 
@@ -43,7 +42,7 @@ def test_execute_returns_offer_with_reference_and_source_id(use_case):
 
     assert isinstance(result, Offer)
     assert result.reference == REFERENCE
-    assert result.source_id == SOURCE_ID
+    assert result.source_id == UUID(SOURCE_ID)
 
 
 def test_execute_maps_title_and_organization(use_case):

--- a/src/ingestion/tests/unit/test_ingest_offer_pipeline.py
+++ b/src/ingestion/tests/unit/test_ingest_offer_pipeline.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
 
@@ -22,7 +23,7 @@ RAW_OFFER = RawOffer(
 )
 CLEANED_OFFER = Offer(
     reference=REFERENCE,
-    source_id=SOURCE_ID,
+    source_id=UUID(SOURCE_ID),
     external_id=f"FPT-{REFERENCE}",
     title="Title",
     profile="Profile",

--- a/src/ingestion/tests/unit/test_publish_offer_use_case.py
+++ b/src/ingestion/tests/unit/test_publish_offer_use_case.py
@@ -7,12 +7,13 @@ import pytest
 from application.use_cases.publish_offer import PublishOfferUseCase
 from domain.entities.offer import Offer
 from domain.gateways.publish_offer_gateway import IPublishOfferGateway
+from domain.gateways.publish_offer_input import PublishOfferInput
 from domain.value_objects.contract_type import ContractType
 from domain.value_objects.verse import Verse
 
 OFFER = Offer(
     reference="2024-OFFER-001",
-    source_id=str(UUID("11111111-2222-3333-4444-555555555555")),
+    source_id=UUID("11111111-2222-3333-4444-555555555555"),
     external_id="FPT-2024-OFFER-001",
     title="Software Engineer",
     profile="Profile text",
@@ -45,7 +46,9 @@ def use_case(mock_gateway):
 async def test_execute_calls_gateway_publish(use_case, mock_gateway):
     await use_case.execute(OFFER)
 
-    mock_gateway.publish.assert_awaited_once_with(OFFER)
+    mock_gateway.publish.assert_awaited_once_with(
+        PublishOfferInput(source_id=OFFER.source_id, offer=OFFER)
+    )
 
 
 @pytest.mark.asyncio

--- a/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
+++ b/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from domain.entities.offer import Offer
+from domain.gateways.publish_offer_input import PublishOfferInput
 from domain.value_objects.area import GeographicalArea
 from domain.value_objects.category import Category
 from domain.value_objects.contract_type import ContractType
@@ -23,7 +24,7 @@ from infrastructure.external_gateways.web_publish_offer_gateway import (
 BASE_URL = "https://web.example.com"
 API_KEY = "test-api-key"
 PUBLISH_URL = f"{BASE_URL}/api/v1/offres/creer_modifier/"
-SOURCE_ID = str(UUID("11111111-2222-3333-4444-555555555555"))
+SOURCE_ID = UUID("11111111-2222-3333-4444-555555555555")
 PUBLICATION_DATE = datetime(2024, 1, 15, tzinfo=timezone.utc)
 
 MINIMAL_OFFER = Offer(
@@ -78,7 +79,7 @@ def gateway():
 async def test_publish_posts_to_correct_url(gateway, httpx_mock: HTTPXMock):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
 
-    await gateway.publish(MINIMAL_OFFER)
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER))
 
     requests = httpx_mock.get_requests()
     assert len(requests) == 1
@@ -89,7 +90,7 @@ async def test_publish_posts_to_correct_url(gateway, httpx_mock: HTTPXMock):
 async def test_publish_sends_api_key_header(gateway, httpx_mock: HTTPXMock):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
 
-    await gateway.publish(MINIMAL_OFFER)
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER))
 
     request = httpx_mock.get_requests()[0]
     assert request.headers["Authorization"] == f"Api-Key {API_KEY}"
@@ -99,10 +100,11 @@ async def test_publish_sends_api_key_header(gateway, httpx_mock: HTTPXMock):
 async def test_publish_serializes_minimal_offer(gateway, httpx_mock: HTTPXMock):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
 
-    await gateway.publish(MINIMAL_OFFER)
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER))
 
     body = json.loads(httpx_mock.get_requests()[0].content)
-    assert list(body.keys()) == ["offres"]
+    assert list(body.keys()) == ["source_id", "offres"]
+    assert body["source_id"] == str(SOURCE_ID)
     assert len(body["offres"]) == 1
     offer = body["offres"][0]
 
@@ -138,7 +140,7 @@ async def test_publish_uses_beginning_date_as_fin_publication(
 ):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
 
-    await gateway.publish(FULL_OFFER)
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=FULL_OFFER))
 
     body = json.loads(httpx_mock.get_requests()[0].content)
     offer = body["offres"][0]
@@ -151,7 +153,7 @@ async def test_publish_defaults_fin_publication_to_one_year_when_no_beginning_da
 ):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
 
-    await gateway.publish(MINIMAL_OFFER)
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER))
 
     body = json.loads(httpx_mock.get_requests()[0].content)
     offer = body["offres"][0]
@@ -162,7 +164,7 @@ async def test_publish_defaults_fin_publication_to_one_year_when_no_beginning_da
 async def test_publish_serializes_localisation(gateway, httpx_mock: HTTPXMock):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
 
-    await gateway.publish(FULL_OFFER)
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=FULL_OFFER))
 
     body = json.loads(httpx_mock.get_requests()[0].content)
     offer = body["offres"][0]
@@ -183,7 +185,7 @@ async def test_publish_serializes_localisation(gateway, httpx_mock: HTTPXMock):
 async def test_publish_serializes_category(gateway, httpx_mock: HTTPXMock):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
 
-    await gateway.publish(FULL_OFFER)
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=FULL_OFFER))
 
     body = json.loads(httpx_mock.get_requests()[0].content)
     offer = body["offres"][0]
@@ -195,4 +197,6 @@ async def test_publish_raises_on_http_error(gateway, httpx_mock: HTTPXMock):
     httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=500)
 
     with pytest.raises(httpx.HTTPStatusError):
-        await gateway.publish(MINIMAL_OFFER)
+        await gateway.publish(
+            PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER)
+        )


### PR DESCRIPTION
## 📝 Description

Dans `ingestion`, passe `source_id` en tant que paramètre principal lors de l'upsert d'une offre.

### Changements

- `Offer.source_id` passe de `str` à `UUID`
- Nouveau dataclass `PublishOfferInput(source_id: UUID, offer: Offer)` dans `domain/gateways/`
- `IPublishOfferGateway.publish()` accepte désormais un `PublishOfferInput` au lieu d'un `Offer`
- `WebPublishOfferGateway` envoie `source_id` dans le payload JSON aux côtés de `offres`
- `OffersCleaner` convertit `raw_offer.source_id` (str) en `UUID` lors de la construction de l'`Offer`
- Tests mis à jour en conséquence

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
