### PR TITLE
♻️(web) rendre les tests plus lisibles en utilisant le decorateur @patch

### DIFF
--- a/src/web/tests/infrastructure/identite/test_api_key_authentication.py
+++ b/src/web/tests/infrastructure/identite/test_api_key_authentication.py
@@ -46,27 +46,27 @@ class TestApiKeyRateThrottle:
     def test_scope_is_api_key(self):
         assert ApiKeyRateThrottle.scope == "api_key"
 
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "3/hour"})
     def test_rate_limit_allows_requests_within_limit(self, rf):
         cache.clear()
         request = rf.get("/")
         request.user = API_KEY_USER
-        with patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "3/hour"}):
-            for _ in range(3):
-                assert ApiKeyRateThrottle().allow_request(request, view=None) is True
+        for _ in range(3):
+            assert ApiKeyRateThrottle().allow_request(request, view=None) is True
 
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "3/hour"})
     def test_rate_limit_blocks_requests_over_limit(self, rf):
         cache.clear()
         request = rf.get("/")
         request.user = API_KEY_USER
-        with patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "3/hour"}):
-            for _ in range(3):
-                ApiKeyRateThrottle().allow_request(request, view=None)
-            assert ApiKeyRateThrottle().allow_request(request, view=None) is False
+        for _ in range(3):
+            ApiKeyRateThrottle().allow_request(request, view=None)
+        assert ApiKeyRateThrottle().allow_request(request, view=None) is False
 
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "3/hour"})
     def test_rate_limit_is_not_applied_to_non_api_key_user(self, rf):
         cache.clear()
         request = rf.get("/")
         request.user = object()
-        with patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "3/hour"}):
-            for _ in range(10):
-                assert ApiKeyRateThrottle().allow_request(request, view=None) is True
+        for _ in range(10):
+            assert ApiKeyRateThrottle().allow_request(request, view=None) is True

--- a/src/web/tests/infrastructure/ingestion/test_load_documents.py
+++ b/src/web/tests/infrastructure/ingestion/test_load_documents.py
@@ -234,6 +234,7 @@ class TestIntegrationLoadOffersUseCase:
         repository_get_by_external_ids.assert_not_called()
         assert result == {"created": 0, "updated": 0, "errors": []}
 
+    @patch.object(load_offers, "MAX_ITERATIONS", MAX_ITERATIONS)
     async def test_stops_after_max_iterations(
         self, db, httpx_mock, documents_ingestion_container, load_offers_usecase
     ):
@@ -251,8 +252,7 @@ class TestIntegrationLoadOffersUseCase:
             kwargs={"document_type": DocumentType.OFFERS},
         )
 
-        with patch.object(load_offers, "MAX_ITERATIONS", MAX_ITERATIONS):
-            await load_offers_usecase.execute(input_data)
+        await load_offers_usecase.execute(input_data)
 
         # (MAX_ITERATIONS - 1) * (getsummaries + getoffer calls)
         assert len(httpx_mock.get_requests()) == (MAX_ITERATIONS - 1) * 2

--- a/src/web/tests/presentation/candidate/accessibility/test_candidate_flow_a11y.py
+++ b/src/web/tests/presentation/candidate/accessibility/test_candidate_flow_a11y.py
@@ -50,8 +50,12 @@ class TestCandidateFlowAccessibility:
 
         _assert_no_violations(Axe().run(page, options=AXE_OPTIONS))
 
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_results_page_has_no_axe_violations(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_entity = OfferFactory.create_entity(title="Offre a11y")
         OfferModel.from_entity(offer_entity).save()
@@ -59,27 +63,24 @@ class TestCandidateFlowAccessibility:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = [(offer_entity, 0.9)]
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [(offer_entity, 0.9)]
+        cv_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
+        )
+        page.goto(f"{live_server.url}{cv_url}")
+        expect(
+            page.get_by_role("heading", name="Offres et concours les plus pertinents")
+        ).to_be_visible()
 
-            cv_url = reverse(
-                "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
-            )
-            page.goto(f"{live_server.url}{cv_url}")
-            expect(
-                page.get_by_role(
-                    "heading", name="Offres et concours les plus pertinents"
-                )
-            ).to_be_visible()
+        _assert_no_violations(Axe().run(page, options=AXE_OPTIONS))
 
