### PR TITLE
♻️(ddd-domain) simplify domain events interface

### DIFF
--- a/libs/ddd/aggregate_root.py
+++ b/libs/ddd/aggregate_root.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from functools import wraps
 from typing import Callable
 
-from ddd.domain_event import DomainEvent, DomainEventMetadata
+from ddd.domain_event import DomainEvent
 from ddd.entity import Entity
 
 
@@ -59,16 +59,11 @@ class AggregateRoot(Entity):
                 )
 
     def add_event(self, event: DomainEvent) -> None:
-        enriched = replace(
-            event,
-            metadata=DomainEventMetadata(
-                aggregate_id=self.entity_id,
-                aggregate=self.__class__.__name__,
-                event_name=event.__class__.__name__,
-                bounded_context=self.__module__,
-            ),
-        )
-        self._pending_events.append(enriched)
+        if not isinstance(event, DomainEvent):
+            raise TypeError(
+                f"add_event() expected a DomainEvent, got {type(event).__name__}."
+            )
+        self._pending_events.append(event)
 
     def collect_events(self) -> list[DomainEvent]:
         events = list(self._pending_events)
@@ -81,15 +76,14 @@ class AggregateRoot(Entity):
 def factory(event_type: type) -> Callable:
     def decorator(method: Callable) -> Callable:
         @wraps(method)
-        def wrapper(
-            cls: type, event: DomainEvent, *args: object, **kwargs: object
-        ) -> "AggregateRoot":
-            if not isinstance(event, event_type):
-                raise TypeError(
-                    f"{method.__name__}() expected {event_type.__name__}, "
-                    f"got {type(event).__name__}."
-                )
-            instance: AggregateRoot = method(cls, event, *args, **kwargs)
+        def wrapper(cls: type, **kwargs: object) -> "AggregateRoot":
+            instance: AggregateRoot = method(cls, **kwargs)
+            event = event_type(
+                aggregate_id=instance.entity_id,
+                aggregate=cls.__name__,
+                event_name=event_type.__name__,
+                **kwargs,
+            )
             instance.add_event(event)
             return instance
 
@@ -102,13 +96,14 @@ def factory(event_type: type) -> Callable:
 def mutate(event_type: type) -> Callable:
     def decorator(method: Callable) -> Callable:
         @wraps(method)
-        def wrapper(self: "AggregateRoot", event: DomainEvent, *args, **kwargs) -> None:
-            if not isinstance(event, event_type):
-                raise TypeError(
-                    f"{method.__name__}() expected {event_type.__name__}, "
-                    f"got {type(event).__name__}."
-                )
-            method(self, event, *args, **kwargs)
+        def wrapper(self: "AggregateRoot", **kwargs: object) -> None:
+            method(self, **kwargs)
+            event = event_type(
+                aggregate_id=self.entity_id,
+                aggregate=self.__class__.__name__,
+                event_name=event_type.__name__,
+                **kwargs,
+            )
             self.add_event(event)
 
         wrapper.__is_mutation__ = True  # type: ignore[attr-defined]

--- a/libs/ddd/aggregate_root.py
+++ b/libs/ddd/aggregate_root.py
@@ -1,9 +1,27 @@
+import dataclasses
+import inspect
 from dataclasses import dataclass, field
 from functools import wraps
 from typing import Callable
 
 from ddd.domain_event import DomainEvent
 from ddd.entity import Entity
+
+_BASE_EVENT_FIELDS = frozenset(f.name for f in dataclasses.fields(DomainEvent))
+
+
+def _check_payload_coverage(event_type: type, method: Callable, exclude: str) -> None:
+    required_payload = {
+        f.name
+        for f in dataclasses.fields(event_type)
+        if f.name not in _BASE_EVENT_FIELDS
+        and f.default is dataclasses.MISSING
+        and f.default_factory is dataclasses.MISSING  # type: ignore[misc]
+    }
+    method_params = set(inspect.signature(method).parameters) - {exclude}
+    missing = required_payload - method_params
+    if missing:
+        raise TypeError(f"{method.__name__}() miss event required fields")
 
 
 @dataclass(kw_only=True)
@@ -75,6 +93,8 @@ class AggregateRoot(Entity):
 # @factory does not allow for that
 def factory(event_type: type) -> Callable:
     def decorator(method: Callable) -> Callable:
+        _check_payload_coverage(event_type, method, exclude="cls")
+
         @wraps(method)
         def wrapper(cls: type, **kwargs: object) -> "AggregateRoot":
             instance: AggregateRoot = method(cls, **kwargs)
@@ -95,6 +115,8 @@ def factory(event_type: type) -> Callable:
 
 def mutate(event_type: type) -> Callable:
     def decorator(method: Callable) -> Callable:
