### PR TITLE
🐛(web-infrastructure) run a single Huey scheduler

### DIFF
--- a/src/web/Procfile
+++ b/src/web/Procfile
@@ -1,4 +1,3 @@
 web: bash ./start.sh
-worker: python manage.py run_huey --no-periodic
-scheduler: python manage.py run_huey --workers 0
+worker: bash ./run_worker.sh
 postdeploy: bash ./postdeploy.sh

--- a/src/web/Procfile
+++ b/src/web/Procfile
@@ -1,3 +1,4 @@
 web: bash ./start.sh
-worker: python manage.py run_huey
+worker: python manage.py run_huey --no-periodic
+scheduler: python manage.py run_huey --workers 0
 postdeploy: bash ./postdeploy.sh

--- a/src/web/run_worker.sh
+++ b/src/web/run_worker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# CONTAINER is set by Scalingo with format "worker-1", "worker-2", etc.
+INDEX="${CONTAINER##*-}"
+
+if [ "$INDEX" = "1" ]; then
+    echo "Instance 1: starting Huey with scheduler and workers"
+    python manage.py run_huey
+else
+    echo "Instance ${INDEX}: starting Huey workers only (no scheduler)"
+    python manage.py run_huey --no-periodic
+fi


### PR DESCRIPTION
## 📝 Description

Suite de #754 pour essayer de n'avoir qu'une seule exécution des tâches Huey programmées. [Voir exception Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/287322/).

>The Procfile starts the worker with a single `run_huey` command, but if you scale that process (e.g., `web: 1, worker: 3`), each worker process runs its own **scheduler** that independently enqueues the periodic task into Redis. `lock_task` only prevents concurrent execution — if the first run finishes before the second worker's copy starts, the lock is gone and both run.
>The fix is to run only **one scheduler** across all workers.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
