### PR TITLE
🐛(ingestion) register Celery tasks via include instead of autodiscover

### DIFF
--- a/src/ingestion/infrastructure/celery_app.py
+++ b/src/ingestion/infrastructure/celery_app.py
@@ -38,8 +38,8 @@ def create_celery_app() -> Celery:
         accept_content=["json"],
         timezone="UTC",
         enable_utc=True,
+        include=["application.tasks.process_webhook"],
     )
-    app.autodiscover_tasks(["application"])
     return app
 
 


### PR DESCRIPTION
## 📝 Description

Répare un bug de https://github.com/betagouv/csplab/pull/737 sur la détection des tâches Celery.

`autodiscover_tasks(["application"])` demande à Celery d'importer le module `application.tasks`. Comme `application/tasks/` est un **package** (dossier avec `__init__.py`), Celery importe uniquement son `__init__.py` — qui était vide. Le fichier `process_webhook.py` n'était donc jamais importé, et la tâche n'était jamais enregistrée dans le registre de Celery.

Quand `process_webhook.delay(...)` était appelé depuis `routes.py`, Celery cherchait la tâche `application.tasks.process_webhook.process_webhook` dans son registre et ne la trouvait pas → `KeyError`.

Si `application/tasks/` avait été un simple fichier `tasks.py` plutôt qu'un dossier, `autodiscover_tasks` aurait fonctionné sans problème.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
