### PR TITLE
♻️(ingestion) rend la configuration des identifiants TalentSoft dynamique

### DIFF
--- a/env.d/ingestion-example
+++ b/env.d/ingestion-example
@@ -1,10 +1,8 @@
-TALENTSOFT_FRONT_CLIENT_ID=
-TALENTSOFT_FRONT_CLIENT_SECRET=
-TALENTSOFT_FRONT_BASE_URL=
-
-TALENTSOFT_BACK_CLIENT_ID=
-TALENTSOFT_BACK_CLIENT_SECRET=
-TALENTSOFT_BACK_BASE_URL=
+# JSON list of {"client_id", "client_secret", "base_url", "role"} objects.
+# "front" credentials get an active TalentsoftFrontClient registered for
+# import/archive calls; "back" credentials are only used to verify webhook
+# signatures. Add as many entries as needed.
+TALENTSOFT_CREDENTIALS=[]
 
 WEB_BASE_URL=
 WEB_API_KEY=

--- a/src/ingestion/api/config.py
+++ b/src/ingestion/api/config.py
@@ -3,6 +3,8 @@ import os
 from pydantic import HttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from domain.value_objects.talentsoft_credential import TalentsoftCredential
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env")
@@ -11,13 +13,12 @@ class Settings(BaseSettings):
     sentry_profiles_sample_rate: float | None = 0.1
     sentry_traces_sample_rate: float | None = 0.1
 
-    talentsoft_front_client_id: str | None = None
-    talentsoft_front_client_secret: str | None = None
-    talentsoft_front_base_url: str | None = None
-
-    talentsoft_back_client_id: str | None = None
-    talentsoft_back_client_secret: str | None = None
-    talentsoft_back_base_url: str | None = None
+    # JSON list of {"client_id", "client_secret", "base_url", "role"}, e.g.
+    # TALENTSOFT_CREDENTIALS='[{"client_id":"...","client_secret":"...",
+    # "base_url":"...","role":"front"}]'
+    # "front" credentials get an active TalentsoftFrontClient registered; "back"
+    # credentials are only used to verify webhook signatures.
+    talentsoft_credentials: list[TalentsoftCredential] = []
 
     web_base_url: str | None = None
     web_api_key: str | None = None

--- a/src/ingestion/domain/value_objects/talentsoft_credential.py
+++ b/src/ingestion/domain/value_objects/talentsoft_credential.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class TalentsoftCredential:
+    client_id: str
+    client_secret: str
+    base_url: str
+    role: Literal["front", "back"]

--- a/src/ingestion/infrastructure/credentials_store.py
+++ b/src/ingestion/infrastructure/credentials_store.py
@@ -5,12 +5,8 @@ class CredentialsStore:
     def __init__(self) -> None:
         self._credentials: dict[str, Credentials] = {}
 
-    def register(self, client_id: str, client_secret: str, base_url: str) -> None:
-        self._credentials[client_id] = Credentials(
-            client_id=client_id,
-            client_secret=client_secret,
-            base_url=base_url,
-        )
+    def register(self, credentials: Credentials) -> None:
+        self._credentials[credentials.client_id] = credentials
 
     def get_secret(self, client_id: str) -> str | None:
         creds = self._credentials.get(client_id)

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -22,6 +22,7 @@ from domain.gateways.sources_gateway import ISourcesGateway
 from domain.repositories.raw_offer_repository import IRawOfferRepository
 from domain.repositories.sources_repository import ISourcesRepository
 from domain.repositories.webhook_repository import IWebhookRepository
