### PR TITLE
✨(ingestion) move source_id to top-level of upsert offers endpoint

### DIFF
--- a/src/web/application/ingestion/interfaces/upsert_offers_input.py
+++ b/src/web/application/ingestion/interfaces/upsert_offers_input.py
@@ -6,5 +6,6 @@ from referentiel.entities.offer import Offer
 
 @dataclass
 class UpsertOffersInput:
+    source_id: UUID
     offers: list[Offer]
     utilisateur_entity_id: UUID | None = None

--- a/src/web/application/ingestion/usecases/upsert_offers.py
+++ b/src/web/application/ingestion/usecases/upsert_offers.py
@@ -33,7 +33,7 @@ class UpsertOffersUseCase(IUseCase[UpsertOffersInput, IUpsertResult]):
             utilisateur = self.utilisateur_repository.get_by_entity_id(
                 input_data.utilisateur_entity_id
             )
-            source_ids = {offer.source_id for offer in input_data.offers}
+            source_ids = {input_data.source_id}
             allowed = self.user_source_repository.get_allowed_source_ids(
                 utilisateur, source_ids
             )

--- a/src/web/presentation/ingestion/mappers.py
+++ b/src/web/presentation/ingestion/mappers.py
@@ -58,5 +58,5 @@ class OfferInputMapper(IToDomainMapper[dict, Offer]):
             localisation=self._localisation_mapper.to_domain(raw_localisation),
             beginning_date=LimitDate(debut_contrat) if debut_contrat else None,
             family_code=data["profession"]["metier"],
-            source_id=data["identification"]["source"],
+            source_id=data["source_id"],
         )

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -100,7 +100,6 @@ class ListMetiersFiltersSerializer(serializers.Serializer):
 
 class IdentityInputSerializer(serializers.Serializer):
     reference = serializers.CharField()
-    source = serializers.UUIDField()
     versant = serializers.ChoiceField(choices=[v.value for v in Verse])
 
 
@@ -212,6 +211,7 @@ class PublicationInputSerializer(serializers.Serializer):
 
 
 class OffersInputSerializer(serializers.Serializer):
+    source_id = serializers.UUIDField()
     identification = IdentityInputSerializer()
 
     # general infos
@@ -245,6 +245,7 @@ class OffersInputSerializer(serializers.Serializer):
 
 
 class UpsertOffersRequestSerializer(serializers.Serializer):
