### PR TITLE
✅(ingestion) couvrir le désarchivage d'une offre lors d'un upsert

### DIFF
--- a/src/web/tests/infrastructure/ingestion/test_upsert_offers.py
+++ b/src/web/tests/infrastructure/ingestion/test_upsert_offers.py
@@ -67,3 +67,38 @@ def test_upsert_offers_result(ingestion_container):
     for offer in [existing_offer, new_offer]:
         model = OfferModel.objects.get(external_id=offer.external_id)
         assert OfferModel.to_entity(model) == offer
+
+
+def test_upsert_offers_unarchives_offer_and_makes_it_eligible_for_reindexing(
+    ingestion_container,
+):
+    archived_offer = OfferFactory.create_model(
+        archived_at=datetime.now(),
+        processed_at=datetime.now() - relativedelta(days=1),
+        updated_at=datetime.now() - relativedelta(days=1),
+    )
+    assert archived_offer.archived_at is not None
+
+    # OffersInputSerializer never exposes archived_at, so a caller upserting
+    # an offer has no way to send it: the incoming entity always defaults to
+    # archived_at=None, regardless of the offer's current archived state.
+    existing_offer = OfferFactory.create_entity(
+        external_id=archived_offer.external_id,
+        reference=archived_offer.reference,
+        source_id=archived_offer.source_id,
+    )
+
+    input_data = UpsertOffersInput(
+        source_id=existing_offer.source_id, offers=[existing_offer]
+    )
+    result = ingestion_container.upsert_offers_usecase().execute(input_data=input_data)
+    assert result == {"created": 0, "updated": 1, "errors": []}
+
+    archived_offer.refresh_from_db()
+    assert archived_offer.archived_at is None
+
+    offers_repository = ingestion_container.offers_repository()
+    pending_offer_ids = {
+        offer.id for offer in offers_repository.get_pending_processing()
+    }
+    assert archived_offer.id in pending_offer_ids

--- a/src/web/tests/presentation/ingestion/test_serializers.py
+++ b/src/web/tests/presentation/ingestion/test_serializers.py
@@ -1,0 +1,14 @@
+from presentation.ingestion.serializers import OffersInputSerializer
+from tests.factories.ingestion.offer_payload_factory import PayloadOfferFactory
+
+
+def test_offers_input_serializer_never_exposes_archived_at():
+    assert "archived_at" not in OffersInputSerializer().fields
+
+    payload = PayloadOfferFactory.create(
+        identification={"reference": "REF-001", "versant": "FPT"},
+        archived_at="2024-01-01T00:00:00Z",
+    )
+    serializer = OffersInputSerializer(data=payload)
+    assert serializer.is_valid(), serializer.errors
+    assert "archived_at" not in serializer.validated_data


### PR DESCRIPTION
## 📝 Description

Ajoute une régression end-to-end confirmant qu'un upsert désarchive toujours une offre archivée et la rend à nouveau éligible à la réindexation Qdrant, ainsi qu'un test confirmant que l'API n'expose jamais archived_at en entrée.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
