### PR TITLE
♻️(storybook) isolate gh pages deployments in subfolders

### DIFF
--- a/.github/workflows/storybook_pages.yml
+++ b/.github/workflows/storybook_pages.yml
@@ -53,6 +53,10 @@ jobs:
         working-directory: ./src/web
     steps:
       - uses: actions/checkout@v5
+      - name: Short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        working-directory: .
       - name: Resolve GitHub Pages base path
         id: pages
         uses: actions/github-script@v7
@@ -100,6 +104,7 @@ jobs:
           folder: ${{ runner.temp }}/ghpages-root
           clean: false
           force: false
+          commit-message: "🚀(storybook) deploy root files from ${{ steps.sha.outputs.short }}"
       - name: Deploy main Storybook
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -107,6 +112,7 @@ jobs:
           folder: src/web/presentation/frontend/storybook-static
           target-folder: storybook/main
           force: false
+          commit-message: "🚀(storybook) deploy main book from ${{ steps.sha.outputs.short }}"
 
   deploy-branch-preview:
     if: github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'branch-preview'
@@ -122,6 +128,7 @@ jobs:
           BRANCH_NAME="${GITHUB_REF_NAME}"
           SANITIZED=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-50)
           echo "name=$SANITIZED" >> $GITHUB_OUTPUT
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
         working-directory: .
       - name: Resolve GitHub Pages base path
         id: pages
@@ -150,6 +157,7 @@ jobs:
           folder: src/web/presentation/frontend/storybook-static
           target-folder: storybook/branch/${{ steps.branch.outputs.name }}
           force: false
+          commit-message: "🚀(storybook) deploy branch preview '${{ steps.branch.outputs.name }}' from ${{ steps.branch.outputs.short_sha }}"
       - name: Print preview URL
         run: |
           echo "## 📖 Storybook Preview" >> $GITHUB_STEP_SUMMARY
@@ -165,6 +173,12 @@ jobs:
         working-directory: ./src/web
     steps:
       - uses: actions/checkout@v5
+      - name: Short SHA
+        id: sha
+        run: echo "short=${HEAD_SHA::7}" >> "$GITHUB_OUTPUT"
+        working-directory: .
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       - name: Resolve GitHub Pages base path
         id: pages
         uses: actions/github-script@v7
@@ -192,6 +206,7 @@ jobs:
           folder: src/web/presentation/frontend/storybook-static
           target-folder: storybook/pr/${{ github.event.number }}
           force: false
+          commit-message: "🚀(storybook) deploy PR #${{ github.event.number }} preview from ${{ steps.sha.outputs.short }}"
       - uses: actions/github-script@v7
         env:
           PREVIEW_URL: ${{ steps.pages.outputs.origin }}${{ steps.pages.outputs.base }}/storybook/pr/${{ github.event.number }}/
@@ -224,7 +239,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm -rf --ignore-unmatch "storybook/pr/${{ github.event.number }}"
           git diff --cached --quiet && exit 0
-          git commit -m "chore: remove Storybook preview for PR #${{ github.event.number }}"
+          git commit -m "🔥(storybook) cleanup PR #${{ github.event.number }} preview"
           for attempt in 1 2 3; do
             if git push origin HEAD:gh-pages; then exit 0; fi
             git pull --rebase origin gh-pages
@@ -256,7 +271,7 @@ jobs:
           fi
           git rm -rf "$FOLDER"
           git diff --cached --quiet && exit 0
-          git commit -m "chore: remove Storybook preview for branch ${{ github.event.ref }}"
+          git commit -m "🔥(storybook) cleanup branch preview '${{ steps.branch.outputs.name }}'"
           for attempt in 1 2 3; do
             if git push origin HEAD:gh-pages; then exit 0; fi
             git pull --rebase origin gh-pages

--- a/.github/workflows/storybook_pages.yml
+++ b/.github/workflows/storybook_pages.yml
@@ -27,7 +27,7 @@ on:
         type: choice
         options:
           - branch-preview
-          - stable
+          - main
 
 permissions:
   contents: write
@@ -45,8 +45,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'branch-preview') }}
 
 jobs:
-  deploy-stable:
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'stable')
+  deploy-main:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy_type == 'main')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -71,26 +71,41 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build Storybook
         env:
-          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base }}/storybook/
+          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base }}/storybook/main/
         run: pnpm --filter csplab-frontend build-storybook
-      - name: Ensure .nojekyll exists at the site root
+      - name: Prepare root site files
         run: |
