### PR TITLE
✨(ingestion) split process_webhook task by action type

### DIFF
--- a/src/ingestion/api/routes.py
+++ b/src/ingestion/api/routes.py
@@ -10,15 +10,14 @@ from pydantic import ValidationError
 
 from api.config import get_settings
 from api.talentsoft import verify_talentsoft_signature
-from application.tasks.process_webhook import process_webhook
+from application.tasks.process_webhook import (
+    archive_offer_webhook,
+    save_raw_offer_webhook,
+)
 from application.use_cases.save_webhook import SaveWebhookUseCase
 from domain.repositories.sources_repository import ISourcesRepository
 from domain.value_objects.source import Source
-from domain.value_objects.webhook_event import (
-    WebhookEvent,
-    should_archive,
-    should_save_raw_offer,
-)
+from domain.value_objects.webhook_event import WebhookActionType, WebhookEvent
 from infrastructure.di.container import Container
 from infrastructure.value_objects import webhook_source
 from presentation.dtos.talentsoft_webhook import TalentsoftWebhookPayload
@@ -98,7 +97,7 @@ async def talentsoft_webhook(
         logger.exception("Failed to store webhook for reference %s", event.reference)
         return _OK
 
-    if not (should_archive(event) or should_save_raw_offer(event)):
+    if webhook.action_type is None:
         logger.info(
             "Unhandled event type %s for reference %s and status %s",
             event.event_type,
@@ -108,7 +107,11 @@ async def talentsoft_webhook(
         )
         return _OK
 
-    process_webhook.delay(str(webhook.id))
+    if webhook.action_type == WebhookActionType.ARCHIVE:
+        archive_offer_webhook.delay(str(webhook.id))
+    elif webhook.action_type == WebhookActionType.SAVE_RAW_OFFER:
+        save_raw_offer_webhook.delay(str(webhook.id))
+
     logger.info(
         "Enqueued processing for event %s reference %s",
         event.event_type,

--- a/src/ingestion/application/tasks/process_webhook.py
+++ b/src/ingestion/application/tasks/process_webhook.py
@@ -4,12 +4,6 @@ from uuid import UUID
 
 import httpx
 
-from domain.value_objects.webhook_event import (
-    OfferStatus,
-    WebhookEvent,
-    should_archive,
-    should_save_raw_offer,
-)
 from infrastructure.celery_app import celery_app, get_container
 from infrastructure.exceptions.exceptions import ExternalApiError
 
@@ -28,67 +22,65 @@ def _is_transient(exc: Exception) -> bool:
     return False
 
 
+async def _run_with_timeout(coro) -> None:
+    async with asyncio.timeout(_TASK_TIMEOUT_SECONDS):
+        await coro
+
+
+def _retry_on_transient(task, exc: Exception) -> None:
+    if _is_transient(exc):
+        raise task.retry(exc=exc, countdown=2**task.request.retries) from exc
+    raise exc
+
+
 @celery_app.task(bind=True, max_retries=_MAX_RETRIES)
-def process_webhook(self, webhook_id: str) -> None:
+def archive_offer_webhook(self, webhook_id: str) -> None:
+    container = get_container()
+
+    async def _run() -> None:
+        webhook = await container.webhook_repository().get_by_id(UUID(webhook_id))
+        await container.archive_offer_use_case().execute(
+            reference=webhook.reference, source_id=webhook.source_id
+        )
+        logger.info("Archived offer %s (webhook %s)", webhook.reference, webhook_id)
+
+    try:
+        asyncio.run(_run_with_timeout(_run()))
+    except Exception as exc:
+        _retry_on_transient(self, exc)
+
+
+@celery_app.task(bind=True, max_retries=_MAX_RETRIES)
+def save_raw_offer_webhook(self, webhook_id: str) -> None:
     container = get_container()
 
     async def _run() -> None:
         webhook = await container.webhook_repository().get_by_id(UUID(webhook_id))
 
-        event = WebhookEvent(
-            event_type=webhook.event_type,
-            reference=webhook.reference,
-            status=OfferStatus(webhook.status_id) if webhook.status_id else None,
+        sources_repository = container.sources_repository()
+        source = sources_repository.get_by_source_id(webhook.source_id)
+        if source is None:
+            raise ValueError(
+                f"Source {webhook.source_id} not found, "
+                f"cannot process webhook {webhook_id}"
+            )
+
+        client = container.talentsoft_client_repository().get(source.client_id_front)
+        if client is None:
+            raise ValueError(
+                f"TalentSoft client not found for source {webhook.source_id}, "
+                f"cannot process webhook {webhook_id}"
+            )
+
+        pipeline = container.ingest_offer_pipeline(
+            save_raw_offer=container.save_raw_offer_use_case(
+                offers_gateway=client,
+            ),
         )
-
-        if should_archive(event):
-            await container.archive_offer_use_case().execute(
-                reference=webhook.reference, source_id=webhook.source_id
-            )
-            logger.info("Archived offer %s (webhook %s)", webhook.reference, webhook_id)
-
-        elif should_save_raw_offer(event):
-            sources_repository = container.sources_repository()
-            source = sources_repository.get_by_source_id(webhook.source_id)
-            if source is None:
-                raise ValueError(
-                    f"Source {webhook.source_id} not found, "
-                    f"cannot process webhook {webhook_id}"
-                )
-
-            client = container.talentsoft_client_repository().get(
-                source.client_id_front
-            )
-            if client is None:
-                raise ValueError(
-                    f"TalentSoft client not found for source {webhook.source_id}, "
-                    f"cannot process webhook {webhook_id}"
-                )
-
-            pipeline = container.ingest_offer_pipeline(
-                save_raw_offer=container.save_raw_offer_use_case(
-                    offers_gateway=client,
-                ),
-            )
-            await pipeline.execute(
-                reference=webhook.reference, source_id=webhook.source_id
-            )
-            logger.info("Ingested offer %s (webhook %s)", webhook.reference, webhook_id)
-
-        else:
-            logger.info(
-                "No action needed for webhook %s (event_type=%s)",
-                webhook_id,
-                webhook.event_type,
-            )
-
-    async def _run_with_timeout() -> None:
-        async with asyncio.timeout(_TASK_TIMEOUT_SECONDS):
-            await _run()
+        await pipeline.execute(reference=webhook.reference, source_id=webhook.source_id)
+        logger.info("Ingested offer %s (webhook %s)", webhook.reference, webhook_id)
 
     try:
-        asyncio.run(_run_with_timeout())
+        asyncio.run(_run_with_timeout(_run()))
     except Exception as exc:
-        if _is_transient(exc):
-            raise self.retry(exc=exc, countdown=2**self.request.retries) from exc
-        raise
+        _retry_on_transient(self, exc)

--- a/src/ingestion/application/use_cases/save_webhook.py
+++ b/src/ingestion/application/use_cases/save_webhook.py
@@ -3,7 +3,7 @@ from typing import Any
 from domain.entities.webhook import Webhook
 from domain.repositories.webhook_repository import IWebhookRepository
 from domain.value_objects.source import Source
-from domain.value_objects.webhook_event import WebhookEvent
+from domain.value_objects.webhook_event import WebhookEvent, get_action_type
 from domain.value_objects.webhook_type import WebhookType
 
 
@@ -24,6 +24,7 @@ class SaveWebhookUseCase:
             event_type=event.event_type,
             reference=event.reference,
             status_id=event.status,
+            action_type=get_action_type(event),
             payload=payload,
         )
         await self._repository.insert(webhook)

--- a/src/ingestion/application/use_cases/save_webhook.py
+++ b/src/ingestion/application/use_cases/save_webhook.py
@@ -3,7 +3,7 @@ from typing import Any
 from domain.entities.webhook import Webhook
 from domain.repositories.webhook_repository import IWebhookRepository
 from domain.value_objects.source import Source
-from domain.value_objects.webhook_event import WebhookEvent, get_action_type
+from domain.value_objects.webhook_event import WebhookEvent
 from domain.value_objects.webhook_type import WebhookType
 
 
@@ -24,7 +24,7 @@ class SaveWebhookUseCase:
             event_type=event.event_type,
             reference=event.reference,
             status_id=event.status,
-            action_type=get_action_type(event),
+            action_type=event.get_action_type(),
             payload=payload,
         )
         await self._repository.insert(webhook)

--- a/src/ingestion/domain/entities/webhook.py
+++ b/src/ingestion/domain/entities/webhook.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
 
-from domain.value_objects.webhook_event import EventType
+from domain.value_objects.webhook_event import EventType, WebhookActionType
 from domain.value_objects.webhook_type import WebhookType
 
 
@@ -16,4 +16,5 @@ class Webhook:
     payload: dict[str, Any]
     webhook_type: WebhookType
     status_id: str | None = None
+    action_type: WebhookActionType | None = None
     id: UUID = field(default_factory=uuid4)

--- a/src/ingestion/domain/value_objects/webhook_event.py
+++ b/src/ingestion/domain/value_objects/webhook_event.py
@@ -26,6 +26,11 @@ class WebhookEvent:
     status: OfferStatus | None = None
 
 
+class WebhookActionType(StrEnum):
+    ARCHIVE = "archive"
+    SAVE_RAW_OFFER = "save_raw_offer"
+
+
 def should_archive(event: WebhookEvent) -> bool:
     if event.event_type == EventType.SUPPRIME:
         return True
@@ -37,3 +42,11 @@ def should_archive(event: WebhookEvent) -> bool:
 
 def should_save_raw_offer(event: WebhookEvent) -> bool:
     return event.event_type in {EventType.CREE, EventType.MIS_A_JOUR}
+
+
+def get_action_type(event: WebhookEvent) -> WebhookActionType | None:
+    if should_archive(event):
+        return WebhookActionType.ARCHIVE
+    if should_save_raw_offer(event):
+        return WebhookActionType.SAVE_RAW_OFFER
+    return None

--- a/src/ingestion/domain/value_objects/webhook_event.py
+++ b/src/ingestion/domain/value_objects/webhook_event.py
@@ -19,34 +19,31 @@ class OfferStatus(StrEnum):
     VALIDE = "Valide"
 
 
+class WebhookActionType(StrEnum):
+    ARCHIVE = "archive"
+    SAVE_RAW_OFFER = "save_raw_offer"
+
+
 @dataclass(frozen=True)
 class WebhookEvent:
     event_type: EventType
     reference: str
     status: OfferStatus | None = None
 
+    def should_archive(self) -> bool:
+        if self.event_type == EventType.SUPPRIME:
+            return True
+        return (
+            self.event_type == EventType.STATUT_CHANGE
+            and self.status != OfferStatus.DIFFUSE
+        )
 
-class WebhookActionType(StrEnum):
-    ARCHIVE = "archive"
-    SAVE_RAW_OFFER = "save_raw_offer"
+    def should_save_raw_offer(self) -> bool:
+        return self.event_type in {EventType.CREE, EventType.MIS_A_JOUR}
 
-
-def should_archive(event: WebhookEvent) -> bool:
-    if event.event_type == EventType.SUPPRIME:
-        return True
-    return (
-        event.event_type == EventType.STATUT_CHANGE
-        and event.status != OfferStatus.DIFFUSE
-    )
-
-
-def should_save_raw_offer(event: WebhookEvent) -> bool:
-    return event.event_type in {EventType.CREE, EventType.MIS_A_JOUR}
-
-
-def get_action_type(event: WebhookEvent) -> WebhookActionType | None:
-    if should_archive(event):
-        return WebhookActionType.ARCHIVE
-    if should_save_raw_offer(event):
-        return WebhookActionType.SAVE_RAW_OFFER
-    return None
+    def get_action_type(self) -> WebhookActionType | None:
+        if self.should_archive():
+            return WebhookActionType.ARCHIVE
+        if self.should_save_raw_offer():
+            return WebhookActionType.SAVE_RAW_OFFER
+        return None

--- a/src/ingestion/infrastructure/models/webhook.py
+++ b/src/ingestion/infrastructure/models/webhook.py
@@ -29,4 +29,5 @@ class WebhookModel(SQLModel, table=True):  # type: ignore[call-arg]
     event_type: str = Field(index=True)
     reference: str
     status_id: Optional[str] = None
+    action_type: Optional[str] = Field(default=None, index=True)
     payload: dict[str, Any] = Field(sa_column=Column(JSONB, nullable=False))

--- a/src/ingestion/infrastructure/webhook_repository.py
+++ b/src/ingestion/infrastructure/webhook_repository.py
@@ -6,7 +6,7 @@ from sqlmodel import Session
 
 from domain.entities.webhook import Webhook
 from domain.repositories.webhook_repository import IWebhookRepository
-from domain.value_objects.webhook_event import EventType
+from domain.value_objects.webhook_event import EventType, WebhookActionType
 from infrastructure.models.webhook import WebhookModel
 from infrastructure.value_objects.webhook_source import (
     SOURCE_TO_WEBHOOK_TYPE,
@@ -30,6 +30,7 @@ class WebhookRepository(IWebhookRepository):
                 event_type=webhook.event_type,
                 reference=webhook.reference,
                 status_id=webhook.status_id,
+                action_type=webhook.action_type,
                 payload=webhook.payload,
             )
             session.add(model)
@@ -51,4 +52,7 @@ class WebhookRepository(IWebhookRepository):
                 payload=model.payload,
                 webhook_type=SOURCE_TO_WEBHOOK_TYPE[model.webhook_type],
                 status_id=model.status_id,
+                action_type=(
+                    WebhookActionType(model.action_type) if model.action_type else None
+                ),
             )

--- a/src/ingestion/migrations/versions/20260617_0000_add_action_type_to_webhooks.py
+++ b/src/ingestion/migrations/versions/20260617_0000_add_action_type_to_webhooks.py
@@ -1,0 +1,37 @@
+"""add action_type to webhooks
+
+Revision ID: 96540e52312c
+Revises: 37a97d8bcec5
+Create Date: 2026-06-17 00:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "96540e52312c"
+down_revision: Union[str, None] = "37a97d8bcec5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "webhooks",
+        sa.Column("action_type", sqlmodel.AutoString(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_webhooks_action_type"),
+        "webhooks",
+        ["action_type"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_webhooks_action_type"), table_name="webhooks")
+    op.drop_column("webhooks", "action_type")

--- a/src/ingestion/tests/presentation/test_webhook_archive.py
+++ b/src/ingestion/tests/presentation/test_webhook_archive.py
@@ -27,7 +27,7 @@ async def test_vacancy_deleted_enqueues_task(talentsoft_client):
         "event_type": TalentsoftEventType.VACANCY_DELETED,
         "reference": REFERENCE,
     }
-    with patch("api.routes.process_webhook") as mock_task:
+    with patch("api.routes.archive_offer_webhook") as mock_task:
         response = make_signed_request(talentsoft_client, payload)
 
     assert response.status_code == 200
@@ -54,7 +54,7 @@ async def test_vacancy_status_non_diffuse_enqueues_task(
         "reference": REFERENCE,
         "statusId": status_id,
     }
-    with patch("api.routes.process_webhook") as mock_task:
+    with patch("api.routes.archive_offer_webhook") as mock_task:
         response = make_signed_request(talentsoft_client, payload)
 
     assert response.status_code == 200
@@ -69,7 +69,7 @@ async def test_vacancy_status_diffuse_saves_but_does_not_enqueue(talentsoft_clie
         "reference": REFERENCE,
         "statusId": TalentsoftOfferStatus.DIFFUSE,
     }
-    with patch("api.routes.process_webhook") as mock_task:
+    with patch("api.routes.archive_offer_webhook") as mock_task:
         response = make_signed_request(talentsoft_client, payload)
 
     assert response.status_code == 200

--- a/src/ingestion/tests/presentation/test_webhook_load_offer.py
+++ b/src/ingestion/tests/presentation/test_webhook_load_offer.py
@@ -13,7 +13,7 @@ REFERENCE = "2024-VACANCY-001"
 @pytest.mark.asyncio
 async def test_vacancy_new_enqueues_task(talentsoft_client):
     payload = {"event_type": TalentsoftEventType.VACANCY_NEW, "reference": REFERENCE}
-    with patch("api.routes.process_webhook") as mock_task:
+    with patch("api.routes.save_raw_offer_webhook") as mock_task:
         response = make_signed_request(talentsoft_client, payload)
 
     assert response.status_code == 200
@@ -26,7 +26,7 @@ async def test_vacancy_new_enqueues_task(talentsoft_client):
 @pytest.mark.asyncio
 async def test_vacancy_update_enqueues_task(talentsoft_client):
     payload = {"event_type": TalentsoftEventType.VACANCY_UPDATE, "reference": REFERENCE}
-    with patch("api.routes.process_webhook") as mock_task:
+    with patch("api.routes.save_raw_offer_webhook") as mock_task:
         response = make_signed_request(talentsoft_client, payload)
 
     assert response.status_code == 200

--- a/src/ingestion/tests/unit/test_process_webhook_task.py
+++ b/src/ingestion/tests/unit/test_process_webhook_task.py
@@ -6,7 +6,11 @@ import pytest
 from celery.app.task import Task
 from celery.exceptions import Retry
 
-from application.tasks.process_webhook import _is_transient, process_webhook
+from application.tasks.process_webhook import (
+    _is_transient,
+    archive_offer_webhook,
+    save_raw_offer_webhook,
+)
 from domain.value_objects.webhook_event import EventType, OfferStatus
 from infrastructure.exceptions.exceptions import ExternalApiError
 from tests.factories.domain_factories import SourceFactory, WebhookFactory
@@ -43,7 +47,7 @@ def test_archive_called_for_supprime_event():
     container = _make_mock_container(webhook)
 
     with patch(_PATCH_CONTAINER, return_value=container):
-        process_webhook(str(WEBHOOK_ID))
+        archive_offer_webhook(str(WEBHOOK_ID))
 
     container.archive_offer_use_case.return_value.execute.assert_awaited_once_with(
         reference=REFERENCE, source_id=SOURCE_ID
@@ -65,28 +69,11 @@ def test_archive_called_for_statut_change_non_diffuse(status_id: OfferStatus):
     container = _make_mock_container(webhook)
 
     with patch(_PATCH_CONTAINER, return_value=container):
-        process_webhook(str(WEBHOOK_ID))
+        archive_offer_webhook(str(WEBHOOK_ID))
 
     container.archive_offer_use_case.return_value.execute.assert_awaited_once_with(
         reference=REFERENCE, source_id=SOURCE_ID
     )
-
-
-def test_no_action_for_statut_change_diffuse():
-    webhook = WebhookFactory.build(
-        id=WEBHOOK_ID,
-        source_id=SOURCE_ID,
-        reference=REFERENCE,
-        event_type=EventType.STATUT_CHANGE,
-        status_id=str(OfferStatus.DIFFUSE),
-    )
-    container = _make_mock_container(webhook)
-
-    with patch(_PATCH_CONTAINER, return_value=container):
-        process_webhook(str(WEBHOOK_ID))
-
-    container.archive_offer_use_case.return_value.execute.assert_not_called()
-    container.sources_repository.return_value.get_by_source_id.assert_not_called()
 
 
 # --- Ingest path ---
@@ -102,7 +89,7 @@ def test_ingest_pipeline_called_for_cree_event():
     container = _make_mock_container(webhook)
 
     with patch(_PATCH_CONTAINER, return_value=container):
-        process_webhook(str(WEBHOOK_ID))
+        save_raw_offer_webhook(str(WEBHOOK_ID))
 
     container.ingest_offer_pipeline.return_value.execute.assert_awaited_once_with(
         reference=REFERENCE, source_id=SOURCE_ID
@@ -119,7 +106,7 @@ def test_ingest_pipeline_called_for_mis_a_jour_event():
     container = _make_mock_container(webhook)
 
     with patch(_PATCH_CONTAINER, return_value=container):
-        process_webhook(str(WEBHOOK_ID))
+        save_raw_offer_webhook(str(WEBHOOK_ID))
 
     container.ingest_offer_pipeline.return_value.execute.assert_awaited_once_with(
         reference=REFERENCE, source_id=SOURCE_ID
@@ -137,7 +124,7 @@ def test_ingest_raises_when_source_not_found():
         patch(_PATCH_CONTAINER, return_value=container),
         pytest.raises(ValueError, match=SOURCE_ID),
     ):
-        process_webhook(str(WEBHOOK_ID))
+        save_raw_offer_webhook(str(WEBHOOK_ID))
 
 
 def test_ingest_raises_when_talentsoft_client_not_found():
@@ -151,7 +138,7 @@ def test_ingest_raises_when_talentsoft_client_not_found():
         patch(_PATCH_CONTAINER, return_value=container),
         pytest.raises(ValueError, match=SOURCE_ID),
     ):
-        process_webhook(str(WEBHOOK_ID))
+        save_raw_offer_webhook(str(WEBHOOK_ID))
 
 
 # --- Edge cases ---
@@ -167,7 +154,7 @@ def test_raises_when_webhook_not_found_in_db():
         patch(_PATCH_CONTAINER, return_value=container),
         pytest.raises(ValueError, match=str(WEBHOOK_ID)),
     ):
-        process_webhook(str(WEBHOOK_ID))
+        archive_offer_webhook(str(WEBHOOK_ID))
 
 
 # --- Retries ---
@@ -209,7 +196,7 @@ def test_retries_on_transport_error():
         patch.object(Task, "retry", side_effect=Retry()) as mock_retry,
         pytest.raises(Retry),
     ):
-        process_webhook(str(WEBHOOK_ID))
+        archive_offer_webhook(str(WEBHOOK_ID))
 
     mock_retry.assert_called_once()
     assert mock_retry.call_args.kwargs["exc"] is exc
@@ -226,7 +213,7 @@ def test_retries_on_external_api_5xx():
         patch.object(Task, "retry", side_effect=Retry()) as mock_retry,
         pytest.raises(Retry),
     ):
-        process_webhook(str(WEBHOOK_ID))
+        archive_offer_webhook(str(WEBHOOK_ID))
 
     mock_retry.assert_called_once()
     assert mock_retry.call_args.kwargs["exc"] is exc
@@ -242,7 +229,7 @@ def test_no_retry_on_external_api_4xx():
         patch.object(Task, "retry") as mock_retry,
         pytest.raises(ExternalApiError),
     ):
-        process_webhook(str(WEBHOOK_ID))
+        archive_offer_webhook(str(WEBHOOK_ID))
 
     mock_retry.assert_not_called()
 
@@ -258,6 +245,6 @@ def test_no_retry_on_value_error():
         patch.object(Task, "retry") as mock_retry,
         pytest.raises(ValueError),
     ):
-        process_webhook(str(WEBHOOK_ID))
+        archive_offer_webhook(str(WEBHOOK_ID))
 
     mock_retry.assert_not_called()


### PR DESCRIPTION
## 📝 Description

- Découpe la tâche Celery `process_webhook` en deux tâches dédiées : `archive_offer_webhook` et `save_raw_offer_webhook`.
- Ajoute un champ `action_type` (`archive` / `save_raw_offer`) sur l'entité et la table `webhooks`, calculé une seule fois lors de l'enregistrement du webhook (`SaveWebhookUseCase`).
- La route `talentsoft_webhook` route désormais vers la bonne tâche en se basant sur `webhook.action_type` stocké en base, au lieu de recalculer `should_archive` / `should_save_raw_offer` dans la tâche.
- Ajoute la migration Alembic correspondante (`add_action_type_to_webhooks`).
- Met à jour les tests unitaires et de présentation impactés.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
