### PR TITLE
✨(ci) check pyproject.toml version bump on libs changes

### DIFF
--- a/.github/workflows/lib_version_bump.yml
+++ b/.github/workflows/lib_version_bump.yml
@@ -1,0 +1,46 @@
+name: Lib Version Bump Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - "libs/**"
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lib: [ddd, referentiel]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check that ${{ matrix.lib }} version was bumped
+        env:
+          LIB: ${{ matrix.lib }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          LIB_PATH="libs/$LIB"
+
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "$LIB_PATH")
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No changes in $LIB_PATH, skipping."
+            exit 0
+          fi
+
+          BASE_VERSION=$(git show "$BASE_SHA:$LIB_PATH/pyproject.toml" | grep -m1 '^version' | sed -E 's/version *= *"(.*)"/\1/')
+          HEAD_VERSION=$(git show "$HEAD_SHA:$LIB_PATH/pyproject.toml" | grep -m1 '^version' | sed -E 's/version *= *"(.*)"/\1/')
+
+          echo "Base version: $BASE_VERSION"
+          echo "Head version: $HEAD_VERSION"
+
+          if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+            echo "::error::Files changed in $LIB_PATH but the version in $LIB_PATH/pyproject.toml was not bumped (still $HEAD_VERSION)."
+            exit 1
+          fi


### PR DESCRIPTION
## 📝 Description

Vérifie que l'on bump la version dans `pyproject.toml` quand on change des fichiers dans ce dossier. L'idée vient de ce commentaire https://github.com/betagouv/csplab/pull/794#pullrequestreview-4513525675.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
