### PR TITLE
✨(ingestion) autoriser l'authentification par API key sur OffersBySourceView

### DIFF
--- a/src/web/application/ingestion/interfaces/get_offers_by_source_input.py
+++ b/src/web/application/ingestion/interfaces/get_offers_by_source_input.py
@@ -5,4 +5,4 @@ from uuid import UUID
 @dataclass
 class GetOffersBySourceInput:
     source_id: UUID
-    utilisateur_entity_id: UUID
+    utilisateur_entity_id: UUID | None = None

--- a/src/web/application/ingestion/usecases/get_offers_by_source.py
+++ b/src/web/application/ingestion/usecases/get_offers_by_source.py
@@ -29,15 +29,16 @@ class GetOffersBySourceUseCase(IUseCase[GetOffersBySourceInput, IPage[Offer]]):
         self.utilisateur_repository = utilisateur_repository
 
     def execute(self, input_data: GetOffersBySourceInput) -> IPage[Offer]:
-        utilisateur = self.utilisateur_repository.get_by_entity_id(
-            input_data.utilisateur_entity_id
-        )
-        if not utilisateur.is_superuser:
-            source_ids = {input_data.source_id}
-            allowed = self.user_source_repository.get_allowed_source_ids(
-                utilisateur, source_ids
+        if input_data.utilisateur_entity_id is not None:
+            utilisateur = self.utilisateur_repository.get_by_entity_id(
+                input_data.utilisateur_entity_id
             )
-            if allowed != source_ids:
-                raise SourceAuthorizationError({input_data.source_id})
+            if not utilisateur.is_superuser:
+                source_ids = {input_data.source_id}
+                allowed = self.user_source_repository.get_allowed_source_ids(
+                    utilisateur, source_ids
+                )
+                if allowed != source_ids:
+                    raise SourceAuthorizationError({input_data.source_id})
 
         return self.offers_repository.get_by_source_id(input_data.source_id)

--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -135,7 +135,7 @@ class OffersListView(APIView):
     },
 )
 class OffersBySourceView(APIView):
-    authentication_classes = [JWTAuthentication]
+    authentication_classes = [JWTAuthentication, ApiKeyAuthentication]
     serializer_class = OfferDetailResponseSerializer
 
     def __init__(self, **kwargs):
@@ -144,7 +144,9 @@ class OffersBySourceView(APIView):
         self.logger = self.container.logger_service()
 
     def get(self, request, source_id):
-        utilisateur_entity_id = UUID(request.user.username)
+        utilisateur_entity_id = (
+            UUID(request.user.username) if isinstance(request.user, UserModel) else None
+        )
         try:
             usecase = self.container.get_offers_by_source_usecase()
             result = usecase.execute(

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -661,6 +661,7 @@ paths:
       - offres
       security:
       - jwtAuth: []
+      - ApiKeyAuth: []
       responses:
         '200':
           content:

--- a/src/web/tests/presentation/ingestion/views/test_offers_by_source.py
+++ b/src/web/tests/presentation/ingestion/views/test_offers_by_source.py
@@ -61,9 +61,16 @@ class TestOffersBySourceView:
         response = api_client.get(URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_api_key_authentication_returns_401(self, api_key_client):
+    def test_api_key_authentication_returns_offers(self, api_key_client, use_case):
+        offer = OfferFactory.create_entity(source_id=SOURCE_ID)
+        _make_paginated_mock(use_case, num_offers=1, offers_slice=[offer])
+
         response = api_key_client.get(URL)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+        assert response.status_code == status.HTTP_200_OK
+        use_case.execute.assert_called_once_with(
+            GetOffersBySourceInput(source_id=SOURCE_ID, utilisateur_entity_id=None)
+        )
 
     def test_post_not_allowed(self, authenticated_client):
         response = authenticated_client.post(URL)


### PR DESCRIPTION
## 📝 Description

`OffersBySourceView` n'acceptait que l'authentification JWT, ce qui empêchait le clients API key (`ingestion`) d'accéder aux offres d'une source.

On a besoin d'accéder aux offres pour une source pour #868. Actuellement on obtient une erreur HTTP 401.

### Changements

- `OffersBySourceView` : ajout de `ApiKeyAuthentication` dans `authentication_classes` ; `utilisateur_entity_id` est mis à `None` quand l'authentification se fait par API key (même pattern que `ArchiveOffersView` et `OffersUpsertView`)
- `GetOffersBySourceInput` : `utilisateur_entity_id` devient optionnel (`UUID | None = None`)
- `GetOffersBySourceUseCase` : la vérification d'autorisation sur la source est skippée quand `utilisateur_entity_id is None`
- Tests : mise à jour de `test_api_key_authentication_returns_401` → `test_api_key_authentication_returns_offers` pour refléter le nouveau comportement

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