-            _assert_no_violations(Axe().run(page, options=AXE_OPTIONS))
-
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_open_drawer_has_no_axe_violations(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_entity = OfferFactory.create_entity(title="Offre drawer a11y")
         OfferModel.from_entity(offer_entity).save()
@@ -87,18 +88,13 @@ class TestCandidateFlowAccessibility:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = [(offer_entity, 0.9)]
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [(offer_entity, 0.9)]
+        cv_url = reverse(
+            "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
+        )
+        page.goto(f"{live_server.url}{cv_url}")
+        page.locator("[data-drawer-open]").first.click()
+        expect(page.locator("dialog[data-drawer][open]")).to_be_visible()
 
-            cv_url = reverse(
-                "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
-            )
-            page.goto(f"{live_server.url}{cv_url}")
-            page.locator("[data-drawer-open]").first.click()
-            expect(page.locator("dialog[data-drawer][open]")).to_be_visible()
-
-            _assert_no_violations(Axe().run(page, options=AXE_OPTIONS))
+        _assert_no_violations(Axe().run(page, options=AXE_OPTIONS))

--- a/src/web/tests/presentation/candidate/e2e/test_cv_flow_keyboard.py
+++ b/src/web/tests/presentation/candidate/e2e/test_cv_flow_keyboard.py
@@ -15,14 +15,20 @@ from tests.factories.referentiel.offer_factory import OfferFactory
 
 @pytest.mark.e2e
 class TestCandidateFlowKeyboard:
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_completes_full_flow_with_keyboard_only(
         self,
+        mock_execute,
         page: Page,
         live_server,
         cv_pdf_path: Path,
         transactional_db,
     ) -> None:
         offer_entity = OfferFactory.create_model(title="Offre keyboard").to_entity()
+        mock_execute.return_value = [((offer_entity, []), 0.9)]
 
         # 1. Upload page: select file, submit via keyboard (Enter on submit button)
         page.goto(f"{live_server.url}/candidate/cv-upload")
@@ -42,35 +48,35 @@ class TestCandidateFlowKeyboard:
         assert match is not None
         cv_uuid = match.group(1)
 
-        # 3. Flip CV to COMPLETED so polling renders results, mock matching usecase
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [((offer_entity, []), 0.9)]
-            CVMetadataModel.objects.filter(id=cv_uuid).update(
-                status=CVStatus.COMPLETED.value, search_query="dev"
-            )
+        # 3. Flip CV to COMPLETED so polling renders results
+        CVMetadataModel.objects.filter(id=cv_uuid).update(
+            status=CVStatus.COMPLETED.value, search_query="dev"
+        )
 
-            results = page.get_by_test_id("cv-results")
-            expect(results).to_be_visible(timeout=10_000)
+        results = page.get_by_test_id("cv-results")
+        expect(results).to_be_visible(timeout=10_000)
 
-            # 4. Open drawer with Enter on first offer link
-            trigger = page.locator("[data-drawer-open]").first
-            trigger.focus()
-            page.keyboard.press("Enter")
+        # 4. Open drawer with Enter on first offer link
+        trigger = page.locator("[data-drawer-open]").first
+        trigger.focus()
+        page.keyboard.press("Enter")
 
-            drawer = page.get_by_test_id("opportunity-drawer")
-            expect(drawer).to_be_visible()
-            expect(drawer.locator("[data-drawer-close]")).to_be_focused()
+        drawer = page.get_by_test_id("opportunity-drawer")
+        expect(drawer).to_be_visible()
+        expect(drawer.locator("[data-drawer-close]")).to_be_focused()
 
-            # 5. Close drawer with Escape, focus returns to trigger
-            page.keyboard.press("Escape")
-            expect(drawer).not_to_be_visible()
-            expect(trigger).to_be_focused()
+        # 5. Close drawer with Escape, focus returns to trigger
+        page.keyboard.press("Escape")
+        expect(drawer).not_to_be_visible()
+        expect(trigger).to_be_focused()
 
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_focus_returns_to_trigger_after_filter_then_drawer_escape(
         self,
+        mock_execute,
         page: Page,
         live_server,
         transactional_db,
@@ -92,30 +98,27 @@ class TestCandidateFlowKeyboard:
                 return [((offer_a, []), 0.9)]
             return [((offer_a, []), 0.9), ((offer_b, []), 0.8)]
 
+        mock_execute.side_effect = fake_execute
+
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute",
-            side_effect=fake_execute,
-        ):
-            page.goto(f"{live_server.url}{results_url}")
-            results = page.get_by_test_id("cv-results")
-            expect(results).to_be_visible()
+        page.goto(f"{live_server.url}{results_url}")
+        results = page.get_by_test_id("cv-results")
+        expect(results).to_be_visible()
 
-            page.locator("label:has(#desktop-filter-category-a)").click()
-            expect(page).to_have_url(re.compile(r"filter-category=a"))
-            expect(results).not_to_contain_text("Offre beta kbd")
+        page.locator("label:has(#desktop-filter-category-a)").click()
+        expect(page).to_have_url(re.compile(r"filter-category=a"))
+        expect(results).not_to_contain_text("Offre beta kbd")
 
-            trigger = page.locator("[data-drawer-open]").first
-            trigger.focus()
-            page.keyboard.press("Enter")
+        trigger = page.locator("[data-drawer-open]").first
+        trigger.focus()
+        page.keyboard.press("Enter")
 
-            drawer = page.get_by_test_id("opportunity-drawer")
-            expect(drawer).to_be_visible()
+        drawer = page.get_by_test_id("opportunity-drawer")
+        expect(drawer).to_be_visible()
 
-            page.keyboard.press("Escape")
-            expect(drawer).not_to_be_visible()
-            expect(trigger).to_be_focused()
+        page.keyboard.press("Escape")
+        expect(drawer).not_to_be_visible()
+        expect(trigger).to_be_focused()

--- a/src/web/tests/presentation/candidate/e2e/test_cv_upload_flow.py
+++ b/src/web/tests/presentation/candidate/e2e/test_cv_upload_flow.py
@@ -12,9 +12,17 @@ from tests.factories.referentiel.offer_factory import OfferFactory
 
 @pytest.mark.e2e
 class TestCVUploadFlow:
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_sees_results_after_processing_completes(
-        self, page: Page, live_server, cv_pdf_path: Path, db
+        self, mock_execute, page: Page, live_server, cv_pdf_path: Path, db
     ) -> None:
+        mock_execute.return_value = [
+            ((OfferFactory.create_entity(title="Offre e2e"), []), 0.9),
+        ]
+
         page.goto(f"{live_server.url}/candidate/cv-upload")
         form = page.get_by_test_id("cv-upload-form")
         form.locator("input[data-file-input]").set_input_files(str(cv_pdf_path))
@@ -25,14 +33,7 @@ class TestCVUploadFlow:
         assert match is not None
         cv_uuid = match.group(1)
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [
-                ((OfferFactory.create_entity(title="Offre e2e"), []), 0.9),
-            ]
-            CVMetadataModel.objects.filter(id=cv_uuid).update(
-                status=CVStatus.COMPLETED.value, search_query="dev"
-            )
-            expect(page.get_by_test_id("cv-results")).to_be_visible(timeout=10_000)
+        CVMetadataModel.objects.filter(id=cv_uuid).update(
+            status=CVStatus.COMPLETED.value, search_query="dev"
+        )
+        expect(page.get_by_test_id("cv-results")).to_be_visible(timeout=10_000)

--- a/src/web/tests/presentation/candidate/e2e/test_results_interaction.py
+++ b/src/web/tests/presentation/candidate/e2e/test_results_interaction.py
@@ -38,8 +38,12 @@ def fake_execute_filter_by_category_and_versant(
 
 @pytest.mark.e2e
 class TestResultsDrawer:
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_opens_offer_drawer_and_closes_it_with_close_button(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_entity = OfferFactory.create_model(title="Offre e2e drawer").to_entity()
 
@@ -47,31 +51,30 @@ class TestResultsDrawer:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = [((offer_entity, []), 0.9)]
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [((offer_entity, []), 0.9)]
+        page.goto(f"{live_server.url}{results_url}")
+        expect(page.get_by_test_id("cv-results")).to_be_visible()
 
-            page.goto(f"{live_server.url}{results_url}")
-            expect(page.get_by_test_id("cv-results")).to_be_visible()
+        page.locator("[data-drawer-open]").first.click()
 
-            page.locator("[data-drawer-open]").first.click()
+        drawer = page.get_by_test_id("opportunity-drawer")
+        expect(drawer).to_be_visible()
+        expect(drawer).to_contain_text("Offre e2e drawer")
 
-            drawer = page.get_by_test_id("opportunity-drawer")
-            expect(drawer).to_be_visible()
-            expect(drawer).to_contain_text("Offre e2e drawer")
+        drawer.locator("[data-drawer-close]").click()
+        expect(drawer).not_to_be_visible()
 
-            drawer.locator("[data-drawer-close]").click()
-            expect(drawer).not_to_be_visible()
-
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_closes_drawer_with_browser_back_navigation(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_entity = OfferFactory.create_model(title="Offre e2e back-nav").to_entity()
 
@@ -79,31 +82,30 @@ class TestResultsDrawer:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = [((offer_entity, []), 0.9)]
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [((offer_entity, []), 0.9)]
+        page.goto(f"{live_server.url}{results_url}")
+        expect(page.get_by_test_id("cv-results")).to_be_visible()
 
-            page.goto(f"{live_server.url}{results_url}")
-            expect(page.get_by_test_id("cv-results")).to_be_visible()
+        page.locator("[data-drawer-open]").first.click()
+        drawer = page.get_by_test_id("opportunity-drawer")
+        expect(drawer).to_be_visible()
 
-            page.locator("[data-drawer-open]").first.click()
-            drawer = page.get_by_test_id("opportunity-drawer")
-            expect(drawer).to_be_visible()
+        page.go_back()
 
-            page.go_back()
+        expect(drawer).not_to_be_visible()
+        expect(page).to_have_url(re.compile(re.escape(results_url) + r"/?$"))
 
-            expect(drawer).not_to_be_visible()
-            expect(page).to_have_url(re.compile(re.escape(results_url) + r"/?$"))
-
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_opens_concours_drawer_and_closes_it_with_close_button(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         concours_model = ConcoursFactory.create_model(
             corps="Corps e2e drawer", grade="Grade e2e drawer"
@@ -114,34 +116,33 @@ class TestResultsDrawer:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = [(concours_entity, 0.9)]
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [(concours_entity, 0.9)]
+        page.goto(f"{live_server.url}{results_url}")
+        expect(page.get_by_test_id("cv-results")).to_be_visible()
 
-            page.goto(f"{live_server.url}{results_url}")
-            expect(page.get_by_test_id("cv-results")).to_be_visible()
+        page.locator("[data-drawer-open]").first.click()
 
-            page.locator("[data-drawer-open]").first.click()
+        drawer = page.get_by_test_id("opportunity-drawer")
+        expect(drawer).to_be_visible()
+        expect(drawer).to_contain_text("Corps e2e drawer")
 
-            drawer = page.get_by_test_id("opportunity-drawer")
-            expect(drawer).to_be_visible()
-            expect(drawer).to_contain_text("Corps e2e drawer")
-
-            drawer.locator("[data-drawer-close]").click()
-            expect(drawer).not_to_be_visible()
+        drawer.locator("[data-drawer-close]").click()
+        expect(drawer).not_to_be_visible()
 
 
 @pytest.mark.e2e
 class TestResultsPersistence:
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_refreshes_results_page_and_state_persists(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_entity = OfferFactory.create_model(title="Offre e2e refresh").to_entity()
 
@@ -149,34 +150,31 @@ class TestResultsPersistence:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = [((offer_entity, []), 0.9)]
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [((offer_entity, []), 0.9)]
+        page.goto(f"{live_server.url}{results_url}")
+        results = page.get_by_test_id("cv-results")
+        expect(results).to_be_visible()
+        expect(results).to_contain_text("Offre e2e refresh")
 
-            page.goto(f"{live_server.url}{results_url}")
-            results = page.get_by_test_id("cv-results")
-            expect(results).to_be_visible()
-            expect(results).to_contain_text("Offre e2e refresh")
+        page.reload()
 
-            page.reload()
-
-            expect(page.get_by_test_id("cv-results")).to_be_visible()
-            expect(page.get_by_test_id("cv-results")).to_contain_text(
-                "Offre e2e refresh"
-            )
+        expect(page.get_by_test_id("cv-results")).to_be_visible()
+        expect(page.get_by_test_id("cv-results")).to_contain_text("Offre e2e refresh")
 
 
 @pytest.mark.e2e
 class TestResultsFilters:
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_narrows_results_by_selecting_category_filter(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_a = OfferFactory.create_model(
             title="Offre alpha", category=Category.A
@@ -189,29 +187,31 @@ class TestResultsFilters:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.side_effect = partial(
+            fake_execute_filter_by_category, offer_a, offer_b
+        )
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute",
-            side_effect=partial(fake_execute_filter_by_category, offer_a, offer_b),
-        ):
-            page.goto(f"{live_server.url}{results_url}")
-            results = page.get_by_test_id("cv-results")
-            expect(results).to_contain_text("Offre alpha")
-            expect(results).to_contain_text("Offre beta")
+        page.goto(f"{live_server.url}{results_url}")
+        results = page.get_by_test_id("cv-results")
+        expect(results).to_contain_text("Offre alpha")
+        expect(results).to_contain_text("Offre beta")
 
-            page.locator("label:has(#desktop-filter-category-a)").click()
+        page.locator("label:has(#desktop-filter-category-a)").click()
 
-            expect(results).to_contain_text("Offre alpha")
-            expect(results).not_to_contain_text("Offre beta")
-            expect(page).to_have_url(re.compile(r"filter-category=a"))
+        expect(results).to_contain_text("Offre alpha")
+        expect(results).not_to_contain_text("Offre beta")
+        expect(page).to_have_url(re.compile(r"filter-category=a"))
 
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_lands_on_filtered_results_via_deep_link(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_a = OfferFactory.create_model(
             title="Offre alpha deep", category=Category.A
@@ -224,26 +224,28 @@ class TestResultsFilters:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.side_effect = partial(
+            fake_execute_filter_by_category, offer_a, offer_b
+        )
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute",
-            side_effect=partial(fake_execute_filter_by_category, offer_a, offer_b),
-        ):
-            page.goto(f"{live_server.url}{results_url}?filter-category=a")
+        page.goto(f"{live_server.url}{results_url}?filter-category=a")
 
-            results = page.get_by_test_id("cv-results")
-            expect(results).to_be_visible()
-            expect(results).to_contain_text("Offre alpha deep")
-            expect(results).not_to_contain_text("Offre beta deep")
-            expect(page.locator("#desktop-filter-category-a")).to_be_checked()
+        results = page.get_by_test_id("cv-results")
+        expect(results).to_be_visible()
+        expect(results).to_contain_text("Offre alpha deep")
+        expect(results).not_to_contain_text("Offre beta deep")
+        expect(page.locator("#desktop-filter-category-a")).to_be_checked()
 
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_combines_category_and_versant_filters(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         offer_a_fpe = OfferFactory.create_model(
             title="Offre alpha FPE", category=Category.A
@@ -259,41 +261,41 @@ class TestResultsFilters:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.side_effect = partial(
+            fake_execute_filter_by_category_and_versant,
+            offer_a_fpe,
+            offer_a_fpt,
+            offer_b_fpe,
+        )
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute",
-            side_effect=partial(
-                fake_execute_filter_by_category_and_versant,
-                offer_a_fpe,
-                offer_a_fpt,
-                offer_b_fpe,
-            ),
-        ):
-            page.goto(f"{live_server.url}{results_url}")
-            results = page.get_by_test_id("cv-results")
-            expect(results).to_contain_text("Offre alpha FPE")
-            expect(results).to_contain_text("Offre alpha FPT")
-            expect(results).to_contain_text("Offre beta FPE")
+        page.goto(f"{live_server.url}{results_url}")
+        results = page.get_by_test_id("cv-results")
+        expect(results).to_contain_text("Offre alpha FPE")
+        expect(results).to_contain_text("Offre alpha FPT")
+        expect(results).to_contain_text("Offre beta FPE")
 
-            page.locator("label:has(#desktop-filter-category-a)").click()
-            expect(page).to_have_url(re.compile(r"filter-category=a"))
-            expect(results).not_to_contain_text("Offre beta FPE")
+        page.locator("label:has(#desktop-filter-category-a)").click()
+        expect(page).to_have_url(re.compile(r"filter-category=a"))
+        expect(results).not_to_contain_text("Offre beta FPE")
 
-            page.locator("label:has(#desktop-filter-versant-FPE)").click()
-            expect(page).to_have_url(re.compile(r"filter-versant=FPE"))
-            expect(results).to_contain_text("Offre alpha FPE")
-            expect(results).not_to_contain_text("Offre alpha FPT")
+        page.locator("label:has(#desktop-filter-versant-FPE)").click()
+        expect(page).to_have_url(re.compile(r"filter-versant=FPE"))
+        expect(results).to_contain_text("Offre alpha FPE")
+        expect(results).not_to_contain_text("Offre alpha FPT")
 
 
 @pytest.mark.e2e
 class TestResultsPagination:
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_navigates_to_page_2_via_dsfr_pagination(
-        self, page: Page, live_server, transactional_db, settings
+        self, mock_execute, page: Page, live_server, transactional_db, settings
     ) -> None:
         settings.CV_RESULTS_PER_PAGE = 3
 
@@ -306,27 +308,22 @@ class TestResultsPagination:
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = [
+            ((offer, []), 0.9 - i * 0.05) for i, offer in enumerate(offers)
+        ]
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = [
-                ((offer, []), 0.9 - i * 0.05) for i, offer in enumerate(offers)
-            ]
+        page.goto(f"{live_server.url}{results_url}")
+        results = page.get_by_test_id("cv-results")
+        expect(results).to_be_visible()
+        expect(results).to_contain_text("Offre paginée 0")
+        expect(results).not_to_contain_text("Offre paginée 4")
 
-            page.goto(f"{live_server.url}{results_url}")
-            results = page.get_by_test_id("cv-results")
-            expect(results).to_be_visible()
-            expect(results).to_contain_text("Offre paginée 0")
-            expect(results).not_to_contain_text("Offre paginée 4")
+        page.locator('a.fr-pagination__link[title="Page 2"]').click()
 
-            page.locator('a.fr-pagination__link[title="Page 2"]').click()
-
-            expect(page).to_have_url(re.compile(r"page=2"))
-            expect(results).to_contain_text("Offre paginée 4")
-            expect(results).not_to_contain_text("Offre paginée 0")
+        expect(page).to_have_url(re.compile(r"page=2"))
+        expect(results).to_contain_text("Offre paginée 4")
+        expect(results).not_to_contain_text("Offre paginée 0")

--- a/src/web/tests/presentation/candidate/e2e/test_results_states.py
+++ b/src/web/tests/presentation/candidate/e2e/test_results_states.py
@@ -11,33 +11,32 @@ from tests.factories.candidate.cv_metadata_factory import CVMetadataFactory
 
 @pytest.mark.e2e
 class TestResultsEmptyAndFailedStates:
+    @patch(
+        "application.candidate.usecases.match_cv_to_opportunities."
+        "MatchCVToOpportunitiesUsecase.execute"
+    )
     def test_user_sees_no_results_state_when_matching_returns_empty(
-        self, page: Page, live_server, transactional_db
+        self, mock_execute, page: Page, live_server, transactional_db
     ) -> None:
         cv_metadata = CVMetadataFactory.create_entity(
             status=CVStatus.COMPLETED, search_query="dev"
         )
         CVMetadataModel.from_entity(cv_metadata).save()
+        mock_execute.return_value = []
 
         results_url = reverse(
             "candidate:cv_results", kwargs={"cv_uuid": cv_metadata.entity_id}
         )
 
-        with patch(
-            "application.candidate.usecases.match_cv_to_opportunities."
-            "MatchCVToOpportunitiesUsecase.execute"
-        ) as mock_execute:
-            mock_execute.return_value = []
+        page.goto(f"{live_server.url}{results_url}")
 
-            page.goto(f"{live_server.url}{results_url}")
-
-            expect(
-                page.get_by_text(
-                    "nous n'avons pas trouvé d'opportunité",
-                    exact=False,
-                )
-            ).to_be_visible()
-            expect(page.get_by_test_id("cv-results")).not_to_be_visible()
+        expect(
+            page.get_by_text(
+                "nous n'avons pas trouvé d'opportunité",
+                exact=False,
+            )
+        ).to_be_visible()
+        expect(page.get_by_test_id("cv-results")).not_to_be_visible()
 
     def test_user_is_redirected_to_upload_when_cv_status_is_failed(
         self, page: Page, live_server, transactional_db

--- a/src/web/tests/presentation/candidate/tasks/test_process_cv_tasks.py
+++ b/src/web/tests/presentation/candidate/tasks/test_process_cv_tasks.py
@@ -7,28 +7,24 @@ CV_UUID = str(uuid4())
 CV_BYTES = b"fake pdf content"
 
 
-def test_process_cv_task_is_enqueued():
-    with patch(
-        "infrastructure.di.candidate.candidate_factory.create_candidate_container"
-    ) as mock_factory:
-        process_cv_task(CV_UUID, CV_BYTES)
+@patch("infrastructure.di.candidate.candidate_factory.create_candidate_container")
+def test_process_cv_task_is_enqueued(mock_factory):
+    process_cv_task(CV_UUID, CV_BYTES)
 
     mock_factory.assert_not_called()
 
 
-def test_process_cv_task_calls_usecase(db):
+@patch("presentation.candidate.tasks.create_candidate_container")
+def test_process_cv_task_calls_usecase(mock_create_container, db):
     mock_execute = AsyncMock()
     mock_usecase = MagicMock()
     mock_usecase.execute = mock_execute
 
     mock_container = MagicMock()
     mock_container.process_uploaded_cv_usecase.return_value = mock_usecase
+    mock_create_container.return_value = mock_container
 
-    with patch(
-        "presentation.candidate.tasks.create_candidate_container",
-        return_value=mock_container,
-    ):
-        process_cv_task.call_local(CV_UUID, CV_BYTES)
+    process_cv_task.call_local(CV_UUID, CV_BYTES)
 
     mock_container.process_uploaded_cv_usecase.assert_called_once()
     mock_execute.assert_awaited_once_with(UUID(CV_UUID), CV_BYTES)

--- a/src/web/tests/presentation/ingestion/management/test_archive_offers.py
+++ b/src/web/tests/presentation/ingestion/management/test_archive_offers.py
@@ -7,17 +7,19 @@ from django.core.management import call_command
 METHOD = "presentation.ingestion.management.commands.archive_offers.archive_offers"
 
 
-def test_command_calls_usecase_with_default_datetime(db):
-    with patch(METHOD) as mock_task:
-        call_command("archive_offers")
-        mock_task.assert_called_once()
-        called_with = mock_task.call_args.kwargs["updated_after"]
-        expected = datetime.now() - relativedelta(hours=24)
-        assert abs((called_with - expected).total_seconds()) < 5  # noqa
+@patch(METHOD)
+def test_command_calls_usecase_with_default_datetime(mock_task, db):
+    call_command("archive_offers")
+
+    mock_task.assert_called_once()
+    called_with = mock_task.call_args.kwargs["updated_after"]
+    expected = datetime.now() - relativedelta(hours=24)
+    assert abs((called_with - expected).total_seconds()) < 5  # noqa
 
 
-def test_command_calls_usecase_with_arg(db):
+@patch(METHOD)
+def test_command_calls_usecase_with_arg(mock_task, db):
     updated_after = "2026-01-01T00:00:00"
-    with patch(METHOD) as mock_task:
-        call_command("archive_offers", updated_after=updated_after)
-        mock_task.assert_called_once_with(updated_after=updated_after)
+    call_command("archive_offers", updated_after=updated_after)
+
+    mock_task.assert_called_once_with(updated_after=updated_after)

--- a/src/web/tests/presentation/ingestion/views/test_views.py
+++ b/src/web/tests/presentation/ingestion/views/test_views.py
@@ -18,12 +18,14 @@ class TestHueyHealthView:
         response = api_client.get(self.url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_redis_unavailable(self, authenticated_client):
-        with patch("huey.contrib.djhuey.HUEY.storage.conn.ping") as mocked_ping:
-            mocked_ping.side_effect = Exception("Redis connection refused")
-            response = authenticated_client.get(self.url)
-            assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-            assert response.data == {"status": "Huey health check failed"}
+    @patch("huey.contrib.djhuey.HUEY.storage.conn.ping")
+    def test_redis_unavailable(self, mocked_ping, authenticated_client):
+        mocked_ping.side_effect = Exception("Redis connection refused")
+
+        response = authenticated_client.get(self.url)
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.data == {"status": "Huey health check failed"}
 
 
 class TestRedocView:

--- a/src/web/tests/presentation/recruteur/test_views.py
+++ b/src/web/tests/presentation/recruteur/test_views.py
@@ -63,7 +63,10 @@ class TestOrganismeView:
         response = api_client.get(ORGANISME_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_authenticated_access_is_ok(self, authenticated_client):
+    @patch("presentation.recruteur.views.recruteur_container")
+    def test_authenticated_access_is_ok(
+        self, mock_recruteur_container, authenticated_client
+    ):
         mock_organisme = MagicMock()
         mock_organisme.nom = "COMMUNE DE BRIANCON"
         mock_organisme.siret = "21050023700354"
@@ -73,12 +76,9 @@ class TestOrganismeView:
 
         mock_container = MagicMock()
         mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
 
-        with patch(
-            "presentation.recruteur.views.recruteur_container",
-            return_value=mock_container,
-        ):
-            response = authenticated_client.get(ORGANISME_URL)
+        response = authenticated_client.get(ORGANISME_URL)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -86,18 +86,18 @@ class TestOrganismeView:
             "siret": "21050023700354",
         }
 
-    def test_returns_404_when_organisme_not_found(self, authenticated_client):
+    @patch("presentation.recruteur.views.recruteur_container")
+    def test_returns_404_when_organisme_not_found(
+        self, mock_recruteur_container, authenticated_client
+    ):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = ErreurRecruteur("not found")
 
         mock_container = MagicMock()
         mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
 
-        with patch(
-            "presentation.recruteur.views.recruteur_container",
-            return_value=mock_container,
-        ):
-            response = authenticated_client.get(ORGANISME_URL)
+        response = authenticated_client.get(ORGANISME_URL)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found."}
@@ -108,23 +108,26 @@ class TestEtapesRecrutementOrganismeView:
         response = api_client.get(ETAPES_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_returns_404_when_organisme_not_found(self, authenticated_client):
+    @patch("presentation.recruteur.views.recruteur_container")
+    def test_returns_404_when_organisme_not_found(
+        self, mock_recruteur_container, authenticated_client
+    ):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = ErreurRecruteur("not found")
 
         mock_container = MagicMock()
         mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
 
-        with patch(
-            "presentation.recruteur.views.recruteur_container",
-            return_value=mock_container,
-        ):
-            response = authenticated_client.get(ETAPES_URL)
+        response = authenticated_client.get(ETAPES_URL)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"organisme_uuid": "Not found."}
 
-    def test_authenticated_access_is_ok(self, authenticated_client):
+    @patch("presentation.recruteur.views.recruteur_container")
+    def test_authenticated_access_is_ok(
+        self, mock_recruteur_container, authenticated_client
+    ):
         organisme = OrganismeRecruteurFactory.create_entity()
 
         mock_usecase = MagicMock()
@@ -132,12 +135,9 @@ class TestEtapesRecrutementOrganismeView:
 
         mock_container = MagicMock()
         mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
 
-        with patch(
-            "presentation.recruteur.views.recruteur_container",
-            return_value=mock_container,
-        ):
-            response = authenticated_client.get(ETAPES_URL)
+        response = authenticated_client.get(ETAPES_URL)
 
         assert response.status_code == status.HTTP_200_OK
         steps = []
@@ -159,39 +159,42 @@ class TestInitEtapesRecrutementOrganismeView:
         response = api_client.post(INIT_ETAPES_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_returns_404_when_organisme_not_found(self, authenticated_client):
+    @patch("presentation.recruteur.views.recruteur_container")
+    def test_returns_404_when_organisme_not_found(
+        self, mock_recruteur_container, authenticated_client
+    ):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = ErreurRecruteur("not found")
 
         mock_container = MagicMock()
         mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
 
-        with patch(
-            "presentation.recruteur.views.recruteur_container",
-            return_value=mock_container,
-        ):
-            response = authenticated_client.post(INIT_ETAPES_URL)
+        response = authenticated_client.post(INIT_ETAPES_URL)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"organisme_uuid": "Not found."}
 
-    def test_returns_500_on_unexpected_error(self, authenticated_client):
+    @patch("presentation.recruteur.views.recruteur_container")
+    def test_returns_500_on_unexpected_error(
+        self, mock_recruteur_container, authenticated_client
+    ):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = Exception("unexpected")
 
         mock_container = MagicMock()
         mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
 
-        with patch(
-            "presentation.recruteur.views.recruteur_container",
-            return_value=mock_container,
-        ):
-            response = authenticated_client.post(INIT_ETAPES_URL)
+        response = authenticated_client.post(INIT_ETAPES_URL)
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json() == {"error": "Unexpected error"}
 
-    def test_authenticated_post_initialize_steps(self, authenticated_client):
+    @patch("presentation.recruteur.views.recruteur_container")
+    def test_authenticated_post_initialize_steps(
+        self, mock_recruteur_container, authenticated_client
+    ):
         organisme = OrganismeRecruteurFactory.create_entity()
         organisme.initialiser_etapes()
 
@@ -200,12 +203,9 @@ class TestInitEtapesRecrutementOrganismeView:
 
         mock_container = MagicMock()
         mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
 
-        with patch(
-            "presentation.recruteur.views.recruteur_container",
-            return_value=mock_container,
-        ):
-            response = authenticated_client.post(INIT_ETAPES_URL)
+        response = authenticated_client.post(INIT_ETAPES_URL)
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == [


### PR DESCRIPTION
## 📝 Description
🎸 remplacer les context managers with patch(...) par des décorateurs @patch dans toute la suite de tests

Laissés volontairement en `with patch` (non convertibles mécaniquement) :
- les blocs `with` combinant un `patch` avec `pytest.raises` ou un `side_effect`/`return_value` local
- les fixtures yield (mock_container, mock_execute, etc.), la forme pytest idiomatique.
- patch.object sur des instances fournies par une fixture, les décorateurs sont évalués au moment de la définition et ne peuvent pas référencer une valeur de fixture résolue à l'exécution. 

## 🏷️ Type de changement
- [x] ♻️ Refactorisation
- [x] 🔧 Changement technique


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
