### PR TITLE
🔧(tooling-admin) désactiver le TOTP en mode dev

### DIFF
--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -67,6 +67,11 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 # ---------------------------------------
 X_FRAME_OPTIONS = "DENY"
 
+# Admin
+# ---------------------------------------
+# Require a verified TOTP device to log into the Django admin.
+ADMIN_OTP_REQUIRED = True
+
 # Application definition
 
 

--- a/src/web/config/settings/dev.py
+++ b/src/web/config/settings/dev.py
@@ -45,6 +45,9 @@ STORAGES = {
 
 SENTRY_DNS = "example.com"
 
+# Allow logging into the admin with a plain superuser, without a TOTP device.
+ADMIN_OTP_REQUIRED = False
+
 HUEY["immediate"] = True  # noqa: F405
 HUEY["consumer"]["periodic"] = False  # noqa: F405
 AUTH_PASSWORD_VALIDATORS = []

--- a/src/web/config/urls.py
+++ b/src/web/config/urls.py
@@ -12,7 +12,8 @@ from presentation.pages import urls as pages_urls
 from presentation.pages.views import security_txt
 from presentation.recruteur import urls as recruteur_urls
 
-admin.site.__class__ = OTPAdminSite
+if settings.ADMIN_OTP_REQUIRED:
+    admin.site.__class__ = OTPAdminSite
 
 urlpatterns: list[URLPattern | URLResolver] = [
     path(".well-known/security.txt", security_txt),

--- a/src/web/tests/presentation/ingestion/views/test_admin.py
+++ b/src/web/tests/presentation/ingestion/views/test_admin.py
@@ -1,10 +1,14 @@
 from http import HTTPStatus
 
+from django.conf import settings
+from django.contrib import admin
 from django.test import Client
+from django_otp.admin import OTPAdminSite
 from django_otp.middleware import is_verified
 from django_otp.oath import totp
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
+import config.urls  # noqa: F401  # imported for its side effect: runs the OTPAdminSite swap
 from tests.factories.identite.utilisateur_factory import (
     DEFAULT_PASSWORD,
     UtilisateurFactory,
@@ -12,6 +16,10 @@ from tests.factories.identite.utilisateur_factory import (
 
 
 class TestAdminOTPRequired:
+    def test_admin_otp_required_by_default(self):
+        assert settings.ADMIN_OTP_REQUIRED is True
+        assert isinstance(admin.site, OTPAdminSite)
+
     def test_admin_shows_totp_input_for_staff_without_otp_device(
         self, db, client: Client
     ):


### PR DESCRIPTION
## 📝 Description
🎸 En mode dev, la connexion au Django admin n'exige plus de dispositif TOTP : un superutilisateur peut se connecter avec son identifiant et son mot de passe. Le comportement reste inchangé en production : l'OTP demeure obligatoire.

Le swap `admin.site.__class__ = OTPAdminSite` est désormais conditionné par un nouveau réglage `ADMIN_OTP_REQUIRED` (sécurisé par défaut : `True` dans `base`, surchargé à `False` uniquement dans `dev`).

## 🏷️ Type de changement
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__
- `config/settings/base.py` : ajout du réglage `ADMIN_OTP_REQUIRED = True` (valeur sécurisée par défaut).
- `config/settings/dev.py` : surcharge `ADMIN_OTP_REQUIRED = False`.
- `config/urls.py` : le passage de l'admin en `OTPAdminSite` n'est appliqué que si `ADMIN_OTP_REQUIRED` est actif.
- `tests/presentation/ingestion/views/test_admin.py` : ajout d'un test vérifiant que l'OTP est bien actif par défaut.

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__
1. Lancer le service avec les réglages de dev : `make run-web`.
2. Se connecter à `/admin/` avec un superutilisateur (`bin/manage createsuperuser` au besoin) : aucun champ de jeton TOTP n'est demandé.
3. Vérifier qu'en réglages par défaut l'OTP reste exigé : `make test-web ARGS="tests/presentation/ingestion/views/test_admin.py"`.

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.