### PR TITLE
♻️(ingestion) casse le cycle d'import celery_app → container

### DIFF
--- a/src/ingestion/application/tasks/process_webhook.py
+++ b/src/ingestion/application/tasks/process_webhook.py
@@ -4,7 +4,8 @@ from uuid import UUID
 
 import httpx
 
-from infrastructure.celery_app import celery_app, get_container
+from infrastructure.celery_app import celery_app
+from infrastructure.di.bootstrap import get_container
 from infrastructure.exceptions.exceptions import ExternalApiError
 
 logger = logging.getLogger(__name__)

--- a/src/ingestion/infrastructure/celery_app.py
+++ b/src/ingestion/infrastructure/celery_app.py
@@ -1,32 +1,6 @@
-import asyncio
-
 from celery import Celery
-from celery.signals import worker_process_init
 
 from api.config import settings
-from infrastructure.di.container import Container, create_container
-
-_state: dict[str, Container | None] = {"container": None}
-
-
-def init_container() -> None:
-    container = create_container()
-    asyncio.run(container.load_sources_use_case().execute())
-    _state["container"] = container
-
-
-def get_container() -> Container:
-    if _state["container"] is None:
-        init_container()
-    container = _state["container"]
-    if container is None:
-        raise RuntimeError("Container could not be initialized")
-    return container
-
-
-@worker_process_init.connect
-def _init_worker_container(**kwargs: object) -> None:
-    init_container()
 
 
 def create_celery_app() -> Celery:

--- a/src/ingestion/infrastructure/di/bootstrap.py
+++ b/src/ingestion/infrastructure/di/bootstrap.py
@@ -1,0 +1,31 @@
+import asyncio
+from typing import TYPE_CHECKING
+
+from celery.signals import worker_process_init
+
+if TYPE_CHECKING:
+    from infrastructure.di.container import Container
+
+_state: dict[str, "Container | None"] = {"container": None}
+
+
+def init_container() -> None:
+    from infrastructure.di.container import create_container  # noqa: PLC0415
+
+    container = create_container()
+    asyncio.run(container.load_sources_use_case().execute())
+    _state["container"] = container
+
+
+def get_container() -> "Container":
+    if _state["container"] is None:
+        init_container()
+    container = _state["container"]
+    if container is None:
+        raise RuntimeError("Container could not be initialized")
+    return container
+
+
+@worker_process_init.connect
+def _init_worker_container(**kwargs: object) -> None:
+    init_container()

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -6,6 +6,7 @@ from sqlalchemy import Engine
 
 from api.config import get_settings
 from application.pipelines.ingest_offer_pipeline import IngestOfferPipeline
+from application.tasks.process_webhook import save_raw_offer_webhook
 from application.use_cases.archive_offer import ArchiveOfferUseCase
 from application.use_cases.clean_raw_offer import CleanRawOfferUseCase
 from application.use_cases.import_offers import ImportOffersUseCase
@@ -38,10 +39,6 @@ from infrastructure.webhook_repository import WebhookRepository
 
 
 def _dispatch_save_raw_offer_webhook(webhook_id: str) -> None:
-    from application.tasks.process_webhook import (  # noqa: PLC0415
-        save_raw_offer_webhook,
-    )
-
     save_raw_offer_webhook.delay(webhook_id)
 
 


### PR DESCRIPTION
## 📝 Description

Extrait le bootstrap DI (get_container/init_container) dans infrastructure/di/bootstrap.py pour que celery_app.py soit un module feuille sans dépendance vers container.py.

container.py peut désormais importer save_raw_offer_webhook en tête de fichier et supprimer l'import différé.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
