### PR TITLE
🐛(ingestion) stop sending source per offer when upserting to web

### DIFF
--- a/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
+++ b/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
@@ -11,7 +11,6 @@ from domain.entities.offer import Offer
 
 class IdentificationPayload(BaseModel):
     reference: str
-    source: str
     versant: Optional[str]
 
 
@@ -116,7 +115,6 @@ class OfferUpsertPayload(BaseModel):
         return cls(
             identification=IdentificationPayload(
                 reference=offer.reference,
-                source=str(offer.source_id),
                 versant=offer.verse.value if offer.verse else None,
             ),
             titre=offer.title,

--- a/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
+++ b/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
@@ -117,7 +117,6 @@ async def test_publish_serializes_minimal_offer(gateway, httpx_mock: HTTPXMock):
     offer = body["offres"][0]
 
     assert offer["identification"]["reference"] == "2024-OFFER-001"
-    assert offer["identification"]["source"] == str(SOURCE_ID)
     assert offer["identification"]["versant"] == "FPT"
     assert offer["titre"] == "Software Engineer"
     assert offer["titre_long"] == "Software Engineer"


### PR DESCRIPTION
## 📝 Description

En lien avec #800

`source_id` n'est pas requis dans chaque offre, c'est envoyé en tant que "top level parameter" à côté de `offres`.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