+from domain.value_objects.talentsoft_credential import TalentsoftCredential
 from infrastructure.credentials_store import CredentialsStore
 from infrastructure.database import make_engine
 from infrastructure.external_gateways.talentsoft_client import (
@@ -48,11 +49,13 @@ def _dispatch_save_raw_offer_webhook(webhook_id: str) -> None:
 
 
 def _build_credentials_store(
-    credentials: list[tuple[str, str, str]],
+    credentials: list[TalentsoftCredential],
 ) -> CredentialsStore:
     store = CredentialsStore()
-    for client_id, client_secret, base_url in credentials:
-        store.register(client_id, client_secret, base_url)
+    for credential in credentials:
+        store.register(
+            credential.client_id, credential.client_secret, credential.base_url
+        )
     return store
 
 
@@ -229,42 +232,25 @@ def create_container() -> Container:
     container.config.web_base_url.from_value(settings.web_base_url)
     container.config.web_api_key.from_value(settings.web_api_key)
     container.config.database_url.from_value(settings.database_url)
-    container.config.talentsoft_credentials.from_value(
-        [
-            (client_id, secret, base_url)
-            for client_id, secret, base_url in [
-                (
-                    settings.talentsoft_back_client_id,
-                    settings.talentsoft_back_client_secret,
-                    settings.talentsoft_back_base_url,
-                ),
-                (
-                    settings.talentsoft_front_client_id,
-                    settings.talentsoft_front_client_secret,
-                    settings.talentsoft_front_base_url,
-                ),
-            ]
-            if client_id and secret and base_url
-        ]
+    container.config.talentsoft_credentials.from_value(settings.talentsoft_credentials)
+
+    _logger = logging.getLogger(__name__)
+    register_talentsoft_front_clients(
+        container, settings.talentsoft_credentials, _logger
     )
-    if settings.talentsoft_front_client_id:
-        _logger = logging.getLogger(__name__)
-        register_talentsoft_front_client(
-            container, settings.talentsoft_front_client_id, _logger
-        )
     return container
 
 
-def register_talentsoft_front_client(
-    container: Container, client_id: str, logger: logging.Logger
+def register_talentsoft_front_clients(
+    container: Container,
+    credentials: list[TalentsoftCredential],
+    logger: logging.Logger,
 ) -> None:
-    creds = container.credentials_store().get_credentials(client_id)
-    if not creds:
-        raise ValueError(f"No credentials found for TalentSoft client {client_id}")
-    config = TalentsoftConfig(
-        base_url=creds.base_url,
-        client_id=creds.client_id,
-        client_secret=creds.client_secret,
-    )
-    client = TalentsoftFrontClient(config=config, logger=logger)
-    container.talentsoft_client_repository().register(client_id, client)
+    for credential in [c for c in credentials if c.role == "front"]:
+        config = TalentsoftConfig(
+            base_url=credential.base_url,
+            client_id=credential.client_id,
+            client_secret=credential.client_secret,
+        )
+        client = TalentsoftFrontClient(config=config, logger=logger)
+        container.talentsoft_client_repository().register(credential.client_id, client)

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -22,6 +22,7 @@ from domain.gateways.sources_gateway import ISourcesGateway
 from domain.repositories.raw_offer_repository import IRawOfferRepository
 from domain.repositories.sources_repository import ISourcesRepository
 from domain.repositories.webhook_repository import IWebhookRepository
+from domain.value_objects.credentials import Credentials
 from domain.value_objects.talentsoft_credential import TalentsoftCredential
 from infrastructure.credentials_store import CredentialsStore
 from infrastructure.database import make_engine
@@ -51,10 +52,18 @@ def _dispatch_save_raw_offer_webhook(webhook_id: str) -> None:
 def _build_credentials_store(
     credentials: list[TalentsoftCredential],
 ) -> CredentialsStore:
+    seen_client_ids = {credential.client_id for credential in credentials}
+    if len(seen_client_ids) != len(credentials):
+        raise ValueError("Duplicate client_id found in TALENTSOFT_CREDENTIALS")
+
     store = CredentialsStore()
     for credential in credentials:
         store.register(
-            credential.client_id, credential.client_secret, credential.base_url
+            Credentials(
+                client_id=credential.client_id,
+                client_secret=credential.client_secret,
+                base_url=credential.base_url,
+            )
         )
     return store
 

--- a/src/ingestion/tests/conftest.py
+++ b/src/ingestion/tests/conftest.py
@@ -1,4 +1,5 @@
 import base64
+import dataclasses
 import hashlib
 import hmac
 import json
@@ -12,6 +13,8 @@ from fastapi.testclient import TestClient
 from httpx import Response
 from referentiel.entities.source import Source
 from referentiel.value_objects.source_type import SourceType
+
+from domain.value_objects.talentsoft_credential import TalentsoftCredential
 
 # --- Constants ---
 
@@ -110,6 +113,10 @@ def make_signed_request(client: TestClient, body: dict) -> Response:
         content=body_bytes,
         headers={"Content-Type": content_type, **ts_rec_headers},
     )
+
+
+def talentsoft_credentials_env(*credentials: TalentsoftCredential) -> str:
+    return json.dumps([dataclasses.asdict(credential) for credential in credentials])
 
 
 def populate_sources_repository(app: FastAPI) -> None:

--- a/src/ingestion/tests/presentation/test_webhook_archive.py
+++ b/src/ingestion/tests/presentation/test_webhook_archive.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import create_app
+from domain.value_objects.talentsoft_credential import TalentsoftCredential
 from presentation.dtos.talentsoft_webhook import (
     TalentsoftEventType,
     TalentsoftOfferStatus,
@@ -16,6 +17,7 @@ from tests.conftest import (
     WEB_BASE_URL,
     make_signed_request,
     populate_sources_repository,
+    talentsoft_credentials_env,
 )
 
 REFERENCE = "2019-1234"
@@ -83,9 +85,17 @@ async def test_vacancy_status_diffuse_saves_but_does_not_enqueue(
 @pytest.mark.asyncio
 async def test_other_event_type_returns_500(httpx_mock, monkeypatch):
     monkeypatch.setenv("TESTING", "true")
-    monkeypatch.setenv("TALENTSOFT_BACK_CLIENT_ID", TALENTSOFT_BACK_CLIENT_ID)
-    monkeypatch.setenv("TALENTSOFT_BACK_CLIENT_SECRET", TALENTSOFT_BACK_CLIENT_SECRET)
-    monkeypatch.setenv("TALENTSOFT_BACK_BASE_URL", TALENTSOFT_BACK_BASE_URL)
+    monkeypatch.setenv(
+        "TALENTSOFT_CREDENTIALS",
+        talentsoft_credentials_env(
+            TalentsoftCredential(
+                client_id=TALENTSOFT_BACK_CLIENT_ID,
+                client_secret=TALENTSOFT_BACK_CLIENT_SECRET,
+                base_url=TALENTSOFT_BACK_BASE_URL,
+                role="back",
+            )
+        ),
+    )
     monkeypatch.setenv("WEB_BASE_URL", WEB_BASE_URL)
     monkeypatch.setenv("WEB_API_KEY", WEB_API_KEY)
     app = create_app()
@@ -99,9 +109,17 @@ async def test_other_event_type_returns_500(httpx_mock, monkeypatch):
 @pytest.mark.asyncio
 async def test_unknown_client_id_returns_403(monkeypatch, httpx_mock):
     monkeypatch.setenv("TESTING", "true")
-    monkeypatch.setenv("TALENTSOFT_BACK_CLIENT_ID", TALENTSOFT_BACK_CLIENT_ID)
-    monkeypatch.setenv("TALENTSOFT_BACK_CLIENT_SECRET", TALENTSOFT_BACK_CLIENT_SECRET)
-    monkeypatch.setenv("TALENTSOFT_BACK_BASE_URL", TALENTSOFT_BACK_BASE_URL)
+    monkeypatch.setenv(
+        "TALENTSOFT_CREDENTIALS",
+        talentsoft_credentials_env(
+            TalentsoftCredential(
+                client_id=TALENTSOFT_BACK_CLIENT_ID,
+                client_secret=TALENTSOFT_BACK_CLIENT_SECRET,
+                base_url=TALENTSOFT_BACK_BASE_URL,
+                role="back",
+            )
+        ),
+    )
     monkeypatch.setenv("WEB_BASE_URL", WEB_BASE_URL)
     monkeypatch.setenv("WEB_API_KEY", WEB_API_KEY)
     app = create_app()

--- a/src/ingestion/tests/shared_fixtures.py
+++ b/src/ingestion/tests/shared_fixtures.py
@@ -17,6 +17,7 @@ from api.config import get_settings
 from api.main import create_app
 from application.use_cases.archive_offer import ArchiveOfferUseCase
 from application.use_cases.load_sources import LoadSourcesUseCase
+from domain.value_objects.talentsoft_credential import TalentsoftCredential
 from infrastructure.database import make_engine, run_migrations
 from infrastructure.di.container import Container
 from infrastructure.external_gateways.talentsoft_client import (
@@ -36,6 +37,7 @@ from tests.conftest import (
     TALENTSOFT_FRONT_CLIENT_SECRET,
     WEB_API_KEY,
     WEB_BASE_URL,
+    talentsoft_credentials_env,
 )
 
 fake = Faker()
@@ -106,10 +108,7 @@ def setup_talentsoft_front_in_container(
 @pytest.fixture
 def test_client(monkeypatch) -> TestClient:
     monkeypatch.setenv("TESTING", "true")
-    monkeypatch.delenv("TALENTSOFT_BACK_CLIENT_ID", raising=False)
-    monkeypatch.delenv("TALENTSOFT_BACK_CLIENT_SECRET", raising=False)
-    monkeypatch.delenv("TALENTSOFT_FRONT_CLIENT_ID", raising=False)
-    monkeypatch.delenv("TALENTSOFT_FRONT_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("TALENTSOFT_CREDENTIALS", raising=False)
     app = create_app()
     return TestClient(app)
 
@@ -117,12 +116,23 @@ def test_client(monkeypatch) -> TestClient:
 @pytest.fixture
 def talentsoft_client(monkeypatch) -> TestClient:
     monkeypatch.setenv("TESTING", "true")
-    monkeypatch.setenv("TALENTSOFT_BACK_CLIENT_ID", TALENTSOFT_BACK_CLIENT_ID)
-    monkeypatch.setenv("TALENTSOFT_BACK_CLIENT_SECRET", TALENTSOFT_BACK_CLIENT_SECRET)
-    monkeypatch.setenv("TALENTSOFT_BACK_BASE_URL", TALENTSOFT_BACK_BASE_URL)
-    monkeypatch.setenv("TALENTSOFT_FRONT_CLIENT_ID", TALENTSOFT_FRONT_CLIENT_ID)
-    monkeypatch.setenv("TALENTSOFT_FRONT_CLIENT_SECRET", TALENTSOFT_FRONT_CLIENT_SECRET)
-    monkeypatch.setenv("TALENTSOFT_FRONT_BASE_URL", TALENTSOFT_FRONT_BASE_URL)
+    monkeypatch.setenv(
+        "TALENTSOFT_CREDENTIALS",
+        talentsoft_credentials_env(
+            TalentsoftCredential(
+                client_id=TALENTSOFT_BACK_CLIENT_ID,
+                client_secret=TALENTSOFT_BACK_CLIENT_SECRET,
+                base_url=TALENTSOFT_BACK_BASE_URL,
+                role="back",
+            ),
+            TalentsoftCredential(
+                client_id=TALENTSOFT_FRONT_CLIENT_ID,
+                client_secret=TALENTSOFT_FRONT_CLIENT_SECRET,
+                base_url=TALENTSOFT_FRONT_BASE_URL,
+                role="front",
+            ),
+        ),
+    )
     monkeypatch.setenv("WEB_BASE_URL", WEB_BASE_URL)
     monkeypatch.setenv("WEB_API_KEY", WEB_API_KEY)
     app = create_app()

--- a/src/ingestion/tests/unit/test_config.py
+++ b/src/ingestion/tests/unit/test_config.py
@@ -1,0 +1,45 @@
+import pytest
+from pydantic import ValidationError
+from pydantic_settings import SettingsError
+
+from api.config import TestSettings
+
+
+class TestTalentsoftCredentialsParsing:
+    def test_invalid_json_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("TALENTSOFT_CREDENTIALS", "not-json")
+
+        with pytest.raises(SettingsError):
+            TestSettings()
+
+    def test_invalid_role_fails_closed(self, monkeypatch):
+        monkeypatch.setenv(
+            "TALENTSOFT_CREDENTIALS",
+            '[{"client_id":"a","client_secret":"b",'
+            '"base_url":"https://x.example.com","role":"bogus"}]',
+        )
+
+        with pytest.raises(ValidationError):
+            TestSettings()
+
+    def test_missing_field_fails_closed(self, monkeypatch):
+        monkeypatch.setenv(
+            "TALENTSOFT_CREDENTIALS",
+            '[{"client_id":"a","base_url":"https://x.example.com","role":"front"}]',
+        )
+
+        with pytest.raises(ValidationError):
+            TestSettings()
+
+    def test_valid_credentials_are_parsed(self, monkeypatch):
+        monkeypatch.setenv(
+            "TALENTSOFT_CREDENTIALS",
+            '[{"client_id":"a","client_secret":"b",'
+            '"base_url":"https://x.example.com","role":"front"}]',
+        )
+
+        settings = TestSettings()
+
+        assert len(settings.talentsoft_credentials) == 1
+        assert settings.talentsoft_credentials[0].client_id == "a"
+        assert settings.talentsoft_credentials[0].role == "front"

--- a/src/ingestion/tests/unit/test_container.py
+++ b/src/ingestion/tests/unit/test_container.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Literal
+
+import pytest
+
+from domain.value_objects.talentsoft_credential import TalentsoftCredential
+from infrastructure.di.container import (
+    Container,
+    _build_credentials_store,
+    register_talentsoft_front_clients,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+def _credential(client_id: str, role: Literal["front", "back"]) -> TalentsoftCredential:
+    return TalentsoftCredential(
+        client_id=client_id,
+        client_secret=f"secret-{client_id}",
+        base_url=f"https://{client_id}.example.com",
+        role=role,
+    )
+
+
+class TestBuildCredentialsStore:
+    def test_registers_every_credential_regardless_of_role(self):
+        credentials = [
+            _credential("front_a", "front"),
+            _credential("front_b", "front"),
+            _credential("back_a", "back"),
+        ]
+
+        store = _build_credentials_store(credentials)
+
+        assert len(store) == 3
+        for credential in credentials:
+            assert store.get_secret(credential.client_id) == credential.client_secret
+
+    def test_raises_on_duplicate_client_id_across_roles(self):
+        credentials = [
+            _credential("shared", "front"),
+            _credential("shared", "back"),
+        ]
+
+        with pytest.raises(ValueError, match="Duplicate client_id"):
+            _build_credentials_store(credentials)
+
+
+class TestRegisterTalentsoftFrontClients:
+    def test_registers_only_front_credentials_as_active_clients(self):
+        container = Container()
+        credentials = [
+            _credential("front_a", "front"),
+            _credential("front_b", "front"),
+            _credential("back_a", "back"),
+        ]
+
+        register_talentsoft_front_clients(container, credentials, _logger)
+
+        repository = container.talentsoft_client_repository()
+        assert repository.get("front_a") is not None
+        assert repository.get("front_b") is not None
+        assert repository.get("back_a") is None
+
+    def test_registers_no_clients_when_no_front_credentials(self):
+        container = Container()
+        credentials = [_credential("back_a", "back")]
+
+        register_talentsoft_front_clients(container, credentials, _logger)
+
+        repository = container.talentsoft_client_repository()
+        assert repository.get("back_a") is None

--- a/src/ingestion/tests/unit/test_credentials_store.py
+++ b/src/ingestion/tests/unit/test_credentials_store.py
@@ -1,5 +1,6 @@
 import pytest
 
+from domain.value_objects.credentials import Credentials
 from infrastructure.credentials_store import CredentialsStore
 
 
@@ -8,17 +9,23 @@ def store() -> CredentialsStore:
     return CredentialsStore()
 
 
+def _credentials(client_id: str, client_secret: str, base_url: str) -> Credentials:
+    return Credentials(
+        client_id=client_id, client_secret=client_secret, base_url=base_url
+    )
+
+
 def test_empty_store_has_length_zero(store):
     assert len(store) == 0
 
 
 def test_register_increases_length(store):
-    store.register("client_a", "secret_a", "https://a.example.com")
+    store.register(_credentials("client_a", "secret_a", "https://a.example.com"))
     assert len(store) == 1
 
 
 def test_get_secret_returns_registered_secret(store):
-    store.register("client_a", "secret_a", "https://a.example.com")
+    store.register(_credentials("client_a", "secret_a", "https://a.example.com"))
     assert store.get_secret("client_a") == "secret_a"
 
 
@@ -27,22 +34,22 @@ def test_get_secret_returns_none_for_unknown_client(store):
 
 
 def test_register_multiple_clients(store):
-    store.register("client_a", "secret_a", "https://a.example.com")
-    store.register("client_b", "secret_b", "https://b.example.com")
+    store.register(_credentials("client_a", "secret_a", "https://a.example.com"))
+    store.register(_credentials("client_b", "secret_b", "https://b.example.com"))
     assert len(store) == 2
     assert store.get_secret("client_a") == "secret_a"
     assert store.get_secret("client_b") == "secret_b"
 
 
 def test_register_overwrites_existing_secret(store):
-    store.register("client_a", "old_secret", "https://a.example.com")
-    store.register("client_a", "new_secret", "https://a.example.com")
+    store.register(_credentials("client_a", "old_secret", "https://a.example.com"))
+    store.register(_credentials("client_a", "new_secret", "https://a.example.com"))
     assert len(store) == 1
     assert store.get_secret("client_a") == "new_secret"
 
 
 def test_get_credentials_returns_full_credentials(store):
-    store.register("client_a", "secret_a", "https://a.example.com")
+    store.register(_credentials("client_a", "secret_a", "https://a.example.com"))
     creds = store.get_credentials("client_a")
     assert creds is not None
     assert creds.client_id == "client_a"


### PR DESCRIPTION
## 📝 Description
Remplace la configuration TalentSoft codée en dur (paires front/back fixes) par une liste dynamique d'identifiants, permettant d'en enregistrer un nombre arbitraire via une seule variable d'environnement `TALENTSOFT_CREDENTIALS` (JSON), chaque entrée précisant son rôle (`front` ou `back`).

## Changements

- Nouvelle value object `TalentsoftCredential` (`domain/value_objects/talentsoft_credential.py`) : `client_id`, `client_secret`, `base_url`, `role`.
- `api/config.py` : le champ `Settings.talentsoft_credentials` remplace les 6 anciens champs `talentsoft_front_*` / `talentsoft_back_*`.
- `infrastructure/di/container.py` : `_build_credentials_store` et `register_talentsoft_front_clients` itèrent désormais sur la liste de credentials ; tous les identifiants de rôle `front` sont enregistrés comme clients actifs (auparavant un seul était géré).
- `env.d/ingestion-example` : mis à jour avec la nouvelle variable `TALENTSOFT_CREDENTIALS`.
- Tests (`conftest.py`, `shared_fixtures.py`, `test_webhook_archive.py`) adaptés à la nouvelle variable d'environnement via un helper `talentsoft_credentials_env(...)`.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
