### PR TITLE
✨(ingestion) add retries to Talentsoft token fetch

### DIFF
--- a/src/ingestion/infrastructure/external_gateways/talentsoft_client.py
+++ b/src/ingestion/infrastructure/external_gateways/talentsoft_client.py
@@ -67,15 +67,21 @@ class BaseTalentsoftClient(AsyncHttpClient):
             "client_secret": self.client_secret,
         }
 
-        try:
-            response = await self.post(url, headers=headers, data=data)
-            response.raise_for_status()
-            payload = response.json()
-        except Exception as exc:
-            self.logger.error("Failed to fetch token from %s", self.api_name)
-            raise ExternalApiError(
-                message=f"Token request failed: {exc}", api_name=self.api_name
-            ) from exc
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await self.post(url, headers=headers, data=data)
+                response.raise_for_status()
+                payload = response.json()
+                break
+            except Exception as exc:
+                if attempt == self.max_retries:
+                    self.logger.error("Failed to fetch token from %s", self.api_name)
+                    raise ExternalApiError(
+                        message=f"Token request failed: {exc}", api_name=self.api_name
+                    ) from exc
+                self.logger.warning(
+                    "Token fetch attempt %d failed, retrying: %s", attempt + 1, exc
+                )
 
         try:
             token_response = TalentsoftTokenResponse(**cast(Dict[str, Any], payload))

--- a/src/ingestion/tests/unit/external_gateways/test_talentsoft_client.py
+++ b/src/ingestion/tests/unit/external_gateways/test_talentsoft_client.py
@@ -108,6 +108,52 @@ class TestGetAccessToken:
             assert exc_info.value.api_name == "Talentsoft Front API"
 
     @pytest.mark.asyncio
+    @patch(
+        "infrastructure.gateways.async_http_client.AsyncHttpClient.post",
+        new_callable=AsyncMock,
+    )
+    async def test_fetching_token_retries_on_transient_error(
+        self, mock_post, talentsoft_client
+    ):
+        talentsoft_client.cached_token = None
+        expected_token = fake.uuid4()
+        failed_response = mocked_response(status_code=503)
+        failed_response.raise_for_status.side_effect = Exception("503 Unavailable")
+        success_response = mocked_response(
+            return_value={
+                "access_token": expected_token,
+                "token_type": fake.word(),
+                "expires_in": 3600,
+            }
+        )
+
+        mock_post.side_effect = [failed_response, success_response]
+        result = await talentsoft_client.get_access_token()
+
+        assert result == expected_token
+        assert mock_post.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch(
+        "infrastructure.gateways.async_http_client.AsyncHttpClient.post",
+        new_callable=AsyncMock,
+    )
+    async def test_fetching_token_raises_after_max_retries(
+        self, mock_post, talentsoft_client
+    ):
+        talentsoft_client.cached_token = None
+        failed_response = mocked_response(status_code=503)
+        failed_response.raise_for_status.side_effect = Exception("503 Unavailable")
+
+        mock_post.return_value = failed_response
+
+        with pytest.raises(ExternalApiError, match="Token request failed") as exc_info:
+            await talentsoft_client.get_access_token()
+
+        assert exc_info.value.api_name == "Talentsoft Front API"
+        assert mock_post.call_count == talentsoft_client.max_retries + 1
+
+    @pytest.mark.asyncio
     async def test_fetching_returns_malformed_token(self, talentsoft_client):
         talentsoft_client.cached_token = None
         mock_response = mocked_response(return_value={"invalid": "response"})


### PR DESCRIPTION
## 📝 Description

La récupération du token d'authentification auprès de l'API Talentsoft échouait définitivement à la moindre erreur réseau transitoire, contrairement aux requêtes authentifiées qui bénéficiaient déjà d'un mécanisme de retry.

### Changements

- Ajout d'une boucle de retry dans `_fetch_new_token` (identique à celle de `_make_authenticated_request`)
- Un warning est loggé à chaque tentative échouée ; l'erreur n'est levée qu'une fois toutes les tentatives épuisées
- Deux nouveaux tests : récupération réussie après une erreur transitoire, et échec après épuisement des retries


## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
