### PR TITLE
🎨(web-presentation) harmonize trailing slash on routes

### DIFF
--- a/src/web/presentation/api/urls.py
+++ b/src/web/presentation/api/urls.py
@@ -9,8 +9,8 @@ from presentation.api.views import HueyHealthView, RedocView
 app_name = "api"
 
 urlpatterns = [
-    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
-    path("health/huey/", HueyHealthView.as_view(), name="health_huey"),
-    path("schema/redoc/", RedocView.as_view(), name="redoc"),
+    path("token", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("token/refresh", TokenRefreshView.as_view(), name="token_refresh"),
+    path("health/huey", HueyHealthView.as_view(), name="health_huey"),
+    path("schema/redoc", RedocView.as_view(), name="redoc"),
 ]

--- a/src/web/presentation/candidate/urls.py
+++ b/src/web/presentation/candidate/urls.py
@@ -10,19 +10,19 @@ from presentation.candidate.views.cv_flow import (
 app_name = "candidate"
 
 urlpatterns = [
-    path("cv-upload/", CVUploadView.as_view(), name="cv_upload"),
+    path("cv-upload", CVUploadView.as_view(), name="cv_upload"),
     path(
-        "cv/<uuid:cv_uuid>/results/",
+        "cv/<uuid:cv_uuid>/results",
         CVResultsView.as_view(),
         name="cv_results",
     ),
     path(
-        "cv/<uuid:cv_uuid>/offers/<uuid:offer_id>/detail/",
+        "cv/<uuid:cv_uuid>/offers/<uuid:offer_id>/detail",
         OfferDrawerView.as_view(),
         name="offer_drawer",
     ),
     path(
-        "cv/<uuid:cv_uuid>/concours/<uuid:concours_id>/detail/",
+        "cv/<uuid:cv_uuid>/concours/<uuid:concours_id>/detail",
         ConcoursDrawerView.as_view(),
         name="concours_drawer",
     ),

--- a/src/web/presentation/frontend/src/api/utilisateur.ts
+++ b/src/web/presentation/frontend/src/api/utilisateur.ts
@@ -4,5 +4,5 @@ import { http } from '@/utils/http'
 export type Utilisateur = components['schemas']['Utilisateur']
 
 export function getMe(): Promise<Utilisateur> {
-  return http.get('/utilisateur/me/')
+  return http.get('/utilisateur/me')
 }

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    "/recruteur/organisme/{organisme_uuid}/": {
+    "/recruteur/organisme/{organisme_uuid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -21,7 +21,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/recruteur/organisme/{organisme_uuid}/parametres/etapes/": {
+    "/recruteur/organisme/{organisme_uuid}/parametres/etapes": {
         parameters: {
             query?: never;
             header?: never;
@@ -39,7 +39,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/recruteur/organisme/{organisme_uuid}/parametres/etapes/init/": {
+    "/recruteur/organisme/{organisme_uuid}/parametres/etapes/init": {
         parameters: {
             query?: never;
             header?: never;
@@ -76,7 +76,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/utilisateur/me/": {
+    "/utilisateur/me": {
         parameters: {
             query?: never;
             header?: never;

--- a/src/web/presentation/frontend/src/utils/http.test.ts
+++ b/src/web/presentation/frontend/src/utils/http.test.ts
@@ -46,13 +46,13 @@ describe('http', () => {
     }))
   })
 
-  it('redirects to /utilisateur/connexion/ on 401', async () => {
+  it('redirects to /utilisateur/connexion on 401', async () => {
     const mockLocation = { href: '', pathname: '/ats/dashboard', search: '' }
     vi.stubGlobal('location', mockLocation)
     mockFetchResponse({}, 401, 'Unauthorized')
 
     await expect(http.get('/api/test')).rejects.toThrow('Redirecting to login')
-    expect(mockLocation.href).toBe('/utilisateur/connexion/?next=%2Fats%2Fdashboard')
+    expect(mockLocation.href).toBe('/utilisateur/connexion?next=%2Fats%2Fdashboard')
   })
 
   it('does NOT redirect on 403 (permission denied is not auth)', async () => {

--- a/src/web/presentation/frontend/src/utils/http.ts
+++ b/src/web/presentation/frontend/src/utils/http.ts
@@ -15,7 +15,7 @@ function readCsrfCookie(): string {
 
 function redirectToLogin(): never {
   const next = encodeURIComponent(window.location.pathname + window.location.search)
-  window.location.href = `/utilisateur/connexion/?next=${next}`
+  window.location.href = `/utilisateur/connexion?next=${next}`
   throw new Error('Redirecting to login')
 }
 

--- a/src/web/presentation/identite/urls.py
+++ b/src/web/presentation/identite/urls.py
@@ -10,8 +10,8 @@ from presentation.identite.views import (
 app_name = "identite"
 
 urlpatterns = [
-    path("connexion/", LoginView.as_view(), name="login"),
-    path("deconnexion/", auth_views.LogoutView.as_view(), name="logout"),
+    path("connexion", LoginView.as_view(), name="login"),
+    path("deconnexion", auth_views.LogoutView.as_view(), name="logout"),
     path("profil", ProfileView.as_view(), name="profile"),
-    path("me/", UtilisateurDetailsView.as_view(), name="user-details"),
+    path("me", UtilisateurDetailsView.as_view(), name="user-details"),
 ]

--- a/src/web/presentation/ingestion/urls.py
+++ b/src/web/presentation/ingestion/urls.py
@@ -13,15 +13,15 @@ from presentation.ingestion.views.sources import SourcesListView
 app_name = "ingestion"
 
 urlpatterns = [
-    path("concours/upload/", ConcoursUploadView.as_view(), name="concours_upload"),
-    path("sources/", SourcesListView.as_view(), name="sources_list"),
-    path("offres/", OffersListView.as_view(), name="offers_list"),
+    path("concours/upload", ConcoursUploadView.as_view(), name="concours_upload"),
+    path("sources", SourcesListView.as_view(), name="sources_list"),
+    path("offres", OffersListView.as_view(), name="offers_list"),
     path(
         "offres/sources/<uuid:source_id>",
         OffersBySourceView.as_view(),
         name="offers_by_source",
     ),
     path("offres/archiver", ArchiveOffersView.as_view(), name="offers_archive"),
-    path("offres/creer_modifier/", OffersUpsertView.as_view(), name="offers_upsert"),
-    path("metiers/", MetiersListView.as_view(), name="metiers_list"),
+    path("offres/creer_modifier", OffersUpsertView.as_view(), name="offers_upsert"),
+    path("metiers", MetiersListView.as_view(), name="metiers_list"),
 ]

--- a/src/web/presentation/recruteur/urls.py
+++ b/src/web/presentation/recruteur/urls.py
@@ -11,17 +11,17 @@ app_name = "recruteur"
 
 urlpatterns = [
     path(
-        "organisme/<uuid:organisme_uuid>/",
+        "organisme/<uuid:organisme_uuid>",
         OrganismeView.as_view(),
         name="organisme",
     ),
     path(
-        "organisme/<uuid:organisme_uuid>/parametres/etapes/",
+        "organisme/<uuid:organisme_uuid>/parametres/etapes",
         EtapesRecrutementOrganismeView.as_view(),
         name="organisme-parametres-etapes",
     ),
     path(
-        "organisme/<uuid:organisme_uuid>/parametres/etapes/init/",
+        "organisme/<uuid:organisme_uuid>/parametres/etapes/init",
         InitEtapesRecrutementOrganismeView.as_view(),
         name="organisme-parametres-etapes-init",
     ),

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -8,273 +8,272 @@ paths:
       operationId: recruteur_organisme_retrieve
       summary: Detail d'un organisme
       parameters:
-        - in: path
-          name: organisme_uuid
-          schema:
-            type: string
-            format: uuid
-          required: true
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
       tags:
-        - recruteur
+      - recruteur
       security:
-        - jwtAuth: []
-        - cookieAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Organisme"
-          description: ""
-        "401":
+                $ref: '#/components/schemas/Organisme'
+          description: ''
+        '401':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenError"
-          description: ""
-        "404":
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '404':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
-        "500":
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/organisme/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organisme_parametres_etapes_list
       summary: Liste des étapes de recrutement d'un organisme
       parameters:
-        - in: path
-          name: organisme_uuid
-          schema:
-            type: string
-            format: uuid
-          required: true
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
       tags:
-        - recruteur
+      - recruteur
       security:
-        - jwtAuth: []
-        - cookieAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/EtapeRecrutement"
-          description: ""
-        "401":
+                  $ref: '#/components/schemas/EtapeRecrutement'
+          description: ''
+        '401':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenError"
-          description: ""
-        "404":
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '404':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
-        "500":
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
+                $ref: '#/components/schemas/GenericError'
+          description: ''
     put:
       operationId: recruteur_organisme_parametres_etapes_update
       summary: Modifier les étapes de recrutement d'un organisme
       parameters:
-        - in: path
-          name: organisme_uuid
-          schema:
-            type: string
-            format: uuid
-          required: true
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
       tags:
-        - recruteur
+      - recruteur
       requestBody:
         content:
           application/json:
             schema:
               type: array
               items:
-                $ref: "#/components/schemas/UpdateEtapeRecrutement"
+                $ref: '#/components/schemas/UpdateEtapeRecrutement'
           application/x-www-form-urlencoded:
             schema:
               type: array
               items:
-                $ref: "#/components/schemas/UpdateEtapeRecrutement"
+                $ref: '#/components/schemas/UpdateEtapeRecrutement'
           multipart/form-data:
             schema:
               type: array
               items:
-                $ref: "#/components/schemas/UpdateEtapeRecrutement"
+                $ref: '#/components/schemas/UpdateEtapeRecrutement'
         required: true
       security:
-        - jwtAuth: []
-        - cookieAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/EtapeRecrutement"
-          description: ""
-        "400":
+                  $ref: '#/components/schemas/EtapeRecrutement'
+          description: ''
+        '400':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
-        "401":
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '401':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenError"
-          description: ""
-        "404":
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '404':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
-        "500":
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/organisme/{organisme_uuid}/parametres/etapes/init:
     post:
       operationId: recruteur_organisme_parametres_etapes_init_create
       summary: Initialiser les étapes de recrutement par défaut d'un organisme
       parameters:
-        - in: path
-          name: organisme_uuid
-          schema:
-            type: string
-            format: uuid
-          required: true
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
       tags:
-        - recruteur
+      - recruteur
       security:
-        - jwtAuth: []
-        - cookieAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/EtapeRecrutement"
-          description: ""
-        "401":
+                  $ref: '#/components/schemas/EtapeRecrutement'
+          description: ''
+        '401':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenError"
-          description: ""
-        "404":
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '404':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
-        "500":
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/organisme/{organisme_uuid}/recrutements/:
     get:
       operationId: recruteur_organisme_recrutements_retrieve
-      description:
-        "Retourne la liste paginée des recrutements d'un organisme. Deux
+      description: 'Retourne la liste paginée des recrutements d''un organisme. Deux
         onglets disponibles via le paramètre `filtre` : `actifs` (recrutements en
-        cours, défaut) et `archives` (offres archivées)."
+        cours, défaut) et `archives` (offres archivées).'
       summary: Liste des recrutements d'un organisme
       parameters:
-        - in: path
-          name: organisme_uuid
-          schema:
-            type: string
-            format: uuid
-          required: true
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
       tags:
-        - recruteur
+      - recruteur
       security:
-        - jwtAuth: []
-        - cookieAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RecrutementActifPage"
-          description: ""
-        "400":
+                $ref: '#/components/schemas/RecrutementActifPage'
+          description: ''
+        '400':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
-        "401":
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '401':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenError"
-          description: ""
-        "500":
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '500':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /utilisateur/me:
     get:
       operationId: utilisateur_me_retrieve
       summary: Detail de l'utilisateur connecté
       tags:
-        - utilisateurs
+      - utilisateurs
       security:
-        - jwtAuth: []
-        - cookieAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Utilisateur"
-          description: ""
-        "400":
+                $ref: '#/components/schemas/Utilisateur'
+          description: ''
+        '400':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
-        "401":
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '401':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenError"
-          description: ""
-        "500":
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '500':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GenericError"
-          description: ""
+                $ref: '#/components/schemas/GenericError'
+          description: ''
 components:
   schemas:
     CandidaturesActives:
@@ -290,14 +289,14 @@ components:
           type: integer
           nullable: true
       required:
-        - a_traiter
-        - en_cours
-        - total
+      - a_traiter
+      - en_cours
+      - total
     CategorieEnum:
       enum:
-        - ENTREE
-        - EN_COURS
-        - TERMINALE
+      - ENTREE
+      - EN_COURS
+      - TERMINALE
       type: string
       description: |-
         * `ENTREE` - entree
@@ -312,25 +311,25 @@ components:
         nom:
           type: string
         categorie:
-          $ref: "#/components/schemas/CategorieEnum"
+          $ref: '#/components/schemas/CategorieEnum'
       required:
-        - categorie
-        - etape_uuid
-        - nom
+      - categorie
+      - etape_uuid
+      - nom
     GenericError:
       type: object
       properties:
         error:
           type: string
       required:
-        - error
+      - error
     KindContratEnum:
       enum:
-        - CDD
-        - CDI
-        - PERMANENT
-        - VACATION
-        - STAGE
+      - CDD
+      - CDI
+      - PERMANENT
+      - VACATION
+      - STAGE
       type: string
       description: |-
         * `CDD` - CDD
@@ -340,7 +339,7 @@ components:
         * `STAGE` - Stage
     NullEnum:
       enum:
-        - null
+      - null
     Organisme:
       type: object
       properties:
@@ -349,8 +348,8 @@ components:
         siret:
           type: string
       required:
-        - nom
-        - siret
+      - nom
+      - siret
     RecrutementActif:
       type: object
       properties:
@@ -364,37 +363,37 @@ components:
         type_contrat:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/TypeContratEnum"
-            - $ref: "#/components/schemas/NullEnum"
+          - $ref: '#/components/schemas/TypeContratEnum'
+          - $ref: '#/components/schemas/NullEnum'
         kind_contrat:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/KindContratEnum"
-            - $ref: "#/components/schemas/NullEnum"
+          - $ref: '#/components/schemas/KindContratEnum'
+          - $ref: '#/components/schemas/NullEnum'
         date_publication:
           type: string
           format: date-time
         responsables:
           type: array
           items:
-            $ref: "#/components/schemas/Responsable"
+            $ref: '#/components/schemas/Responsable'
         derniere_activite:
           type: string
           format: date-time
         candidatures:
           allOf:
-            - $ref: "#/components/schemas/CandidaturesActives"
+          - $ref: '#/components/schemas/CandidaturesActives'
           nullable: true
       required:
-        - candidatures
-        - date_publication
-        - derniere_activite
-        - intitule
-        - kind_contrat
-        - offer_id
-        - reference_csp
-        - responsables
-        - type_contrat
+      - candidatures
+      - date_publication
+      - derniere_activite
+      - intitule
+      - kind_contrat
+      - offer_id
+      - reference_csp
+      - responsables
+      - type_contrat
     RecrutementActifPage:
       type: object
       properties:
@@ -411,19 +410,19 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/RecrutementActif"
+            $ref: '#/components/schemas/RecrutementActif'
       required:
-        - count
-        - next
-        - previous
-        - results
+      - count
+      - next
+      - previous
+      - results
     Responsable:
       type: object
       properties:
         nom:
           type: string
       required:
-        - nom
+      - nom
     TokenError:
       type: object
       properties:
@@ -434,11 +433,11 @@ components:
         messages:
           type: array
           items:
-            $ref: "#/components/schemas/TokenErrorMessage"
+            $ref: '#/components/schemas/TokenErrorMessage'
       required:
-        - code
-        - detail
-        - messages
+      - code
+      - detail
+      - messages
     TokenErrorMessage:
       type: object
       properties:
@@ -449,14 +448,14 @@ components:
         message:
           type: string
       required:
-        - message
-        - token_class
-        - token_type
+      - message
+      - token_class
+      - token_type
     TypeContratEnum:
       enum:
-        - TITULAIRE_CONTRACTUEL
-        - CONTRACTUELS
-        - TERRITORIAL
+      - TITULAIRE_CONTRACTUEL
+      - CONTRACTUELS
+      - TERRITORIAL
       type: string
       description: |-
         * `TITULAIRE_CONTRACTUEL` - TITULAIRE_CONTRACTUEL
@@ -471,10 +470,10 @@ components:
         nom:
           type: string
         categorie:
-          $ref: "#/components/schemas/CategorieEnum"
+          $ref: '#/components/schemas/CategorieEnum'
       required:
-        - categorie
-        - nom
+      - categorie
+      - nom
     Utilisateur:
       type: object
       properties:
@@ -486,9 +485,9 @@ components:
         nom:
           type: string
       required:
-        - email
-        - nom
-        - prenom
+      - email
+      - nom
+      - prenom
   securitySchemes:
     cookieAuth:
       type: apiKey
@@ -499,5 +498,5 @@ components:
       scheme: bearer
       bearerFormat: JWT
 tags:
-  - name: utilisateurs
-    description: Gestion des utilisateurs
+- name: utilisateurs
+  description: Gestion des utilisateurs

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -3,277 +3,278 @@ info:
   title: CSPLab Internal API
   version: 0.0.1
 paths:
-  /recruteur/organisme/{organisme_uuid}/:
+  /recruteur/organisme/{organisme_uuid}:
     get:
       operationId: recruteur_organisme_retrieve
       summary: Detail d'un organisme
       parameters:
-      - in: path
-        name: organisme_uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
+        - in: path
+          name: organisme_uuid
+          schema:
+            type: string
+            format: uuid
+          required: true
       tags:
-      - recruteur
+        - recruteur
       security:
-      - jwtAuth: []
-      - cookieAuth: []
+        - jwtAuth: []
+        - cookieAuth: []
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organisme'
-          description: ''
-        '401':
+                $ref: "#/components/schemas/Organisme"
+          description: ""
+        "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenError'
-          description: ''
-        '404':
+                $ref: "#/components/schemas/TokenError"
+          description: ""
+        "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-        '500':
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+        "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-  /recruteur/organisme/{organisme_uuid}/parametres/etapes/:
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+  /recruteur/organisme/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organisme_parametres_etapes_list
       summary: Liste des étapes de recrutement d'un organisme
       parameters:
-      - in: path
-        name: organisme_uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
+        - in: path
+          name: organisme_uuid
+          schema:
+            type: string
+            format: uuid
+          required: true
       tags:
-      - recruteur
+        - recruteur
       security:
-      - jwtAuth: []
-      - cookieAuth: []
+        - jwtAuth: []
+        - cookieAuth: []
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/EtapeRecrutement'
-          description: ''
-        '401':
+                  $ref: "#/components/schemas/EtapeRecrutement"
+          description: ""
+        "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenError'
-          description: ''
-        '404':
+                $ref: "#/components/schemas/TokenError"
+          description: ""
+        "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-        '500':
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+        "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
+                $ref: "#/components/schemas/GenericError"
+          description: ""
     put:
       operationId: recruteur_organisme_parametres_etapes_update
       summary: Modifier les étapes de recrutement d'un organisme
       parameters:
-      - in: path
-        name: organisme_uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
+        - in: path
+          name: organisme_uuid
+          schema:
+            type: string
+            format: uuid
+          required: true
       tags:
-      - recruteur
+        - recruteur
       requestBody:
         content:
           application/json:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/UpdateEtapeRecrutement'
+                $ref: "#/components/schemas/UpdateEtapeRecrutement"
           application/x-www-form-urlencoded:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/UpdateEtapeRecrutement'
+                $ref: "#/components/schemas/UpdateEtapeRecrutement"
           multipart/form-data:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/UpdateEtapeRecrutement'
+                $ref: "#/components/schemas/UpdateEtapeRecrutement"
         required: true
       security:
-      - jwtAuth: []
-      - cookieAuth: []
+        - jwtAuth: []
+        - cookieAuth: []
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/EtapeRecrutement'
-          description: ''
-        '400':
+                  $ref: "#/components/schemas/EtapeRecrutement"
+          description: ""
+        "400":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-        '401':
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+        "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenError'
-          description: ''
-        '404':
+                $ref: "#/components/schemas/TokenError"
+          description: ""
+        "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-        '500':
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+        "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-  /recruteur/organisme/{organisme_uuid}/parametres/etapes/init/:
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+  /recruteur/organisme/{organisme_uuid}/parametres/etapes/init:
     post:
       operationId: recruteur_organisme_parametres_etapes_init_create
       summary: Initialiser les étapes de recrutement par défaut d'un organisme
       parameters:
-      - in: path
-        name: organisme_uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
+        - in: path
+          name: organisme_uuid
+          schema:
+            type: string
+            format: uuid
+          required: true
       tags:
-      - recruteur
+        - recruteur
       security:
-      - jwtAuth: []
-      - cookieAuth: []
+        - jwtAuth: []
+        - cookieAuth: []
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/EtapeRecrutement'
-          description: ''
-        '401':
+                  $ref: "#/components/schemas/EtapeRecrutement"
+          description: ""
+        "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenError'
-          description: ''
-        '404':
+                $ref: "#/components/schemas/TokenError"
+          description: ""
+        "404":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-        '500':
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+        "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
+                $ref: "#/components/schemas/GenericError"
+          description: ""
   /recruteur/organisme/{organisme_uuid}/recrutements/:
     get:
       operationId: recruteur_organisme_recrutements_retrieve
-      description: 'Retourne la liste paginée des recrutements d''un organisme. Deux
+      description:
+        "Retourne la liste paginée des recrutements d'un organisme. Deux
         onglets disponibles via le paramètre `filtre` : `actifs` (recrutements en
-        cours, défaut) et `archives` (offres archivées).'
+        cours, défaut) et `archives` (offres archivées)."
       summary: Liste des recrutements d'un organisme
       parameters:
-      - in: path
-        name: organisme_uuid
-        schema:
-          type: string
-          format: uuid
-        required: true
+        - in: path
+          name: organisme_uuid
+          schema:
+            type: string
+            format: uuid
+          required: true
       tags:
-      - recruteur
+        - recruteur
       security:
-      - jwtAuth: []
-      - cookieAuth: []
+        - jwtAuth: []
+        - cookieAuth: []
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RecrutementActifPage'
-          description: ''
-        '400':
+                $ref: "#/components/schemas/RecrutementActifPage"
+          description: ""
+        "400":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-        '401':
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+        "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenError'
-          description: ''
-        '500':
+                $ref: "#/components/schemas/TokenError"
+          description: ""
+        "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-  /utilisateur/me/:
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+  /utilisateur/me:
     get:
       operationId: utilisateur_me_retrieve
       summary: Detail de l'utilisateur connecté
       tags:
-      - utilisateurs
+        - utilisateurs
       security:
-      - jwtAuth: []
-      - cookieAuth: []
+        - jwtAuth: []
+        - cookieAuth: []
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Utilisateur'
-          description: ''
-        '400':
+                $ref: "#/components/schemas/Utilisateur"
+          description: ""
+        "400":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
-        '401':
+                $ref: "#/components/schemas/GenericError"
+          description: ""
+        "401":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenError'
-          description: ''
-        '500':
+                $ref: "#/components/schemas/TokenError"
+          description: ""
+        "500":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GenericError'
-          description: ''
+                $ref: "#/components/schemas/GenericError"
+          description: ""
 components:
   schemas:
     CandidaturesActives:
@@ -289,14 +290,14 @@ components:
           type: integer
           nullable: true
       required:
-      - a_traiter
-      - en_cours
-      - total
+        - a_traiter
+        - en_cours
+        - total
     CategorieEnum:
       enum:
-      - ENTREE
-      - EN_COURS
-      - TERMINALE
+        - ENTREE
+        - EN_COURS
+        - TERMINALE
       type: string
       description: |-
         * `ENTREE` - entree
@@ -311,25 +312,25 @@ components:
         nom:
           type: string
         categorie:
-          $ref: '#/components/schemas/CategorieEnum'
+          $ref: "#/components/schemas/CategorieEnum"
       required:
-      - categorie
-      - etape_uuid
-      - nom
+        - categorie
+        - etape_uuid
+        - nom
     GenericError:
       type: object
       properties:
         error:
           type: string
       required:
-      - error
+        - error
     KindContratEnum:
       enum:
-      - CDD
-      - CDI
-      - PERMANENT
-      - VACATION
-      - STAGE
+        - CDD
+        - CDI
+        - PERMANENT
+        - VACATION
+        - STAGE
       type: string
       description: |-
         * `CDD` - CDD
@@ -339,7 +340,7 @@ components:
         * `STAGE` - Stage
     NullEnum:
       enum:
-      - null
+        - null
     Organisme:
       type: object
       properties:
@@ -348,8 +349,8 @@ components:
         siret:
           type: string
       required:
-      - nom
-      - siret
+        - nom
+        - siret
     RecrutementActif:
       type: object
       properties:
@@ -363,37 +364,37 @@ components:
         type_contrat:
           nullable: true
           oneOf:
-          - $ref: '#/components/schemas/TypeContratEnum'
-          - $ref: '#/components/schemas/NullEnum'
+            - $ref: "#/components/schemas/TypeContratEnum"
+            - $ref: "#/components/schemas/NullEnum"
         kind_contrat:
           nullable: true
           oneOf:
-          - $ref: '#/components/schemas/KindContratEnum'
-          - $ref: '#/components/schemas/NullEnum'
+            - $ref: "#/components/schemas/KindContratEnum"
+            - $ref: "#/components/schemas/NullEnum"
         date_publication:
           type: string
           format: date-time
         responsables:
           type: array
           items:
-            $ref: '#/components/schemas/Responsable'
+            $ref: "#/components/schemas/Responsable"
         derniere_activite:
           type: string
           format: date-time
         candidatures:
           allOf:
-          - $ref: '#/components/schemas/CandidaturesActives'
+            - $ref: "#/components/schemas/CandidaturesActives"
           nullable: true
       required:
-      - candidatures
-      - date_publication
-      - derniere_activite
-      - intitule
-      - kind_contrat
-      - offer_id
-      - reference_csp
-      - responsables
-      - type_contrat
+        - candidatures
+        - date_publication
+        - derniere_activite
+        - intitule
+        - kind_contrat
+        - offer_id
+        - reference_csp
+        - responsables
+        - type_contrat
     RecrutementActifPage:
       type: object
       properties:
@@ -410,19 +411,19 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/RecrutementActif'
+            $ref: "#/components/schemas/RecrutementActif"
       required:
-      - count
-      - next
-      - previous
-      - results
+        - count
+        - next
+        - previous
+        - results
     Responsable:
       type: object
       properties:
         nom:
           type: string
       required:
-      - nom
+        - nom
     TokenError:
       type: object
       properties:
@@ -433,11 +434,11 @@ components:
         messages:
           type: array
           items:
-            $ref: '#/components/schemas/TokenErrorMessage'
+            $ref: "#/components/schemas/TokenErrorMessage"
       required:
-      - code
-      - detail
-      - messages
+        - code
+        - detail
+        - messages
     TokenErrorMessage:
       type: object
       properties:
@@ -448,14 +449,14 @@ components:
         message:
           type: string
       required:
-      - message
-      - token_class
-      - token_type
+        - message
+        - token_class
+        - token_type
     TypeContratEnum:
       enum:
-      - TITULAIRE_CONTRACTUEL
-      - CONTRACTUELS
-      - TERRITORIAL
+        - TITULAIRE_CONTRACTUEL
+        - CONTRACTUELS
+        - TERRITORIAL
       type: string
       description: |-
         * `TITULAIRE_CONTRACTUEL` - TITULAIRE_CONTRACTUEL
@@ -470,10 +471,10 @@ components:
         nom:
           type: string
         categorie:
-          $ref: '#/components/schemas/CategorieEnum'
+          $ref: "#/components/schemas/CategorieEnum"
       required:
-      - categorie
-      - nom
+        - categorie
+        - nom
     Utilisateur:
       type: object
       properties:
@@ -485,9 +486,9 @@ components:
         nom:
           type: string
       required:
-      - email
-      - nom
-      - prenom
+        - email
+        - nom
+        - prenom
   securitySchemes:
     cookieAuth:
       type: apiKey
@@ -498,5 +499,5 @@ components:
       scheme: bearer
       bearerFormat: JWT
 tags:
-- name: utilisateurs
-  description: Gestion des utilisateurs
+  - name: utilisateurs
+    description: Gestion des utilisateurs

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.0.1
   description: API for CSPLab
 paths:
-  /api/token/:
+  /api/token:
     post:
       operationId: token_create
       description: |-
@@ -31,7 +31,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenObtainPair'
           description: ''
-  /api/token/refresh/:
+  /api/token/refresh:
     post:
       operationId: token_refresh_create
       description: |-
@@ -58,7 +58,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenRefresh'
           description: ''
-  /api/v1/concours/upload/:
+  /api/v1/concours/upload:
     post:
       operationId: v1_concours_upload_create
       description: |-
@@ -224,7 +224,7 @@ paths:
                   summary: Erreur serveur inattendue
                   description: Une erreur inattendue s'est produite côté serveur.
           description: ''
-  /api/v1/metiers/:
+  /api/v1/metiers:
     get:
       operationId: v1_metiers_retrieve
       description: |2
@@ -349,7 +349,7 @@ paths:
                   summary: Erreur serveur inattendue
                   description: Une erreur inattendue s'est produite côté serveur.
           description: ''
-  /api/v1/offres/:
+  /api/v1/offres:
     get:
       operationId: v1_offres_retrieve
       description: |2
@@ -549,7 +549,7 @@ paths:
                   summary: Offre introuvable
                   description: Aucune offre ne correspond à la référence fournie.
           description: ''
-  /api/v1/offres/creer_modifier/:
+  /api/v1/offres/creer_modifier:
     post:
       operationId: v1_offres_creer_modifier_create
       description: |2

--- a/src/web/tests/presentation/candidate/e2e/test_cv_flow_keyboard.py
+++ b/src/web/tests/presentation/candidate/e2e/test_cv_flow_keyboard.py
@@ -25,7 +25,7 @@ class TestCandidateFlowKeyboard:
         offer_entity = OfferFactory.create_model(title="Offre keyboard").to_entity()
 
         # 1. Upload page: select file, submit via keyboard (Enter on submit button)
-        page.goto(f"{live_server.url}/candidate/cv-upload/")
+        page.goto(f"{live_server.url}/candidate/cv-upload")
         form = page.get_by_test_id("cv-upload-form")
         form.locator("input[data-file-input]").set_input_files(str(cv_pdf_path))
 
@@ -35,10 +35,10 @@ class TestCandidateFlowKeyboard:
         page.keyboard.press("Enter")
 
         # 2. Processing page reached
-        expect(page).to_have_url(re.compile(r"/candidate/cv/[0-9a-f-]+/results/"))
+        expect(page).to_have_url(re.compile(r"/candidate/cv/[0-9a-f-]+/results"))
         expect(page.get_by_test_id("cv-processing")).to_be_visible()
 
-        match = re.search(r"/candidate/cv/([0-9a-f-]+)/results/", page.url)
+        match = re.search(r"/candidate/cv/([0-9a-f-]+)/results", page.url)
         assert match is not None
         cv_uuid = match.group(1)
 

--- a/src/web/tests/presentation/candidate/e2e/test_cv_upload_flow.py
+++ b/src/web/tests/presentation/candidate/e2e/test_cv_upload_flow.py
@@ -15,13 +15,13 @@ class TestCVUploadFlow:
     def test_user_sees_results_after_processing_completes(
         self, page: Page, live_server, cv_pdf_path: Path, db
     ) -> None:
-        page.goto(f"{live_server.url}/candidate/cv-upload/")
+        page.goto(f"{live_server.url}/candidate/cv-upload")
         form = page.get_by_test_id("cv-upload-form")
         form.locator("input[data-file-input]").set_input_files(str(cv_pdf_path))
         form.locator('button[type="submit"]:visible').click()
         expect(page.get_by_test_id("cv-processing")).to_be_visible()
 
-        match = re.search(r"/candidate/cv/([0-9a-f-]+)/results/", page.url)
+        match = re.search(r"/candidate/cv/([0-9a-f-]+)/results", page.url)
         assert match is not None
         cv_uuid = match.group(1)
 

--- a/src/web/tests/presentation/candidate/views/test_cv_results_view.py
+++ b/src/web/tests/presentation/candidate/views/test_cv_results_view.py
@@ -35,7 +35,7 @@ def mock_execute():
 
 
 def test_cv_results_invalid_uuid_returns_404(client, db):
-    response = client.get("/candidate/cv/invalid-uuid/results/")
+    response = client.get("/candidate/cv/invalid-uuid/results")
 
     assert response.status_code == HTTPStatus.NOT_FOUND
 

--- a/src/web/tests/presentation/candidate/views/test_cv_upload_view.py
+++ b/src/web/tests/presentation/candidate/views/test_cv_upload_view.py
@@ -56,7 +56,7 @@ def test_cv_upload_valid_pdf_redirects_to_results(mock_container, client, db, fi
     )
 
     # Check redirect to cv_results with correct URL pattern
-    assert response.redirect_chain[-1][0] == f"/candidate/cv/{mock_uuid}/results/"
+    assert response.redirect_chain[-1][0] == f"/candidate/cv/{mock_uuid}/results"
 
 
 def test_cv_upload_empty_submission_shows_error(client, db):


### PR DESCRIPTION
## 📝 Description
🎸 Les routes du service `web` n'appliquaient pas de manière homogène la convention de slash de fin (règle 5.6 des guidelines Django). Cette PR uniformise l'ensemble des URLconfs.

## 🏷️ Type de changement
- [x] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Convention appliquée (règle 5.6)
- **Route feuille** (qui résout une vue, sans sous-routes) → **sans** slash de fin.
- **Route préfixe** (`include(...)`) → **conserve** son slash de fin.
- `path("", ...)` racine et le catch-all regex de l'ATS laissés inchangés.

## ⚠️ Changement de contrat sur l'API publique
Les endpoints `/api/token`, `/api/token/refresh` et `/api/v1/*` perdent leur slash de fin. Avec `APPEND_SLASH=True` (valeur par défaut), une requête vers l'ancienne forme avec slash renverra désormais un **404** (APPEND_SLASH ajoute un slash mais n'en retire jamais). Les intégrations externes appelant la forme avec slash devront être mises à jour.

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
