### PR TITLE
♻️(referentiel) sépare IOffersRepository en base et IIngestionOffersRepository

### DIFF
--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.1.11"
+version = "0.1.12"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/repositories/offers_repository_interface.py
+++ b/libs/referentiel/repositories/offers_repository_interface.py
@@ -1,29 +1,12 @@
-from typing import List, Protocol, TypedDict
+from typing import List, Protocol
 from uuid import UUID
 
 from ddd.page_interface import IPage
 
 from referentiel.entities.offer import Offer
-from referentiel.types import IUpsertResult
-
-
-class IArchiveError(TypedDict):
-    entity_id: UUID
-    error: str
-    exception: Exception
-
-
-class IArchiveResult(TypedDict):
-    fetched: int
-    vector_deleted: int
-    entity_archived: int
-    errors: List[IArchiveError]
 
 
 class IOffersRepository(Protocol):
-    # todo move this logic in ingestion
-    def upsert_batch(self, offers_list: List[Offer]) -> IUpsertResult: ...
-
     def get_by_id(self, offer_id: UUID) -> Offer: ...
 
     def get_by_ids(self, offer_ids: List[UUID]) -> List[Offer]: ...
@@ -43,14 +26,3 @@ class IOffersRepository(Protocol):
     ) -> IPage[Offer]: ...
 
     def get_by_source_id(self, source_id: UUID) -> IPage[Offer]: ...
-
-    # todo move this logic in ingestion
-    def get_pending_processing(self, limit: int = 1000) -> List[Offer]: ...
-
-    # todo move this logic in ingestion
-    def mark_as_processed(self, offers_list: List[Offer]) -> int: ...
-
-    # todo move this logic in ingestion
-    def mark_as_pending(self, offers_list: List[Offer]) -> int: ...
-
-    def mark_as_archived(self, offers_list: List[Offer]) -> int: ...

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1234,7 +1234,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/application/ingestion/usecases/archive_offer_by_reference.py
+++ b/src/web/application/ingestion/usecases/archive_offer_by_reference.py
@@ -1,5 +1,4 @@
 from ddd.usecase_interface import IUseCase
