### PR TITLE
🔧(tooling) Sécuriser le déploiement Scalingo en fixant explicitement `DJANGO_SETTINGS_MODULE` dans les scripts  de démarrage

### DIFF
--- a/src/web/bin/postdeploy.sh
+++ b/src/web/bin/postdeploy.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings.base}"
 
 echo "🗃️ Apply new migrations"
 python3 manage.py migrate --noinput

--- a/src/web/bin/run_worker.sh
+++ b/src/web/bin/run_worker.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings.base}"
+
 # CONTAINER is set by Scalingo with format "worker-1", "worker-2", etc.
 INDEX="${CONTAINER##*-}"
 

--- a/src/web/bin/start.sh
+++ b/src/web/bin/start.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings.base}"
+
 echo "PRODUCTION mode activated."
 echo "📦 Collecting static files..."
 python manage.py collectstatic --noinput --clear


### PR DESCRIPTION
## 📝 Description
🎸 Sécurise le déploiement Scalingo en fixant explicitement `DJANGO_SETTINGS_MODULE` dans les scripts de démarrage. 

Possibilité : retirer ensuite la variable d'env `DJANGO_SETTINGS_MODULE` dans scalingo pour l'instance de prod et de démo

## 🏷️ Type de changement
- [x] 🔧 Changement technique

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.