### PR TITLE
🐛(web-ingestion) hide source_id from OffersInputSerializer OpenAPI doc

### DIFF
--- a/src/web/presentation/ingestion/mappers.py
+++ b/src/web/presentation/ingestion/mappers.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from uuid import UUID
 
 from ddd.mapper_interface import IToDomainMapper
 from referentiel.entities.offer import Offer
@@ -29,7 +30,7 @@ class OfferInputMapper(IToDomainMapper[dict, Offer]):
     def __init__(self) -> None:
         self._localisation_mapper = LocalisationInputMapper()
 
-    def to_domain(self, data: Optional[dict]) -> Optional[Offer]:
+    def to_domain(self, data: Optional[dict], source_id: UUID) -> Optional[Offer]:
         if not data:
             return None
 
@@ -58,5 +59,5 @@ class OfferInputMapper(IToDomainMapper[dict, Offer]):
             localisation=self._localisation_mapper.to_domain(raw_localisation),
             beginning_date=LimitDate(debut_contrat) if debut_contrat else None,
             family_code=data["profession"]["metier"],
-            source_id=data["source_id"],
+            source_id=source_id,
         )

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -1,4 +1,3 @@
-from drf_spectacular.utils import extend_schema_serializer
 from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractKind, ContractType
@@ -211,9 +210,7 @@ class PublicationInputSerializer(serializers.Serializer):
     debut_vacance_poste = serializers.DateTimeField(allow_null=True, required=False)
 
 
-@extend_schema_serializer(exclude_fields=["source_id"])
 class OffersInputSerializer(serializers.Serializer):
-    source_id = serializers.UUIDField()
     identification = IdentityInputSerializer()
 
     # general infos

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema_serializer
 from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractKind, ContractType
@@ -210,6 +211,7 @@ class PublicationInputSerializer(serializers.Serializer):
     debut_vacance_poste = serializers.DateTimeField(allow_null=True, required=False)
 
 
+@extend_schema_serializer(exclude_fields=["source_id"])
 class OffersInputSerializer(serializers.Serializer):
     source_id = serializers.UUIDField()
     identification = IdentityInputSerializer()

--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -237,9 +237,7 @@ class OffersUpsertView(APIView):
         offer_mapper = OfferInputMapper()
 
         for _, offer_data in enumerate(request.data["offres"]):
-            serializer = OffersInputSerializer(
-                data={**offer_data, "source_id": source_id}
-            )
+            serializer = OffersInputSerializer(data=offer_data)
             if not serializer.is_valid():
                 errors.append(
                     {
@@ -249,7 +247,9 @@ class OffersUpsertView(APIView):
                 )
                 continue
             try:
-                valid_offers.append(offer_mapper.to_domain(serializer.validated_data))
+                valid_offers.append(
+                    offer_mapper.to_domain(serializer.validated_data, source_id)
+                )
             except Exception as e:
                 errors.append(
                     {

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -1243,9 +1243,6 @@ components:
     OffersInput:
       type: object
       properties:
-        source_id:
-          type: string
-          format: uuid
         identification:
           $ref: '#/components/schemas/IdentityInput'
         titre:
@@ -1318,7 +1315,6 @@ components:
       - organisation
       - profession
       - publication
-      - source_id
       - titre
       - titre_long
       - type_contrat


### PR DESCRIPTION
## 📝 Description

Modifie la documentation pour [`upsert`](https://csplab.beta.gouv.fr/api/schema/redoc/#tag/offres/operation/v1_offres_creer_modifier_create) en cachant le champ `source_id` de chaque offre. En effet ce champ est passé "top level" et injecté dans chaque offre, on ne devrait pas l'attendre.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [x] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