+        _check_payload_coverage(event_type, method, exclude="self")
+
         @wraps(method)
         def wrapper(self: "AggregateRoot", **kwargs: object) -> None:
             method(self, **kwargs)

--- a/libs/ddd/domain_event.py
+++ b/libs/ddd/domain_event.py
@@ -4,16 +4,9 @@ from uuid import UUID, uuid4
 
 
 @dataclass(frozen=True, kw_only=True)
-class DomainEventMetadata:
-    aggregate_id: UUID
-    aggregate: str
-    event_name: str
-    bounded_context: str | None = None
-    version: int = 1
-
-
-@dataclass(frozen=True, kw_only=True)
 class DomainEvent:
     event_id: UUID = field(default_factory=uuid4)
     occurred_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
-    metadata: DomainEventMetadata | None = field(default=None)
+    aggregate_id: UUID
+    aggregate: str
+    event_name: str

--- a/libs/ddd/pyproject.toml
+++ b/libs/ddd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ddd"
-version = "0.1.2"
+version = "0.2.0"
 description = "Pure technical DDD scaffolding — AggregateRoot, DomainEvent, Entity, decorators and interfaces"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/ddd/tests/example_aggregate.py
+++ b/libs/ddd/tests/example_aggregate.py
@@ -4,12 +4,12 @@ from ddd.aggregate_root import AggregateRoot, factory, mutate, query
 from ddd.domain_event import DomainEvent
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ExampleAggregateCree(DomainEvent):
     name: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ExampleAggregateRenomme(DomainEvent):
     new_name: str
 
@@ -20,16 +20,16 @@ class ExampleAggregate(AggregateRoot):
 
     @classmethod
     @factory(ExampleAggregateCree)
-    def create(cls, event: ExampleAggregateCree) -> "ExampleAggregate":
-        return cls(_name=event.name)
+    def create(cls, name: str) -> "ExampleAggregate":
+        return cls(_name=name)
 
     @classmethod
     def build(cls, name: str) -> "ExampleAggregate":
         return cls(_name=name)
 
     @mutate(ExampleAggregateRenomme)
-    def rename(self, event: ExampleAggregateRenomme) -> None:
-        self._name = event.new_name
+    def rename(self, new_name: str) -> None:
+        self._name = new_name
 
     @query
     def name_starts_with(self, prefix: str) -> bool:

--- a/libs/ddd/tests/test_aggregate_root.py
+++ b/libs/ddd/tests/test_aggregate_root.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 
 import pytest
 