-          mkdir -p "${{ runner.temp }}/ghpages-nojekyll"
-          touch "${{ runner.temp }}/ghpages-nojekyll/.nojekyll"
-      - uses: JamesIves/github-pages-deploy-action@v4
+          ROOT="${{ runner.temp }}/ghpages-root"
+          mkdir -p "$ROOT/storybook"
+          touch "$ROOT/.nojekyll"
+          cat > "$ROOT/storybook/index.html" <<'HTML'
+          <!doctype html>
+          <html lang="fr">
+            <head>
+              <meta charset="utf-8" />
+              <meta http-equiv="refresh" content="0; url=./main/" />
+              <link rel="canonical" href="./main/" />
+              <title>Storybook</title>
+            </head>
+            <body>
+              <p>Redirection vers <a href="./main/">le Storybook</a>…</p>
+            </body>
+          </html>
+          HTML
+        working-directory: .
+      - name: Deploy root site files
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: ${{ runner.temp }}/ghpages-nojekyll
+          folder: ${{ runner.temp }}/ghpages-root
           clean: false
           force: false
-      - uses: JamesIves/github-pages-deploy-action@v4
+      - name: Deploy main Storybook
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: src/web/presentation/frontend/storybook-static
-          target-folder: storybook
-          clean-exclude: |
-            pr-*
-            branch-*
+          target-folder: storybook/main
           force: false
 
   deploy-branch-preview:
@@ -126,19 +141,20 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build Storybook
         env:
-          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base }}/storybook/branch-${{ steps.branch.outputs.name }}/
+          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base }}/storybook/branch/${{ steps.branch.outputs.name }}/
         run: pnpm --filter csplab-frontend build-storybook
-      - uses: JamesIves/github-pages-deploy-action@v4
+      - name: Deploy branch preview
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: src/web/presentation/frontend/storybook-static
-          target-folder: storybook/branch-${{ steps.branch.outputs.name }}
+          target-folder: storybook/branch/${{ steps.branch.outputs.name }}
           force: false
       - name: Print preview URL
         run: |
           echo "## 📖 Storybook Preview" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "URL: ${{ steps.pages.outputs.origin }}${{ steps.pages.outputs.base }}/storybook/branch-${{ steps.branch.outputs.name }}/" >> $GITHUB_STEP_SUMMARY
+          echo "URL: ${{ steps.pages.outputs.origin }}${{ steps.pages.outputs.base }}/storybook/branch/${{ steps.branch.outputs.name }}/" >> $GITHUB_STEP_SUMMARY
         working-directory: .
 
   deploy-preview:
@@ -167,17 +183,18 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build Storybook
         env:
-          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base }}/storybook/pr-${{ github.event.number }}/
+          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base }}/storybook/pr/${{ github.event.number }}/
         run: pnpm --filter csplab-frontend build-storybook
-      - uses: JamesIves/github-pages-deploy-action@v4
+      - name: Deploy PR preview
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: src/web/presentation/frontend/storybook-static
-          target-folder: storybook/pr-${{ github.event.number }}
+          target-folder: storybook/pr/${{ github.event.number }}
           force: false
       - uses: actions/github-script@v7
         env:
-          PREVIEW_URL: ${{ steps.pages.outputs.origin }}${{ steps.pages.outputs.base }}/storybook/pr-${{ github.event.number }}/
+          PREVIEW_URL: ${{ steps.pages.outputs.origin }}${{ steps.pages.outputs.base }}/storybook/pr/${{ github.event.number }}/
         with:
           script: |
             const url = process.env.PREVIEW_URL
@@ -205,14 +222,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git rm -rf --ignore-unmatch "storybook/pr-${{ github.event.number }}"
+          git rm -rf --ignore-unmatch "storybook/pr/${{ github.event.number }}"
           git diff --cached --quiet && exit 0
           git commit -m "chore: remove Storybook preview for PR #${{ github.event.number }}"
-          # gh-pages can move under us (a stable deploy may push concurrently),
-          # so rebase and retry rather than failing on a rejected push.
           for attempt in 1 2 3; do
             if git push origin HEAD:gh-pages; then exit 0; fi
-            echo "Push rejected, rebasing onto gh-pages (attempt $attempt)…"
             git pull --rebase origin gh-pages
           done
           echo "Could not push preview cleanup after 3 attempts" >&2
@@ -235,7 +249,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          FOLDER="storybook/branch-${{ steps.branch.outputs.name }}"
+          FOLDER="storybook/branch/${{ steps.branch.outputs.name }}"
           if [ ! -d "$FOLDER" ]; then
             echo "Folder $FOLDER does not exist, nothing to clean"
             exit 0
@@ -245,7 +259,6 @@ jobs:
           git commit -m "chore: remove Storybook preview for branch ${{ github.event.ref }}"
           for attempt in 1 2 3; do
             if git push origin HEAD:gh-pages; then exit 0; fi
