### PR TITLE
🔧(frontend) improve ide setup and dx

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,6 +63,8 @@
   "emmet.includeLanguages": {
     "django-html": "html"
   },
+  "typescript.tsdk": "src/web/presentation/frontend/node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "eslint.format.enable": true,
   "eslint.useFlatConfig": true,
   "eslint.workingDirectories": [

--- a/csplab-frontend.code-workspace
+++ b/csplab-frontend.code-workspace
@@ -1,0 +1,12 @@
+{
+  "folders": [
+    {
+      "name": "Root",
+      "path": "."
+    },
+    {
+      "name": "Frontend",
+      "path": "./src/web/presentation/frontend"
+    }
+  ]
+}

--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       vue:
         specifier: ^3.5.38
         version: 3.5.38(typescript@6.0.3)
-      vue-component-meta:
-        specifier: ^3.3.5
-        version: 3.3.5(typescript@6.0.3)
       vue-router:
         specifier: ^5.1.0
         version: 5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
@@ -126,6 +123,9 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
+      vue-component-meta:
+        specifier: ^3.3.5
+        version: 3.3.5(typescript@6.0.3)
       vue-tsc:
         specifier: ^3.3.5
         version: 3.3.5(typescript@6.0.3)
@@ -5929,7 +5929,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
@@ -5979,7 +5979,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0)
-    optional: true
 
   '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0))':
     dependencies:
@@ -8767,7 +8766,6 @@ snapshots:
       jiti: 2.7.0
       sass: 1.100.0
       yaml: 2.9.0
-    optional: true
 
   vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0):
     dependencies:
@@ -8812,7 +8810,6 @@ snapshots:
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
-    optional: true
 
   vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.101.0)(yaml@2.9.0)):
     dependencies:

--- a/src/web/presentation/frontend/eslint.config.js
+++ b/src/web/presentation/frontend/eslint.config.js
@@ -8,7 +8,7 @@ export default antfu(
     },
     vue: true,
     typescript: true,
-    ignores: ['node_modules/', 'dist/', '../static/frontend/', 'storybook-static/', 'src/types/'],
+    ignores: ['node_modules/', 'dist/', 'storybook-static/', 'src/types/'],
   },
   {
     files: ['**/*.vue'],

--- a/src/web/presentation/frontend/package.json
+++ b/src/web/presentation/frontend/package.json
@@ -26,7 +26,6 @@
     "pinia": "^3.0.4",
     "reka-ui": "^2.9.10",
     "vue": "^3.5.38",
-    "vue-component-meta": "^3.3.5",
     "vue-router": "^5.1.0"
   },
   "devDependencies": {
@@ -52,6 +51,7 @@
     "typescript": "~6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.9",
+    "vue-component-meta": "^3.3.5",
     "vue-tsc": "^3.3.5"
   }
 }

--- a/src/web/presentation/frontend/src/env.d.ts
+++ b/src/web/presentation/frontend/src/env.d.ts
@@ -1,12 +1,5 @@
 /// <reference types="vite/client" />
 
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue'
-
-  const component: DefineComponent<object, object, unknown>
-  export default component
-}
-
 interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_SENTRY_ENVIRONMENT?: string

--- a/src/web/presentation/frontend/tsconfig.json
+++ b/src/web/presentation/frontend/tsconfig.json
@@ -13,24 +13,6 @@
     "paths": {
       "@/*": [
         "./src/*"
-      ],
-      "@/app/*": [
-        "./src/app/*"
-      ],
-      "@/features/*": [
-        "./src/features/*"
-      ],
-      "@/components/*": [
-        "./src/components/*"
-      ],
-      "@/composables/*": [
-        "./src/composables/*"
-      ],
-      "@/types/*": [
-        "./src/types/*"
-      ],
-      "@/utils/*": [
-        "./src/utils/*"
       ]
     },
     "resolveJsonModule": true,

--- a/src/web/presentation/frontend/vite.config.ts
+++ b/src/web/presentation/frontend/vite.config.ts
@@ -31,7 +31,6 @@ export default defineConfig(({ command }) => ({
     },
   },
   test: {
-    globals: true,
     environment: 'jsdom',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## 📝 Description
🎸 Corrige plusieurs failles de setup qui rendent l'expérience IDE parfois laborieuses côté front :
- pinne `typescript.tsdk` dans vscode pour s'assurer d'utiliser la même version que le projet
- suppression du shim `*.vue` obsolète et qui empêche de détecter des composants missings
- corrections mineures