-from ddd.aggregate_root import AggregateRoot
+from ddd.aggregate_root import AggregateRoot, factory
+from ddd.domain_event import DomainEvent
 from tests.example_aggregate import (
     ExampleAggregate,
     ExampleAggregateCree,
@@ -132,3 +133,18 @@ def test_add_event_rejects_non_domain_event():
     example = ExampleAggregateFactory.build()
     with pytest.raises(TypeError, match="expected a DomainEvent"):
         example.add_event("not_an_event")  # type: ignore[arg-type]
+
+
+def test_factory_missing_required_payload_param_raises():
+    @dataclass(frozen=True, kw_only=True)
+    class _Event(DomainEvent):
+        required_field: str
+
+    with pytest.raises(TypeError, match="miss event required field"):
+
+        @dataclass(kw_only=True)
+        class _BadAggregate(AggregateRoot):
+            @classmethod
+            @factory(_Event)
+            def create(cls) -> "_BadAggregate":  # type: ignore[override]
+                return cls()

--- a/libs/ddd/tests/test_aggregate_root.py
+++ b/libs/ddd/tests/test_aggregate_root.py
@@ -3,18 +3,12 @@ from dataclasses import dataclass
 import pytest
 
 from ddd.aggregate_root import AggregateRoot
-from ddd.domain_event import DomainEvent
 from tests.example_aggregate import (
     ExampleAggregate,
     ExampleAggregateCree,
     ExampleAggregateRenomme,
 )
 from tests.example_aggregate_factory import ExampleAggregateFactory
-
-
-@dataclass(frozen=True)
-class _UnknownDomainEvent(DomainEvent):
-    pass
 
 
 def test_build_produces_no_pending_events():
@@ -24,17 +18,20 @@ def test_build_produces_no_pending_events():
 
 def test_mutate_applies_state_change_and_emits_event():
     example = ExampleAggregateFactory.build(name="Initial")
-    example.rename(ExampleAggregateRenomme(new_name="Updated"))
+    example.rename(new_name="Updated")
     events = example.collect_events()
     assert len(events) == 1
     assert isinstance(events[0], ExampleAggregateRenomme)
     assert example.name == "Updated"
 
 
-def test_mutate_with_wrong_event_type_raises():
-    example = ExampleAggregateFactory.build()
-    with pytest.raises(TypeError, match="expected ExampleAggregateRenomme"):
-        example.rename(_UnknownDomainEvent())  # type: ignore[arg-type]
+def test_mutate_enriches_event_with_aggregate_context():
+    example = ExampleAggregateFactory.build(name="Initial")
+    example.rename(new_name="Updated")
+    event = example.collect_events()[0]
+    assert event.aggregate_id == example.entity_id
+    assert event.aggregate == "ExampleAggregate"
+    assert event.event_name == "ExampleAggregateRenomme"
 
 
 def test_public_method_without_decorator_raises():
@@ -59,17 +56,20 @@ def test_create_properties_are_read_only():
 
 
 def test_factory_emits_event_automatically():
-    event = ExampleAggregateCree(name="Nouveau")
-    example = ExampleAggregate.create(event)
+    example = ExampleAggregate.create(name="Nouveau")
     events = example.collect_events()
     assert len(events) == 1
     assert isinstance(events[0], ExampleAggregateCree)
     assert example.name == "Nouveau"
 
 
-def test_factory_with_wrong_event_type_raises():
-    with pytest.raises(TypeError, match="expected ExampleAggregateCree"):
-        ExampleAggregate.create(_UnknownDomainEvent())  # type: ignore[arg-type]
+def test_factory_enriches_event_with_aggregate_context():
+    example = ExampleAggregate.create(name="Nouveau")
+    event = example.collect_events()[0]
+    assert event.aggregate_id == example.entity_id
+    assert event.aggregate == "ExampleAggregate"
+    assert event.event_name == "ExampleAggregateCree"
+    assert event.name == "Nouveau"
 
 
 def test_create_without_factory_decorator_raises():
@@ -126,3 +126,9 @@ def test_public_non_callable_class_attribute_is_allowed():
         MAX_SIZE = 100
 
     assert AggregateWithConstant.MAX_SIZE == 100  # noqa
+
+
+def test_add_event_rejects_non_domain_event():
+    example = ExampleAggregateFactory.build()
+    with pytest.raises(TypeError, match="expected a DomainEvent"):
+        example.add_event("not_an_event")  # type: ignore[arg-type]

--- a/libs/ddd/uv.lock
+++ b/libs/ddd/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "ddd"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.1.4"
+version = "0.1.5"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "ddd"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "../ddd" }
 
 [package.metadata]
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -363,7 +363,7 @@ wheels = [
 
 [[package]]
 name = "ddd"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "../../libs/ddd" }
 
 [package.metadata]
@@ -1249,7 +1249,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/application/candidate/usecases/submit_application.py
+++ b/src/web/application/candidate/usecases/submit_application.py
@@ -5,10 +5,6 @@ from application.candidate.commands.submit_application_command import (
     SubmitApplicationCommand,
 )
 from domain.candidate.entities.candidature import Candidature
-from domain.candidate.events.candidature_events import (
-    CandidatureSoumise,
-    DossierCandidatureInitialise,
-)
 from domain.candidate.exceptions.candidature_errors import (
     CandidatureNexistePas,
 )
