### PR TITLE
🔧(tooling) remove `make lint` when commiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ git add .
 bin/cz commit
 ```
 
+`bin/cz` lance `make lint` avant le commit ; ajoutez `-n` (ex. `bin/cz -n commit`) pour ignorer le linting.
+
 ### Format des messages de commit
 
 Les messages de commit doivent respecter le format gitmoji configuré :

--- a/bin/cz
+++ b/bin/cz
@@ -2,10 +2,4 @@
 
 set -eo pipefail
 
-if [ "$1" = "-n" ]; then
-  shift
-else
-  make lint
-fi
-
 cd dev && direnv exec . uv run cz "$@"

--- a/bin/cz
+++ b/bin/cz
@@ -2,4 +2,10 @@
 
 set -eo pipefail
 
-make lint && cd dev && direnv exec . uv run cz "$@"
+if [ "$1" = "-n" ]; then
+  shift
+else
+  make lint
+fi
+
+cd dev && direnv exec . uv run cz "$@"


### PR DESCRIPTION
## 📝 Description
🎸 commiter sans déclencher `make lint`
💡 laisser la responsabilité aux devs de lancer le lint avant de pousser leurs commits

## 🏷️ Type de changement
- [x] 🔧 Changement technique


## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
