### PR TITLE
🐛(tooling) fix installation paths for backup script

### DIFF
--- a/src/web/bin/backup-db-to-scaleway.sh
+++ b/src/web/bin/backup-db-to-scaleway.sh
@@ -31,8 +31,7 @@ install_scalingo_cli() {
     brew install scalingo
   else
     curl -fsSO https://cli-dl.scalingo.com/install
-    bash install
-    rm -f install
+    bash install -i $HOME/bin
   fi
 }
 
@@ -41,10 +40,10 @@ install_aws_cli() {
   if [[ "$(uname -s)" == "Darwin" ]] && command -v brew &>/dev/null; then
     brew install awscli
   else
-    local zip="$WORKDIR/awscliv2.zip"
+    local zip="$HOME/awscliv2.zip"
     curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "$zip"
-    unzip -q "$zip" -d "$WORKDIR"
-    "$WORKDIR/aws/install" --update
+    unzip -q "$zip" -d "$HOME"
+    "$HOME/aws/install" -i "$HOME/aws-cli" -b "$HOME/bin"
   fi
 }
 
@@ -58,8 +57,12 @@ done
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
 
+mkdir -p "$HOME/bin"
+export PATH="$PATH:$HOME/bin"
+
 command -v scalingo &>/dev/null || install_scalingo_cli
 command -v aws &>/dev/null || install_aws_cli
+
 
 scalingo login --api-token "$SCALINGO_API_TOKEN"
 


### PR DESCRIPTION
## 📝 Description

Suite de #833 

L'installation de `scalingo` et de `aws` échouaient sur le container one-off exécuté en cronn sur Scalingo car :
- il fallait avoir `sudo` pour `scalingo`
- il fallait pouvoir écrire dans `/usr/local` pour `aws`


👉 Revois les chemins d'installation pour écrire dans `$HOME/bin` à la place.


## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