-from referentiel.repositories.offers_repository_interface import IOffersRepository
 
 from application.ingestion.interfaces.archive_offer_by_reference_input import (
     ArchiveOfferByReferenceInput,
@@ -10,6 +9,9 @@ from domain.identite.repositories.utilisateur_repository_interface import (
 from domain.ingestion.exceptions.source_authorization_error import (
     SourceAuthorizationError,
 )
+from domain.ingestion.repositories.ingestion_offers_repository_interface import (
+    IIngestionOffersRepository,
+)
 from domain.ingestion.repositories.user_source_repository_interface import (
     IUserSourceRepository,
 )
@@ -19,7 +21,7 @@ from domain.ingestion.repositories.vector_repository_interface import IVectorRep
 class ArchiveOfferByReferenceUseCase(IUseCase[ArchiveOfferByReferenceInput, None]):
     def __init__(
         self,
-        offers_repository: IOffersRepository,
+        offers_repository: IIngestionOffersRepository,
         vector_repository: IVectorRepository,
         user_source_repository: IUserSourceRepository,
         utilisateur_repository: IUtilisateurRepository,

--- a/src/web/application/ingestion/usecases/archive_offers.py
+++ b/src/web/application/ingestion/usecases/archive_offers.py
@@ -3,12 +3,12 @@ from datetime import datetime
 from asgiref.sync import async_to_sync
 from ddd.services.logger_interface import ILogger
 from ddd.usecase_interface import IUseCase
-from referentiel.repositories.offers_repository_interface import (
-    IArchiveResult,
-    IOffersRepository,
-)
 
 from domain.ingestion.gateways.document_gateway_interface import IDocumentGateway
+from domain.ingestion.repositories.ingestion_offers_repository_interface import (
+    IArchiveResult,
+    IIngestionOffersRepository,
+)
 from domain.ingestion.repositories.vector_repository_interface import IVectorRepository
 
 MAX_OFFSET = 100000
@@ -17,7 +17,7 @@ MAX_OFFSET = 100000
 class ArchiveOffersUsecase(IUseCase[datetime, IArchiveResult]):
     def __init__(
         self,
-        offers_repository: IOffersRepository,
+        offers_repository: IIngestionOffersRepository,
         document_gateway: IDocumentGateway,
         vector_repository: IVectorRepository,
         logger: ILogger,

--- a/src/web/application/ingestion/usecases/upsert_offers.py
+++ b/src/web/application/ingestion/usecases/upsert_offers.py
@@ -1,6 +1,5 @@
 from ddd.services.logger_interface import ILogger
 from ddd.usecase_interface import IUseCase
-from referentiel.repositories.offers_repository_interface import IOffersRepository
 from referentiel.types import IUpsertResult
 
 from application.ingestion.interfaces.upsert_offers_input import UpsertOffersInput
@@ -10,6 +9,9 @@ from domain.identite.repositories.utilisateur_repository_interface import (
 from domain.ingestion.exceptions.source_authorization_error import (
     SourceAuthorizationError,
 )
+from domain.ingestion.repositories.ingestion_offers_repository_interface import (
+    IIngestionOffersRepository,
+)
 from domain.ingestion.repositories.user_source_repository_interface import (
     IUserSourceRepository,
 )
@@ -18,7 +20,7 @@ from domain.ingestion.repositories.user_source_repository_interface import (
 class UpsertOffersUseCase(IUseCase[UpsertOffersInput, IUpsertResult]):
     def __init__(
         self,
-        offers_repository: IOffersRepository,
+        offers_repository: IIngestionOffersRepository,
         logger: ILogger,
         user_source_repository: IUserSourceRepository,
         utilisateur_repository: IUtilisateurRepository,

--- a/src/web/domain/ingestion/repositories/ingestion_offers_repository_interface.py
+++ b/src/web/domain/ingestion/repositories/ingestion_offers_repository_interface.py
@@ -1,0 +1,35 @@
+from typing import List, Protocol, TypedDict
+from uuid import UUID
+
+from referentiel.entities.offer import Offer
+from referentiel.repositories.offers_repository_interface import IOffersRepository
+from referentiel.types import IUpsertResult
+
+
+class IArchiveError(TypedDict):
+    entity_id: UUID
+    error: str
+    exception: Exception
+
+
+class IArchiveResult(TypedDict):
+    fetched: int
+    vector_deleted: int
+    entity_archived: int
+    errors: List[IArchiveError]
+
+
+class IIngestionOffersRepository(IOffersRepository, Protocol):
+    def upsert_batch(self, offers_list: List[Offer]) -> IUpsertResult: ...
+
+    def get_pending_processing(self, limit: int = 1000) -> List[Offer]: ...
+
+    def mark_as_processed(self, offers_list: List[Offer]) -> int: ...
+
+    def mark_as_pending(self, offers_list: List[Offer]) -> int: ...
+
+    def mark_as_archived(self, offers_list: List[Offer]) -> int: ...
+
+    def count_published(self) -> int: ...
+
+    def count_archived(self) -> int: ...

--- a/src/web/domain/ingestion/repositories/repository_factory_interface.py
+++ b/src/web/domain/ingestion/repositories/repository_factory_interface.py
@@ -3,9 +3,11 @@ from typing import Protocol, TypeVar, Union
 from referentiel.repositories.concours_repository_interface import IConcoursRepository
 from referentiel.repositories.corps_repository_interface import ICorpsRepository
 from referentiel.repositories.metier_repository_interface import IMetierRepository
-from referentiel.repositories.offers_repository_interface import IOffersRepository
 
 from domain.ingestion.entities.document import DocumentType
+from domain.ingestion.repositories.ingestion_offers_repository_interface import (
+    IIngestionOffersRepository,
+)
 
 TRepository = TypeVar("TRepository")
 
@@ -14,5 +16,8 @@ class IRepositoryFactory(Protocol):
     def get_repository(
         self, document_type: DocumentType
     ) -> Union[
-        ICorpsRepository, IConcoursRepository, IOffersRepository, IMetierRepository
+        ICorpsRepository,
+        IConcoursRepository,
+        IIngestionOffersRepository,
+        IMetierRepository,
     ]: ...

--- a/src/web/infrastructure/repositories/repository_factory.py
+++ b/src/web/infrastructure/repositories/repository_factory.py
@@ -3,10 +3,12 @@ from typing import Union
 from referentiel.repositories.concours_repository_interface import IConcoursRepository
 from referentiel.repositories.corps_repository_interface import ICorpsRepository
 from referentiel.repositories.metier_repository_interface import IMetierRepository
-from referentiel.repositories.offers_repository_interface import IOffersRepository
 
 from domain.ingestion.entities.document import DocumentType
 from domain.ingestion.exceptions.document_error import UnsupportedDocumentTypeError
+from domain.ingestion.repositories.ingestion_offers_repository_interface import (
+    IIngestionOffersRepository,
+)
 from domain.ingestion.repositories.repository_factory_interface import (
     IRepositoryFactory,
 )
@@ -17,7 +19,7 @@ class RepositoryFactory(IRepositoryFactory):
         self,
         corps_repository: ICorpsRepository,
         concours_repository: IConcoursRepository,
-        offers_repository: IOffersRepository,
+        offers_repository: IIngestionOffersRepository,
         metiers_repository: IMetierRepository,
     ):
         self.corps_repository = corps_repository
@@ -28,7 +30,10 @@ class RepositoryFactory(IRepositoryFactory):
     def get_repository(
         self, document_type: DocumentType
     ) -> Union[
-        ICorpsRepository, IConcoursRepository, IOffersRepository, IMetierRepository
+        ICorpsRepository,
+        IConcoursRepository,
+        IIngestionOffersRepository,
+        IMetierRepository,
     ]:
         match document_type:
             case DocumentType.CORPS:

--- a/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
+++ b/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
@@ -9,14 +9,16 @@ from django.db.models import F, Q
 from django.utils import timezone
 from referentiel.entities.offer import Offer
 from referentiel.exceptions.offer_errors import OfferDoesNotExist
-from referentiel.repositories.offers_repository_interface import IOffersRepository
 from referentiel.types import IUpsertResult
 
+from domain.ingestion.repositories.ingestion_offers_repository_interface import (
+    IIngestionOffersRepository,
+)
 from infrastructure.django_apps.referentiel.models.offer import OfferModel
 from infrastructure.mappers.queryset_page import QuerySetPage
 
 
-class PostgresOffersRepository(IOffersRepository):
+class PostgresOffersRepository(IIngestionOffersRepository):
     def __init__(self, logger: ILogger):
         self.logger = logger
 

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -29,9 +29,6 @@ from application.candidate.usecases.match_cv_to_opportunities import (
 )
 from application.candidate.usecases.process_uploaded_cv import ProcessUploadedCVUsecase
 from application.candidate.usecases.submit_application import SubmitApplicationUsecase
-from application.commons.usecases.calculate_daily_stats import (
-    CalculateDailyStatsUseCase,
-)
 from application.identite.usecases.create_agent import CreateAgentUsecase
 from application.identite.usecases.create_organisme import CreateOrganismeUsecase
 from application.ingestion.usecases.archive_offers import ArchiveOffersUsecase
@@ -56,9 +53,6 @@ from domain.candidate.repositories.candidature_repository_interface import (
 )
 from domain.candidate.repositories.cv_metadata_repository_interface import (
     ICVMetadataRepository,
-)
-from domain.commons.repositories.stats_history_repository_interface import (
-    IStatsHistoryRepository,
 )
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.repositories.agent_repository_interface import IAgentRepository
@@ -537,19 +531,3 @@ def initialize_organisme_steps_usecase():
         create_interface_aware_mock(IOrganismeRecruteurRepository),
     )
     return InitializeOrganismeStepsUsecase(organisme_repository=repository)
-
-
-@pytest.fixture
-def calculate_daily_stats_usecase():
-    offers_repo = cast(
-        IIngestionOffersRepository,
-        create_interface_aware_mock(IIngestionOffersRepository),
-    )
-    stats_history_repo = cast(
-        IStatsHistoryRepository,
-        create_interface_aware_mock(IStatsHistoryRepository),
-    )
-    return CalculateDailyStatsUseCase(
-        offers_repository=offers_repo,
-        stats_history_repository=stats_history_repo,
-    )

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -29,6 +29,9 @@ from application.candidate.usecases.match_cv_to_opportunities import (
 )
 from application.candidate.usecases.process_uploaded_cv import ProcessUploadedCVUsecase
 from application.candidate.usecases.submit_application import SubmitApplicationUsecase
+from application.commons.usecases.calculate_daily_stats import (
+    CalculateDailyStatsUseCase,
+)
 from application.identite.usecases.create_agent import CreateAgentUsecase
 from application.identite.usecases.create_organisme import CreateOrganismeUsecase
 from application.ingestion.usecases.archive_offers import ArchiveOffersUsecase
@@ -54,6 +57,9 @@ from domain.candidate.repositories.candidature_repository_interface import (
 from domain.candidate.repositories.cv_metadata_repository_interface import (
     ICVMetadataRepository,
 )
+from domain.commons.repositories.stats_history_repository_interface import (
+    IStatsHistoryRepository,
+)
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.repositories.agent_repository_interface import IAgentRepository
 from domain.identite.repositories.organisme_repository_interface import (
@@ -66,6 +72,9 @@ from domain.ingestion.entities.document import DocumentType
 from domain.ingestion.exceptions.document_error import UnsupportedDocumentTypeError
 from domain.ingestion.repositories.document_repository_interface import (
     IDocumentRepository,
+)
+from domain.ingestion.repositories.ingestion_offers_repository_interface import (
+    IIngestionOffersRepository,
 )
 from domain.ingestion.repositories.source_repository_interface import ISourceRepository
 from domain.ingestion.repositories.user_source_repository_interface import (
@@ -381,7 +390,8 @@ def archive_offers_usecase():
         IVectorRepository, create_interface_aware_mock(IVectorRepository)
     )
     offers_repo = cast(
-        IOffersRepository, create_interface_aware_mock(IOffersRepository)
+        IIngestionOffersRepository,
+        create_interface_aware_mock(IIngestionOffersRepository),
     )
 
     return ArchiveOffersUsecase(
@@ -409,7 +419,8 @@ def list_offers_usecase():
 def upsert_offers_usecase():
     logger = MagicMock()
     offers_repo = cast(
-        IOffersRepository, create_interface_aware_mock(IOffersRepository)
+        IIngestionOffersRepository,
+        create_interface_aware_mock(IIngestionOffersRepository),
     )
     user_source_repo = cast(
         IUserSourceRepository, create_interface_aware_mock(IUserSourceRepository)
@@ -460,7 +471,8 @@ def list_sources_usecase():
 def get_opportunity_details_usecase():
     logger = MagicMock()
     offers_repository = cast(
-        IOffersRepository, create_interface_aware_mock(IOffersRepository)
+        IIngestionOffersRepository,
+        create_interface_aware_mock(IIngestionOffersRepository),
     )
     concours_repository = cast(
         IConcoursRepository, create_interface_aware_mock(IConcoursRepository)
@@ -525,3 +537,19 @@ def initialize_organisme_steps_usecase():
         create_interface_aware_mock(IOrganismeRecruteurRepository),
     )
     return InitializeOrganismeStepsUsecase(organisme_repository=repository)
+
+
+@pytest.fixture
+def calculate_daily_stats_usecase():
+    offers_repo = cast(
+        IIngestionOffersRepository,
+        create_interface_aware_mock(IIngestionOffersRepository),
+    )
+    stats_history_repo = cast(
+        IStatsHistoryRepository,
+        create_interface_aware_mock(IStatsHistoryRepository),
+    )
+    return CalculateDailyStatsUseCase(
+        offers_repository=offers_repo,
+        stats_history_repository=stats_history_repo,
+    )

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1258,7 +1258,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },


### PR DESCRIPTION
## Résumé

- Déplace les méthodes ingestion-spécifiques (`upsert_batch`, `get_pending_processing`, `mark_as_processed`, `mark_as_pending`, `mark_as_archived`, `count_published`, `count_archived`) vers une nouvelle interface `IIngestionOffersRepository` dans `domain/ingestion`
- `IOffersRepository` ne conserve plus que les lectures cross-domaine
- Bump referentiel `0.1.11` → `0.1.12`

Extrait de #884 
