### PR TITLE
🐛(ingestion) run Flower inside web container for Scalingo compatibility

### DIFF
--- a/src/ingestion/Procfile
+++ b/src/ingestion/Procfile
@@ -1,4 +1,3 @@
 web: bin/start_web.sh
 worker: bin/start_worker.sh
-flower: bin/start_flower.sh
 postdeploy: bin/run_migrations.sh

--- a/src/ingestion/bin/start_web.sh
+++ b/src/ingestion/bin/start_web.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Start the webserver
+# Start Flower in the background so the web process can proxy to it via localhost
+if [ -n "${FLOWER_PORT:-}" ] && [ -n "${FLOWER_BASIC_AUTH_USER:-}" ] && [ -n "${FLOWER_BASIC_AUTH_PASSWORD:-}" ]; then
+    celery -A infrastructure.celery_app flower \
+        --port="$FLOWER_PORT" \
+        --url-prefix=flower \
+        --basic-auth="$FLOWER_BASIC_AUTH_USER:$FLOWER_BASIC_AUTH_PASSWORD" &
+fi
+
 exec uvicorn api.main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
## 📝 Description

Retravaille #737

Le process `flower` tournait dans un container isolé sur Scalingo, `localhost` n'est pas partagé et Flower n'était donc pas accessible.

Le trick est de démarrer `flower` dans le même container que `web`.

En dev il n'y a pas de changements, on démarre plusieurs processus et `localhost` est partagé.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