-            echo "Push rejected, rebasing onto gh-pages (attempt $attempt)…"
             git pull --rebase origin gh-pages
           done
           echo "Could not push preview cleanup after 3 attempts" >&2

--- a/docs/storybook_pages.md
+++ b/docs/storybook_pages.md
@@ -1,0 +1,40 @@
+# Storybook on GitHub Pages
+
+The `Storybook Pages` workflow (`.github/workflows/storybook_pages.yml`) publishes
+Storybook to the `gh-pages` branch.
+
+## Layout
+
+Each source gets its own isolated folder under `storybook/`:
+
+| Path | Source | Trigger |
+| --- | --- | --- |
+| `storybook/main/` | `main` branch | push to `main`, or manual dispatch `deploy_type: main` |
+| `storybook/branch/<name>/` | any branch | manual dispatch `deploy_type: branch-preview` |
+| `storybook/pr/<number>/` | a pull request | PR labelled `storybook` |
+| `storybook/index.html` | — | redirects to `storybook/main/` |
+
+## Deploy a branch preview without a PR
+
+Run the workflow manually (Actions → Storybook Pages → Run workflow) from the
+branch, keeping `deploy_type: branch-preview`. The run summary prints the URL.
+A branch preview stays up until its branch is deleted; merges to `main` and other
+previews never remove it.
+
+## Why isolated folders
+
+`JamesIves/github-pages-deploy-action` cleans with `rsync --delete` scoped to its
+`target-folder`. Giving each source its own folder means a deploy can only delete
+its own files.
+
+**Invariant:** no job deploys to the `storybook/` root with `clean: true`. The
+root only receives `.nojekyll` and the redirect `index.html`, written with
+`clean: false`.
+
+## Cleanup
+
+- Closing a PR removes `storybook/pr/<number>/`.
+- Deleting a branch removes `storybook/branch/<name>/`.
+
+Cleanup jobs push directly to `gh-pages` and retry with `git pull --rebase` because
+a concurrent `main` deploy can move the branch under them.


### PR DESCRIPTION
## 📝 Description

Le déploiement storybook principal ("stable") effaçait les autres storybooks non exclus explicitement (avec `clean-exlude`) : les books de preview par pr étaient bien exclus, mais pas ceux déployés manuellement par branche qu'on vient d'ajouter.

Cette PR :

1. Isole chaque source dans son propre sous-dossier pour que la sécurité des previews ne dépende plus d'une liste à maintenir.

2. Renomme aussi le storybook "stable" en "main" pour mieux refléter ce qu'il est, un miroir de l'état du design system sur la branche main.

3. Rend les commits sur gh-pages plus explicites et moins verbeux :
```
🚀(storybook) deploy main book from <sha7>
🚀(storybook) deploy root files from <sha7>
🚀(storybook) deploy branch preview '<name>' from <sha7>
🚀(storybook) deploy PR #<n> preview from <sha7>
🔥(storybook) cleanup PR #<n> preview
🔥(storybook) cleanup branch preview '<name>'
```

## 🏷️ Type de changement
- [x] ♻️ Refactorisation
- [x] 🔧 Changement technique
- [x] 📚 Mise à jour de la documentation

## 🔧 Modifications

- Arborescence : `storybook/main/`, `storybook/branch/<name>/`, `storybook/pr/<number>/`, plus une redirection `storybook/index.html` vers `main/`.
- Chaque déploiement `clean` uniquement son propre dossier (le clean de l'action est scopé au `target-folder`, plus de `clean-exclude`)
- Messages de commit gh-pages explicites (source + SHA court) pour pouvoir auditer les déploiements avec `git log`.
- Doc dans `docs/storybook_pages.md`.

Renommage `stable` → `main` au passage : ce dossier contient le book de la branche main, pas une release figée.

## 🏝️ Comment tester

- le label `storybook` asspocié à cette pr doit déclencher le job pr preview, qui publie sous `storybook/pr/<numéro>/`, commente l'URL qui pointe vers un book fonctionnel
- depuis n'importe quelle branche une fois cette pr mergée (ou depuis celle associée à cette pr avant merge), actions => storybook pages => run workflow (`branch-preview`) publie sous `storybook/branch/<nom>/`. L'url est dans le récap du run et doit rendre un sb fonctionnel
- Une fois cette PR mergée, le book de référence reste accessible via `…/storybook/` (redirection) et `…/storybook/main/`
- Ces différents books ne doivent plus s'écraser les un les autres une fois publiées

## ✅ Liste de contrôle
- [ ] 💅 J'ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J'ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J'ai pris en compte l'impact sur les performances, la sécurité et l'expérience utilisateur.
- [x] 👀 J'ai demandé une revue à une personne de l'équipe.