+    source_id = serializers.UUIDField()
     offres = serializers.ListField(
         child=serializers.DictField(),
         min_length=1,

--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -170,12 +170,15 @@ class ArchiveOffersView(APIView):
     request=inline_serializer(
         name="UpsertOffersRequest",
         fields={
+            "source_id": serializers.UUIDField(
+                help_text="Identifiant de la source des offres"
+            ),
             "offres": serializers.ListField(
                 child=OffersInputSerializer(),
                 min_length=1,
                 max_length=100,
                 help_text="Liste d'offres à créer ou mettre à jour (min: 1, max: 100)",
-            )
+            ),
         },
     ),
     responses={
@@ -226,13 +229,17 @@ class OffersUpsertView(APIView):
             logger.warning("OffersUpsertView: validation errors %s", serializer.errors)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+        source_id = serializer.validated_data["source_id"]
+
         # iterate over offers, to handle only valid ones
         valid_offers = []
         errors = []
         offer_mapper = OfferInputMapper()
 
         for _, offer_data in enumerate(request.data["offres"]):
-            serializer = OffersInputSerializer(data=offer_data)
+            serializer = OffersInputSerializer(
+                data={**offer_data, "source_id": source_id}
+            )
             if not serializer.is_valid():
                 errors.append(
                     {
@@ -258,7 +265,9 @@ class OffersUpsertView(APIView):
             usecase = container.upsert_offers_usecase()
             result = usecase.execute(
                 UpsertOffersInput(
-                    offers=valid_offers, utilisateur_entity_id=utilisateur_entity_id
+                    source_id=source_id,
+                    offers=valid_offers,
+                    utilisateur_entity_id=utilisateur_entity_id,
                 )
             )
             result["errors"].extend(errors)

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -1067,14 +1067,10 @@ components:
       properties:
         reference:
           type: string
-        source:
-          type: string
-          format: uuid
         versant:
           $ref: '#/components/schemas/VersantEnum'
       required:
       - reference
-      - source
       - versant
     LanguageInput:
       type: object
@@ -1247,6 +1243,9 @@ components:
     OffersInput:
       type: object
       properties:
+        source_id:
+          type: string
+          format: uuid
         identification:
           $ref: '#/components/schemas/IdentityInput'
         titre:
@@ -1319,6 +1318,7 @@ components:
       - organisation
       - profession
       - publication
+      - source_id
       - titre
       - titre_long
       - type_contrat
@@ -1524,6 +1524,10 @@ components:
     UpsertOffersRequest:
       type: object
       properties:
+        source_id:
+          type: string
+          format: uuid
+          description: Identifiant de la source des offres
         offres:
           type: array
           items:
@@ -1533,6 +1537,7 @@ components:
           minItems: 1
       required:
       - offres
+      - source_id
     UpsertOffersResponse:
       type: object
       properties:

--- a/src/web/tests/application/ingestion/test_upsert_offers.py
+++ b/src/web/tests/application/ingestion/test_upsert_offers.py
@@ -1,10 +1,12 @@
+import uuid
+
 from application.ingestion.interfaces.upsert_offers_input import (
     UpsertOffersInput,
 )
 
 
 def test_execute_returns_empty_list_when_no_sources(upsert_offers_usecase):
-    input_data = UpsertOffersInput(offers=[])
+    input_data = UpsertOffersInput(source_id=uuid.uuid4(), offers=[])
     upsert_offers_usecase.execute(input_data=input_data)
     offers = upsert_offers_usecase.offers_repository.get_all()
     assert offers == []

--- a/src/web/tests/infrastructure/ingestion/test_upsert_offers.py
+++ b/src/web/tests/infrastructure/ingestion/test_upsert_offers.py
@@ -57,7 +57,9 @@ def test_upsert_offers_result(ingestion_container):
 
     new_offer = OfferFactory.create_entity(source_id=existing_offer.source_id)
 
-    input_data = UpsertOffersInput(offers=[existing_offer, new_offer])
+    input_data = UpsertOffersInput(
+        source_id=existing_offer.source_id, offers=[existing_offer, new_offer]
+    )
     result = ingestion_container.upsert_offers_usecase().execute(input_data=input_data)
 
     assert result == {"created": 1, "updated": 1, "errors": []}

--- a/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
@@ -34,11 +34,11 @@ URL = reverse("ingestion:offers_upsert")
 
 
 MINIMAL_VALID_OFFER = PayloadOfferFactory.create(
-    identification={"reference": "REF-001", "source": SOURCE_UUID, "versant": "FPT"}
+    identification={"reference": "REF-001", "versant": "FPT"}
 )
 
 PARTIAL_VALID_OFFER = PayloadOfferFactory.create(
-    identification={"reference": "REF-002", "source": SOURCE_UUID, "versant": "FPE"},
+    identification={"reference": "REF-002", "versant": "FPE"},
     localisation=[],
     criteres={"diplome_niveau": 3},
     conditions={
@@ -51,7 +51,7 @@ PARTIAL_VALID_OFFER = PayloadOfferFactory.create(
 )
 
 COMPLETE_VALID_OFFER = PayloadOfferFactory.create(
-    identification={"reference": "REF-003", "source": SOURCE_UUID, "versant": "FPH"},
+    identification={"reference": "REF-003", "versant": "FPH"},
     organisation={"nom": fake.company(), "siret": fake.siret().replace(" ", "")},
     url_offre="https://example.com/offre",
     url_candidature="https://example.com/candidature",
@@ -89,17 +89,17 @@ COMPLETE_VALID_OFFER = PayloadOfferFactory.create(
 )
 
 INVALID_PAYLOAD_OFFER = PayloadOfferFactory.create(
-    identification={"reference": "REF-004", "source": SOURCE_UUID, "versant": "FPT"},
+    identification={"reference": "REF-004", "versant": "FPT"},
     titre=None,  # missing required field
 )
 
 INVALID_DATA_OFFER = PayloadOfferFactory.create(
-    identification={"reference": "REF-005", "source": SOURCE_UUID, "versant": "FPT"},
+    identification={"reference": "REF-005", "versant": "FPT"},
     type_contrat="ABC",  # invalid enum value
 )
 
 
-def parse_offer_from_payload(payload: dict) -> Offer:
+def parse_offer_from_payload(payload: dict, source_id: UUID) -> Offer:
     reference = payload["identification"]["reference"]
     versant = payload["identification"]["versant"]
 
@@ -143,7 +143,7 @@ def parse_offer_from_payload(payload: dict) -> Offer:
         localisation=localisation,
         beginning_date=debut_contrat,
         family_code=payload["profession"]["metier"],
-        source_id=UUID(payload["identification"]["source"]),
+        source_id=source_id,
     )
 
 
@@ -181,7 +181,7 @@ def test_api_key_authentication(api_key_client, use_case):
     use_case.execute.return_value = {"created": 1, "updated": 0, "errors": []}
     response = api_key_client.post(
         URL,
-        data={"offres": [MINIMAL_VALID_OFFER]},
+        data={"source_id": SOURCE_UUID, "offres": [MINIMAL_VALID_OFFER]},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -204,7 +204,7 @@ def test_invalid_payload_returns_error_400(
 ):
     response = authenticated_client.post(
         URL,
-        data={"offres": [MINIMAL_VALID_OFFER] * num_offers},
+        data={"source_id": SOURCE_UUID, "offres": [MINIMAL_VALID_OFFER] * num_offers},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -215,7 +215,7 @@ def test_jwt_forbidden_source_id_returns_403(authenticated_client, use_case):
     use_case.execute.side_effect = SourceAuthorizationError({UUID(SOURCE_UUID)})
     response = authenticated_client.post(
         URL,
-        data={"offres": [MINIMAL_VALID_OFFER]},
+        data={"source_id": SOURCE_UUID, "offres": [MINIMAL_VALID_OFFER]},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -233,14 +233,14 @@ def test_valid_payload_returns_201_and_valid_offers_to_usecase(
     }
     response = authenticated_client_with_source.post(
         URL,
-        data={"offres": offers_payload},
+        data={"source_id": SOURCE_UUID, "offres": offers_payload},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
 
     upsert_input = use_case.execute.call_args[0][0]
     for payload, offer in zip(offers_payload, upsert_input.offers, strict=True):
-        expected = parse_offer_from_payload(payload)
+        expected = parse_offer_from_payload(payload, source_id=UUID(SOURCE_UUID))
         for attr in [
             "external_id",
             "title",
@@ -272,7 +272,7 @@ def test_mixed_valid_invalid_offers_in_payload(
     }
     response = authenticated_client_with_source.post(
         URL,
-        data={"offres": offers_payload},
+        data={"source_id": SOURCE_UUID, "offres": offers_payload},
         content_type="application/json",
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -280,11 +280,11 @@ def test_mixed_valid_invalid_offers_in_payload(
     assert errors == [
         "db error on offer xxx",
         {
-            "offer": {"reference": "REF-004", "source": SOURCE_UUID, "versant": "FPT"},
+            "offer": {"reference": "REF-004", "versant": "FPT"},
             "error": {"titre": ["Ce champ ne peut être nul."]},
         },
         {
-            "offer": {"reference": "REF-005", "source": SOURCE_UUID, "versant": "FPT"},
+            "offer": {"reference": "REF-005", "versant": "FPT"},
             "error": {"type_contrat": ["«\xa0ABC\xa0» n'est pas un choix valide."]},
         },
     ]
@@ -294,6 +294,8 @@ def test_returns_error_500(authenticated_client_with_source, use_case):
     use_case.execute.side_effect = Exception("db error")
 
     response = authenticated_client_with_source.post(
-        URL, data={"offres": [MINIMAL_VALID_OFFER]}, content_type="application/json"
+        URL,
+        data={"source_id": SOURCE_UUID, "offres": [MINIMAL_VALID_OFFER]},
+        content_type="application/json",
     )
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## 📝 Description

Dans `web`, pour l'API d'upsert des offres, ajouter `source_id` en tant que paramètre principal, à côté de `offres`.

La partie `ingestion` pour cette feature est réalisée dans https://github.com/betagouv/csplab/pull/755

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [x] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
