### PR TITLE
📝(ingestion) corriger le schéma OpenAPI de OffersListView pour la pagination

### DIFF
--- a/src/web/presentation/ingestion/openapi.py
+++ b/src/web/presentation/ingestion/openapi.py
@@ -282,14 +282,25 @@ LIST_OFFERS_EXAMPLES = [
             "Les offres d'emploi sans date d'archivage sont retournées paginées"
         ),
         value={
-            "external_id": "Versant_FPE-2026-999999",
-            "title": "Responsable de la Division des Affaires Financières H/F",
-            "organization": "Ecole Nationale Supérieure de Techniques Avancées (ENSTA)",
-            "contract_type": "TITULAIRE_CONTRACTUEL",
-            "category": "A",
-            "publication_date": "2026-04-17T14:44:49.873000+00:00",
-            "offer_url": "https://test.com/offre-emploi/2026-999999/",
-            "archived_at": None,
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [
+                {
+                    "external_id": "Versant_FPE-2026-999999",
+                    "reference": "2026-999999",
+                    "source_id": "12345678-1234-4234-b234-123456789abc",
+                    "title": "Responsable de la Division des Affaires Financières H/F",
+                    "organization": (
+                        "Ecole Nationale Supérieure de Techniques Avancées (ENSTA)"
+                    ),
+                    "contract_type": "TITULAIRE_CONTRACTUEL",
+                    "category": "A",
+                    "publication_date": "2026-04-17T14:44:49.873000+00:00",
+                    "offer_url": "https://test.com/offre-emploi/2026-999999/",
+                    "archived_at": None,
+                }
+            ],
         },
         response_only=True,
         status_codes=["200"],
@@ -301,14 +312,25 @@ LIST_OFFERS_EXAMPLES = [
             "Les offres d'emploi avec une date d'archivage sont retournées paginées"
         ),
         value={
-            "external_id": "Versant_FPE-2026-999999",
-            "title": "Responsable de la Division des Affaires Financières H/F",
-            "organization": "Ecole Nationale Supérieure de Techniques Avancées (ENSTA)",
-            "contract_type": "TITULAIRE_CONTRACTUEL",
-            "category": "A",
-            "publication_date": "2026-04-17T14:44:49.873000+00:00",
-            "offer_url": "https://test.com/offre-emploi/2026-999999/",
-            "archived_at": "2026-05-17T12:42:42.873000+00:00",
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [
+                {
+                    "external_id": "Versant_FPE-2026-999999",
+                    "reference": "2026-999999",
+                    "source_id": "12345678-1234-4234-b234-123456789abc",
+                    "title": "Responsable de la Division des Affaires Financières H/F",
+                    "organization": (
+                        "Ecole Nationale Supérieure de Techniques Avancées (ENSTA)"
+                    ),
+                    "contract_type": "TITULAIRE_CONTRACTUEL",
+                    "category": "A",
+                    "publication_date": "2026-04-17T14:44:49.873000+00:00",
+                    "offer_url": "https://test.com/offre-emploi/2026-999999/",
+                    "archived_at": "2026-05-17T12:42:42.873000+00:00",
+                }
+            ],
         },
         response_only=True,
         status_codes=["200"],

--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -60,7 +60,15 @@ from presentation.ingestion.serializers import (
     examples=LIST_OFFERS_EXAMPLES,
     tags=["offres"],
     responses={
-        200: ListOffersResponseSerializer,
+        200: inline_serializer(
+            name="PaginatedListOffersResponse",
+            fields={
+                "count": drf_serializers.IntegerField(),
+                "next": drf_serializers.CharField(allow_null=True),
+                "previous": drf_serializers.CharField(allow_null=True),
+                "results": ListOffersResponseSerializer(many=True),
+            },
+        ),
         400: GenericErrorSerializer,
         401: TokenErrorSerializer,
         500: GenericErrorSerializer,

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -384,33 +384,45 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListOffersResponse'
+                $ref: '#/components/schemas/PaginatedListOffersResponse'
               examples:
                 Success-ActiveOffers:
                   value:
-                    external_id: Versant_FPE-2026-999999
-                    title: Responsable de la Division des Affaires Financières H/F
-                    organization: Ecole Nationale Supérieure de Techniques Avancées
-                      (ENSTA)
-                    contract_type: TITULAIRE_CONTRACTUEL
-                    category: A
-                    publication_date: '2026-04-17T14:44:49.873000+00:00'
-                    offer_url: https://test.com/offre-emploi/2026-999999/
-                    archived_at: null
+                    count: 1
+                    next: null
+                    previous: null
+                    results:
+                    - external_id: Versant_FPE-2026-999999
+                      reference: 2026-999999
+                      source_id: 12345678-1234-4234-b234-123456789abc
+                      title: Responsable de la Division des Affaires Financières H/F
+                      organization: Ecole Nationale Supérieure de Techniques Avancées
+                        (ENSTA)
+                      contract_type: TITULAIRE_CONTRACTUEL
+                      category: A
+                      publication_date: '2026-04-17T14:44:49.873000+00:00'
+                      offer_url: https://test.com/offre-emploi/2026-999999/
+                      archived_at: null
                   summary: Liste des offres d'emploi actives
                   description: Les offres d'emploi sans date d'archivage sont retournées
                     paginées
                 Success-ArchivedOffers:
                   value:
-                    external_id: Versant_FPE-2026-999999
-                    title: Responsable de la Division des Affaires Financières H/F
-                    organization: Ecole Nationale Supérieure de Techniques Avancées
-                      (ENSTA)
-                    contract_type: TITULAIRE_CONTRACTUEL
-                    category: A
-                    publication_date: '2026-04-17T14:44:49.873000+00:00'
-                    offer_url: https://test.com/offre-emploi/2026-999999/
-                    archived_at: '2026-05-17T12:42:42.873000+00:00'
+                    count: 1
+                    next: null
+                    previous: null
+                    results:
+                    - external_id: Versant_FPE-2026-999999
+                      reference: 2026-999999
+                      source_id: 12345678-1234-4234-b234-123456789abc
+                      title: Responsable de la Division des Affaires Financières H/F
+                      organization: Ecole Nationale Supérieure de Techniques Avancées
+                        (ENSTA)
+                      contract_type: TITULAIRE_CONTRACTUEL
+                      category: A
+                      publication_date: '2026-04-17T14:44:49.873000+00:00'
+                      offer_url: https://test.com/offre-emploi/2026-999999/
+                      archived_at: '2026-05-17T12:42:42.873000+00:00'
                   summary: Liste des offres d'emploi archivées
                   description: Les offres d'emploi avec une date d'archivage sont
                     retournées paginées
@@ -1567,6 +1579,26 @@ components:
       description: |-
         * `NON` - Non
         * `OUI` - Oui
+    PaginatedListOffersResponse:
+      type: object
+      properties:
+        count:
+          type: integer
+        next:
+          type: string
+          nullable: true
+        previous:
+          type: string
+          nullable: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ListOffersResponse'
+      required:
+      - count
+      - next
+      - previous
+      - results
     ProfessionInput:
       type: object
       properties:


### PR DESCRIPTION
## 📝 Description

Le schéma OpenAPI de `OffersListView` déclarait un `ListOffersResponseSerializer` direct en réponse 200, alors que la vue retourne en réalité une réponse paginée via `WebPagination` (enveloppe `count / next / previous / results`).

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