@@ -52,13 +48,14 @@ class SubmitApplicationUsecase(
         except CandidatureNexistePas as e:
             self.logger.info(e.message)
             candidature = Candidature.create(
-                DossierCandidatureInitialise(offre_id, candidat_id)
+                offre_id=offre_id,
+                candidat_id=candidat_id,
             )
         # todo entity document
         # add document gate way and repository here
         # candidature.deposer_documents(DocumentsDeposes())
 
-        candidature.soumettre_candidature(CandidatureSoumise())
+        candidature.soumettre_candidature()
         self.candidature_repository.save(candidature)
 
         # todo: collect_events => save in audit logs

--- a/src/web/application/identite/usecases/create_agent.py
+++ b/src/web/application/identite/usecases/create_agent.py
@@ -6,7 +6,6 @@ from domain.identite.entities.agent import Agent
 from domain.identite.entities.utilisateurs import Utilisateur
 from domain.identite.errors.agent_errors import ProfilAgentExisteDeja
 from domain.identite.errors.identite_errors import UtilisateurNexistePas
-from domain.identite.events.agent_events import ProfilAgentCree
 from domain.identite.repositories.agent_repository_interface import IAgentRepository
 from domain.identite.repositories.utilisateur_repository_interface import (
     IUtilisateurRepository,
@@ -35,25 +34,23 @@ class CreateAgentUsecase:
         if existing is not None:
             raise ProfilAgentExisteDeja(input_data.email)
 
-        event = ProfilAgentCree(
+        try:
+            utilisateur = self.utilisateur_repository.get_by_email(input_data.email)
+        except UtilisateurNexistePas:
+            utilisateur = self.utilisateur_repository.create(
+                Utilisateur(
+                    email=input_data.email,
+                    prenom=input_data.prenom,
+                    nom=input_data.nom,
+                )
+            )
+
+        agent = Agent.create(
             email=input_data.email,
             prenom=input_data.prenom,
             nom=input_data.nom,
             intitule_poste=input_data.intitule_poste,
+            user_id=utilisateur.entity_id,
         )
-
-        try:
-            utilisateur = self.utilisateur_repository.get_by_email(input_data.email)
-            agent = Agent.create(event, entity_id=utilisateur.entity_id)
-        except UtilisateurNexistePas:
-            agent = Agent.create(event)
-            utilisateur = self.utilisateur_repository.create(
-                Utilisateur(
-                    entity_id=agent.entity_id,
-                    email=agent.email,
-                    prenom=agent.prenom,
-                    nom=agent.nom,
-                )
-            )
 
         return self.agent_repository.create(utilisateur, agent)

--- a/src/web/application/identite/usecases/create_candidat.py
+++ b/src/web/application/identite/usecases/create_candidat.py
@@ -6,7 +6,6 @@ from domain.identite.entities.candidat import Candidat
 from domain.identite.entities.utilisateurs import Utilisateur
 from domain.identite.errors.candidat_errors import ProfilCandidatExisteDeja
 from domain.identite.errors.identite_errors import UtilisateurNexistePas
-from domain.identite.events.candidat_events import ProfilCandidatCree
 from domain.identite.repositories.candidat_repository_interface import (
     ICandidatRepository,
 )
@@ -37,25 +36,23 @@ class CreateCandidatUsecase:
         if existing is not None:
             raise ProfilCandidatExisteDeja(input_data.email)
 
-        event = ProfilCandidatCree(
+        try:
+            utilisateur = self.utilisateur_repository.get_by_email(input_data.email)
+        except UtilisateurNexistePas:
+            utilisateur = self.utilisateur_repository.create(
+                Utilisateur(
+                    email=input_data.email,
+                    prenom=input_data.prenom,
+                    nom=input_data.nom,
+                )
+            )
+
+        candidat = Candidat.create(
             email=input_data.email,
             prenom=input_data.prenom,
             nom=input_data.nom,
             resume=input_data.resume,
+            user_id=utilisateur.entity_id,
         )
-
-        try:
-            utilisateur = self.utilisateur_repository.get_by_email(input_data.email)
-            candidat = Candidat.create(event, entity_id=utilisateur.entity_id)
-        except UtilisateurNexistePas:
-            candidat = Candidat.create(event)
-            utilisateur = self.utilisateur_repository.create(
-                Utilisateur(
-                    entity_id=candidat.entity_id,
-                    email=candidat.email,
-                    prenom=candidat.prenom,
-                    nom=candidat.nom,
-                )
-            )
 
         return self.candidat_repository.create(utilisateur, candidat)

--- a/src/web/domain/candidate/entities/candidature.py
+++ b/src/web/domain/candidate/entities/candidature.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from ddd.aggregate_root import AggregateRoot, factory, mutate
@@ -27,13 +27,12 @@ class Candidature(AggregateRoot):
 
     @classmethod
     @factory(DossierCandidatureInitialise)
-    def create(cls, event: DossierCandidatureInitialise) -> "Candidature":
-        # deduplicate
+    def create(cls, offre_id: UUID, candidat_id: UUID) -> "Candidature":
         return cls(
-            _candidat_id=event.candidat_id,
-            _offre_id=event.offre_id,
+            _candidat_id=candidat_id,
+            _offre_id=offre_id,
             _statut=StatutCandidature.INITIAL,
-            _mise_a_jour_le=event.occurred_at,
+            _mise_a_jour_le=datetime.now(tz=timezone.utc),
         )
 
     @classmethod
@@ -83,19 +82,19 @@ class Candidature(AggregateRoot):
         return self._mise_a_jour_le
 
     @mutate(DocumentsDeposes)
-    def deposer_documents(self, event: DocumentsDeposes) -> None:
-        if len(event.documents) == 0:
+    def deposer_documents(self, documents: tuple[UUID, ...]) -> None:
+        if len(documents) == 0:
             raise DossierCandidatureInvalide(
-                ("Le dossier de candidature doit contenir au moins un document")
+                "Le dossier de candidature doit contenir au moins un document"
             )
-        else:
-            self._documents = event.documents
-            self._mise_a_jour_le = event.occurred_at
+        self._documents = documents
+        self._mise_a_jour_le = datetime.now(tz=timezone.utc)
 
     @mutate(CandidatureSoumise)
-    def soumettre_candidature(self, event: CandidatureSoumise) -> None:
+    def soumettre_candidature(self) -> None:
         if self._statut == StatutCandidature.SOUMISE:
             raise CandidatureDejaSoumise(self.candidat_id, self.offre_id)
         self._statut = StatutCandidature.SOUMISE
-        self._soumise_le = event.occurred_at
-        self._mise_a_jour_le = event.occurred_at
+        now = datetime.now(tz=timezone.utc)
+        self._soumise_le = now
+        self._mise_a_jour_le = now

--- a/src/web/domain/identite/entities/agent.py
+++ b/src/web/domain/identite/entities/agent.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from ddd.aggregate_root import AggregateRoot, factory
 from pydantic import EmailStr
@@ -16,13 +16,20 @@ class Agent(AggregateRoot):
 
     @classmethod
     @factory(ProfilAgentCree)
-    def create(cls, event: ProfilAgentCree, entity_id: UUID | None = None) -> "Agent":
+    def create(
+        cls,
+        email: EmailStr,
+        prenom: str,
+        nom: str,
+        intitule_poste: str,
+        user_id: UUID,
+    ) -> "Agent":
         return cls(
-            entity_id=entity_id or uuid4(),
-            _email=event.email,
-            _prenom=event.prenom,
-            _nom=event.nom,
-            _intitule_poste=event.intitule_poste,
+            entity_id=user_id,
+            _email=email,
+            _prenom=prenom,
+            _nom=nom,
+            _intitule_poste=intitule_poste,
         )
 
     @classmethod

--- a/src/web/domain/identite/entities/candidat.py
+++ b/src/web/domain/identite/entities/candidat.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from ddd.aggregate_root import AggregateRoot, factory
 from pydantic import EmailStr
@@ -17,14 +17,19 @@ class Candidat(AggregateRoot):
     @classmethod
     @factory(ProfilCandidatCree)
     def create(
-        cls, event: ProfilCandidatCree, entity_id: UUID | None = None
+        cls,
+        email: EmailStr,
+        prenom: str,
+        nom: str,
+        resume: str,
+        user_id: UUID,
     ) -> "Candidat":
         return cls(
-            entity_id=entity_id or uuid4(),
-            _email=event.email,
-            _prenom=event.prenom,
-            _nom=event.nom,
-            _resume=event.resume,
+            entity_id=user_id,
+            _email=email,
+            _prenom=prenom,
+            _nom=nom,
+            _resume=resume,
         )
 
     @classmethod

--- a/src/web/domain/identite/entities/organisme.py
+++ b/src/web/domain/identite/entities/organisme.py
@@ -58,11 +58,18 @@ class Organisme(AggregateRoot):
 
     @classmethod
     @factory(OrganismeCree)
-    def create(cls, event: OrganismeCree) -> "Organisme":
+    def create(
+        cls,
+        nom: str,
+        versant: Verse,
+        localisation: Localisation | None,
+        siret: SIRET | None,
+        parent_id: UUID | None,
+    ) -> "Organisme":
         return cls(
-            _nom=event.nom,
-            _versant=event.versant,
-            _localisation=event.localisation,
-            _siret=event.siret,
-            _parent_id=event.parent_id,
+            _nom=nom,
+            _versant=versant,
+            _localisation=localisation,
+            _siret=siret,
+            _parent_id=parent_id,
         )

--- a/src/web/domain/identite/events/agent_events.py
+++ b/src/web/domain/identite/events/agent_events.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from uuid import UUID
 
 from ddd.domain_event import DomainEvent
 from pydantic import EmailStr
@@ -10,3 +11,4 @@ class ProfilAgentCree(DomainEvent):
     prenom: str
     nom: str
     intitule_poste: str
+    user_id: UUID

--- a/src/web/domain/identite/events/candidat_events.py
+++ b/src/web/domain/identite/events/candidat_events.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from uuid import UUID
 
 from ddd.domain_event import DomainEvent
 from pydantic import EmailStr
@@ -10,3 +11,4 @@ class ProfilCandidatCree(DomainEvent):
     prenom: str
     nom: str
     resume: str
+    user_id: UUID

--- a/src/web/domain/recruteur/entities/organisme.py
+++ b/src/web/domain/recruteur/entities/organisme.py
@@ -28,9 +28,9 @@ class Organisme(AggregateRoot):
         return self._parametres
 
     @mutate(OrganismeParametresInitialises)
-    def initialiser_parametres(self, event: OrganismeParametresInitialises) -> None:
-        self._parametres = event.parametres
+    def initialiser_parametres(self, parametres: EtapesRecrutement) -> None:
+        self._parametres = parametres
 
     @mutate(OrganismeParametresModifies)
-    def modifier_parametres(self, event: OrganismeParametresModifies) -> None:
-        self._parametres = event.parametres
+    def modifier_parametres(self, parametres: EtapesRecrutement) -> None:
+        self._parametres = parametres

--- a/src/web/pyproject.toml
+++ b/src/web/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
   "pytest-httpx>=0.35.0",
   "responses>=0.25.8",
   "ruff>=0.14.3",
+  "time-machine>=2.16.0",
   "types-requests>=2.32.4.20250913",
   "types-python-dateutil>=2.9.0.20260124",
 ]

--- a/src/web/tests/domain/candidate/test_candidature.py
+++ b/src/web/tests/domain/candidate/test_candidature.py
@@ -1,6 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
+import time_machine
 
 from domain.candidate.entities.candidature import Candidature
 from domain.candidate.events.candidature_events import (
@@ -18,14 +19,14 @@ from tests.factories.candidate.candidature_factory import (
     make_documents,
 )
 
+_FROZEN_TS = datetime(2025, 6, 18, 10, 0, 0, tzinfo=timezone.utc)
+
 
 def test_dossier_candidature_cree():
     candidature_factory = CandidatureFactory.build()
     candidature = Candidature.create(
-        DossierCandidatureInitialise(
-            candidat_id=candidature_factory.candidat_id,
-            offre_id=candidature_factory.offre_id,
-        )
+        offre_id=candidature_factory.offre_id,
+        candidat_id=candidature_factory.candidat_id,
     )
     events = candidature.collect_events()
     assert len(events) == 1
@@ -33,48 +34,43 @@ def test_dossier_candidature_cree():
     assert candidature.statut == StatutCandidature.INITIAL
 
 
+@time_machine.travel(_FROZEN_TS, tick=False)
 def test_documents_deposes():
     documents = make_documents()
     candidature_factory = CandidatureFactory.build(documents=documents)
-    ts = datetime.now()
-    candidature_factory.deposer_documents(
-        DocumentsDeposes(documents=documents, occurred_at=ts)
-    )
+    candidature_factory.deposer_documents(documents=documents)
     events = candidature_factory.collect_events()
     assert len(events) == 1
     assert isinstance(events[0], DocumentsDeposes)
     assert candidature_factory.documents == documents
-    assert candidature_factory.mise_a_jour_le == ts
+    assert candidature_factory.mise_a_jour_le == _FROZEN_TS
 
 
 def test_candidature_invalide():
     candidature_factory = CandidatureFactory.build()
     with pytest.raises(DossierCandidatureInvalide):
-        candidature_factory.deposer_documents(DocumentsDeposes(documents=()))
+        candidature_factory.deposer_documents(documents=())
     events = candidature_factory.collect_events()
     assert len(events) == 0
 
 
+@time_machine.travel(_FROZEN_TS, tick=False)
 def test_candidature_soumise():
     candidature_factory = CandidatureFactory.build()
     documents = make_documents()
-    candidature_factory.deposer_documents(DocumentsDeposes(documents=documents))
-    ts = datetime.now()
-    candidature_factory.soumettre_candidature(
-        CandidatureSoumise(
-            occurred_at=ts,
-        )
-    )
+    candidature_factory.deposer_documents(documents=documents)
+    candidature_factory.soumettre_candidature()
     events = candidature_factory.collect_events()
     assert len(events) == 2  # noqa
     assert isinstance(events[1], CandidatureSoumise)
     assert candidature_factory.statut == StatutCandidature.SOUMISE
-    assert candidature_factory.soumise_le == ts
+    assert candidature_factory.soumise_le == _FROZEN_TS
+    assert candidature_factory.mise_a_jour_le == _FROZEN_TS
 
 
 def test_candidature_deja_soumise():
     candidature_factory = CandidatureFactory.build(statut=StatutCandidature.SOUMISE)
     with pytest.raises(CandidatureDejaSoumise):
-        candidature_factory.soumettre_candidature(CandidatureSoumise())
+        candidature_factory.soumettre_candidature()
     events = candidature_factory.collect_events()
     assert len(events) == 0

--- a/src/web/tests/domain/identite/test_agent.py
+++ b/src/web/tests/domain/identite/test_agent.py
@@ -1,36 +1,30 @@
 from uuid import UUID, uuid4
 
-import pytest
 from faker import Faker
 
 from domain.identite.entities.agent import Agent
 from domain.identite.events.agent_events import ProfilAgentCree
 
 fake = Faker()
-_FIXED_ID = uuid4()
 
 
-@pytest.mark.parametrize(
-    "entity_id",
-    [pytest.param(None, id="generated"), pytest.param(_FIXED_ID, id="provided")],
-)
-def test_create(entity_id):
-    event = ProfilAgentCree(
+def test_create():
+    user_id = uuid4()
+    agent = Agent.create(
         email=fake.email(),
         prenom=fake.first_name(),
         nom=fake.last_name(),
         intitule_poste=fake.word(),
+        user_id=user_id,
     )
 
-    agent = Agent.create(event, entity_id=entity_id)
-
     assert isinstance(agent.entity_id, UUID)
-    if entity_id is not None:
-        assert agent.entity_id == entity_id
+    assert agent.entity_id == user_id
 
     events = agent.collect_events()
     assert len(events) == 1
     assert isinstance(events[0], ProfilAgentCree)
+    assert events[0].user_id == user_id
 
 
 def test_build():

--- a/src/web/tests/domain/identite/test_candidat.py
+++ b/src/web/tests/domain/identite/test_candidat.py
@@ -1,36 +1,30 @@
 from uuid import UUID, uuid4
 
-import pytest
 from faker import Faker
 
 from domain.identite.entities.candidat import Candidat
 from domain.identite.events.candidat_events import ProfilCandidatCree
 
 fake = Faker()
-_FIXED_ID = uuid4()
 
 
-@pytest.mark.parametrize(
-    "entity_id",
-    [pytest.param(None, id="generated"), pytest.param(_FIXED_ID, id="provided")],
-)
-def test_create(entity_id):
-    event = ProfilCandidatCree(
+def test_create():
+    user_id = uuid4()
+    candidat = Candidat.create(
         email=fake.email(),
         prenom=fake.first_name(),
         nom=fake.last_name(),
         resume=fake.text(max_nb_chars=200),
+        user_id=user_id,
     )
 
-    candidat = Candidat.create(event, entity_id=entity_id)
-
     assert isinstance(candidat.entity_id, UUID)
-    if entity_id is not None:
-        assert candidat.entity_id == entity_id
+    assert candidat.entity_id == user_id
 
     events = candidat.collect_events()
     assert len(events) == 1
     assert isinstance(events[0], ProfilCandidatCree)
+    assert events[0].user_id == user_id
 
 
 def test_build():

--- a/src/web/tests/domain/identite/test_organisme_identite.py
+++ b/src/web/tests/domain/identite/test_organisme_identite.py
@@ -1,9 +1,7 @@
 from referentiel.value_objects.verse import Verse
 
 from domain.identite.entities.organisme import Organisme
-from domain.identite.events.organisme_events import (
-    OrganismeCree,
-)
+from domain.identite.events.organisme_events import OrganismeCree
 from domain.identite.value_objects.siret import SIRET
 from tests.factories.identite.organisme_factory import OrganismeFactory
 
@@ -16,13 +14,11 @@ def test_organisme_creation():
         )
     )
     organisme = Organisme.create(
-        OrganismeCree(
-            nom="Ecole du Louvre",
-            versant=Verse.FPE,
-            localisation=parent_organisme.localisation,
-            siret=SIRET("19754687200015"),
-            parent_id=parent_organisme.entity_id,
-        )
+        nom="Ecole du Louvre",
+        versant=Verse.FPE,
+        localisation=parent_organisme.localisation,
+        siret=SIRET("19754687200015"),
+        parent_id=parent_organisme.entity_id,
     )
     assert organisme.nom == "Ecole du Louvre"
     assert organisme.versant == Verse.FPE

--- a/src/web/tests/domain/recruteur/test_organisme.py
+++ b/src/web/tests/domain/recruteur/test_organisme.py
@@ -7,9 +7,7 @@ from tests.factories.recruteur.organisme_factory import OrganismeFactory
 
 def test_organisme_parametres_initialises():
     organisme = OrganismeFactory.build()
-    organisme.initialiser_parametres(
-        OrganismeParametresInitialises(parametres=organisme.parametres)
-    )
+    organisme.initialiser_parametres(parametres=organisme.parametres)
     events = organisme.collect_events()
     assert len(events) == 1
     assert isinstance(events[0], OrganismeParametresInitialises)
@@ -17,9 +15,7 @@ def test_organisme_parametres_initialises():
 
 def test_organisme_configuration_modifiee():
     organisme = OrganismeFactory.build()
-    organisme.modifier_parametres(
-        OrganismeParametresModifies(parametres=organisme.parametres)
-    )
+    organisme.modifier_parametres(parametres=organisme.parametres)
     events = organisme.collect_events()
     assert len(events) == 1
     assert isinstance(events[0], OrganismeParametresModifies)

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1410,6 +1410,25 @@ wheels = [
 ]
 
 [[package]]
+name = "time-machine"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/fc/37b02f6094dbb1f851145330460532176ed2f1dc70511a35828166c41e52/time_machine-3.2.0.tar.gz", hash = "sha256:a4ddd1cea17b8950e462d1805a42b20c81eb9aafc8f66b392dd5ce997e037d79", size = 14804, upload-time = "2025-12-17T23:33:02.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/8b/080c8eedcd67921a52ba5bd0e075362062509ab63c86fc1a0442fad241a6/time_machine-3.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cc4bee5b0214d7dc4ebc91f4a4c600f1a598e9b5606ac751f42cb6f6740b1dbb", size = 19255, upload-time = "2025-12-17T23:31:58.057Z" },
+    { url = "https://files.pythonhosted.org/packages/66/17/0e5291e9eb705bf8a5a1305f826e979af307bbeb79def4ddbf4b3f9a81e0/time_machine-3.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ca036304b4460ae2fdc1b52dd8b1fa7cf1464daa427fc49567413c09aa839c1", size = 15360, upload-time = "2025-12-17T23:31:59.048Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e8/9ab87b71d2e2b62463b9b058b7ae7ac09fb57f8fcd88729dec169d304340/time_machine-3.2.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5442735b41d7a2abc2f04579b4ca6047ed4698a8338a4fec92c7c9423e7938cb", size = 33029, upload-time = "2025-12-17T23:32:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/26/b5ca19da6f25ea905b3e10a0ea95d697c1aeba0404803a43c68f1af253e6/time_machine-3.2.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:97da3e971e505cb637079fb07ab0bcd36e33279f8ecac888ff131f45ef1e4d8d", size = 34579, upload-time = "2025-12-17T23:32:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ca/6ac7ad5f10ea18cc1d9de49716ba38c32132c7b64532430d92ef240c116b/time_machine-3.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3cdda6dee4966e38aeb487309bb414c6cb23a81fc500291c77a8fcd3098832e7", size = 35961, upload-time = "2025-12-17T23:32:02.521Z" },
+    { url = "https://files.pythonhosted.org/packages/33/67/390dd958bed395ab32d79a9fe61fe111825c0dd4ded54dbba7e867f171e6/time_machine-3.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:33d9efd302a6998bcc8baa4d84f259f8a4081105bd3d7f7af7f1d0abd3b1c8aa", size = 34668, upload-time = "2025-12-17T23:32:03.585Z" },
+    { url = "https://files.pythonhosted.org/packages/da/57/c88fff034a4e9538b3ae7c68c9cfb283670b14d17522c5a8bc17d29f9a4b/time_machine-3.2.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3a0b0a33971f14145853c9bd95a6ab0353cf7e0019fa2a7aa1ae9fddfe8eab50", size = 32891, upload-time = "2025-12-17T23:32:04.656Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/70/ebbb76022dba0fec8f9156540fc647e4beae1680c787c01b1b6200e56d70/time_machine-3.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2d0be9e5f22c38082d247a2cdcd8a936504e9db60b7b3606855fb39f299e9548", size = 34080, upload-time = "2025-12-17T23:32:06.146Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/2ca9e7af3df540dc1c79e3de588adeddb7dcc2107829248e6969c4f14167/time_machine-3.2.0-cp312-cp312-win32.whl", hash = "sha256:3f74623648b936fdce5f911caf386c0a0b579456410975de8c0dfeaaffece1d8", size = 17371, upload-time = "2025-12-17T23:32:07.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ce/21d23efc9c2151939af1b7ee4e60d86d661b74ef32b8eaa148f6fe8c899c/time_machine-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:34e26a41d994b5e4b205136a90e9578470386749cc9a2ecf51ca18f83ce25e23", size = 18132, upload-time = "2025-12-17T23:32:08.447Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/34/c2b70be483accf6db9e5d6c3139bce3c38fe51f898ccf64e8d3fe14fbf4d/time_machine-3.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:0615d3d82c418d6293f271c348945c5091a71f37e37173653d5c26d0e74b13a8", size = 16930, upload-time = "2025-12-17T23:32:09.477Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1553,6 +1572,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "time-machine" },
     { name = "types-python-dateutil" },
     { name = "types-requests" },
 ]
@@ -1608,6 +1628,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "responses", specifier = ">=0.25.8" },
     { name = "ruff", specifier = ">=0.14.3" },
+    { name = "time-machine", specifier = ">=2.16.0" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20260124" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
 ]

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -149,7 +149,7 @@ wheels = [
 
 [[package]]
 name = "ddd"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "../../libs/ddd" }
 
 [package.metadata]
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },


### PR DESCRIPTION
## 📝 Description
Simplification de l'interface des domain events en vue de cette [PR](https://github.com/betagouv/csplab/pull/738), comme discuté mardi et hier @vincentporte.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
- simplification de l'interface d'un domain event (plus de champs imbriqués dans metadatas).
- on en profite pour simplifier aussi l'implémentation des mutation dans un aggregate root : plus besoin de déclaré une domain event en plus de celui déclaré dans le decorator mutate.
- ajout d'une vérification de type sur les propriétés passées dans les méthodes de mutation de l'aggregate root: doivent contenir tous les champs obligatoires déclarés dans le domain event.
- refacto des aggregate root avec ce nouveau format (Candidat, Agent, Candidature, Organisme).

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
