### PR TITLE
✨(storybook) Add workflow for on-demand branch previews

### DIFF
--- a/.github/workflows/storybook_pages.yml
+++ b/.github/workflows/storybook_pages.yml
@@ -14,7 +14,20 @@ on:
       - "src/web/presentation/frontend/**"
       - ".github/workflows/storybook_pages.yml"
       - ".github/actions/**"
+  delete:
+    branches-ignore:
+      - main
+      - gh-pages
   workflow_dispatch:
+    inputs:
+      deploy_type:
+        description: "Type de déploiement"
+        required: true
+        default: "branch-preview"
+        type: choice
+        options:
+          - branch-preview
+          - stable
 
 permissions:
   contents: write
@@ -22,12 +35,18 @@ permissions:
   pages: read
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('gh-pages-deploy-pr-{0}', github.event.number) || 'gh-pages-deploy' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: >-
+    ${{
+      github.event_name == 'pull_request' && format('gh-pages-deploy-pr-{0}', github.event.number) ||
+      github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'branch-preview' && format('gh-pages-deploy-branch-{0}', github.ref_name) ||
+      github.event_name == 'delete' && format('gh-pages-cleanup-branch-{0}', github.event.ref) ||
+      'gh-pages-deploy'
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'branch-preview') }}
 
 jobs:
   deploy-stable:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'stable')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -69,8 +88,58 @@ jobs:
           branch: gh-pages
           folder: src/web/presentation/frontend/storybook-static
           target-folder: storybook
-          clean-exclude: pr-*
+          clean-exclude: |
+            pr-*
+            branch-*
           force: false
+
+  deploy-branch-preview:
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'branch-preview'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/web
+    steps:
+      - uses: actions/checkout@v5
+      - name: Sanitize branch name
+        id: branch
+        run: |
+          BRANCH_NAME="${GITHUB_REF_NAME}"
+          SANITIZED=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-50)
+          echo "name=$SANITIZED" >> $GITHUB_OUTPUT
+        working-directory: .
+      - name: Resolve GitHub Pages base path
+        id: pages
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getPages({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            const { origin, pathname } = new URL(data.html_url)
+            core.setOutput('origin', origin)
+            core.setOutput('base', pathname.replace(/\/$/, ''))
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          lock-file-path: src/web/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - name: Build Storybook
+        env:
+          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base }}/storybook/branch-${{ steps.branch.outputs.name }}/
+        run: pnpm --filter csplab-frontend build-storybook
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: src/web/presentation/frontend/storybook-static
+          target-folder: storybook/branch-${{ steps.branch.outputs.name }}
+          force: false
+      - name: Print preview URL
+        run: |
+          echo "## 📖 Storybook Preview" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "URL: ${{ steps.pages.outputs.origin }}${{ steps.pages.outputs.base }}/storybook/branch-${{ steps.branch.outputs.name }}/" >> $GITHUB_STEP_SUMMARY
+        working-directory: .
 
   deploy-preview:
     if: github.event_name == 'pull_request' && github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'storybook')
@@ -141,6 +210,39 @@ jobs:
           git commit -m "chore: remove Storybook preview for PR #${{ github.event.number }}"
           # gh-pages can move under us (a stable deploy may push concurrently),
           # so rebase and retry rather than failing on a rejected push.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:gh-pages; then exit 0; fi
+            echo "Push rejected, rebasing onto gh-pages (attempt $attempt)…"
+            git pull --rebase origin gh-pages
+          done
+          echo "Could not push preview cleanup after 3 attempts" >&2
+          exit 1
+
+  cleanup-branch-preview:
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+      - name: Sanitize branch name
+        id: branch
+        run: |
+          BRANCH_NAME="${{ github.event.ref }}"
+          SANITIZED=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-50)
+          echo "name=$SANITIZED" >> $GITHUB_OUTPUT
+      - name: Remove branch preview folder
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          FOLDER="storybook/branch-${{ steps.branch.outputs.name }}"
+          if [ ! -d "$FOLDER" ]; then
+            echo "Folder $FOLDER does not exist, nothing to clean"
+            exit 0
+          fi
+          git rm -rf "$FOLDER"
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: remove Storybook preview for branch ${{ github.event.ref }}"
           for attempt in 1 2 3; do
             if git push origin HEAD:gh-pages; then exit 0; fi
             echo "Push rejected, rebasing onto gh-pages (attempt $attempt)…"


### PR DESCRIPTION
## 📝 Description
Permettre de déployer des storybook directement depuis une branche (sans passer pour un PR) pour le prototypage d'écran.

**Flux complet**

- Création de la branche feat/proto-ecrans
- Déploiement du storybook via Actions → Run workflow → branch-preview → URL : .../storybook/branch-feat-proto-ecrans/
- Suppression de la branche → Le dossier storybook/branch-feat-proto-ecrans/ est automatiquement supprimé de gh-pages

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
