### PR TITLE
🎨(identite-presentation) get better admin readibility on ProfilCandidat and ProfilAgent

### DIFF
--- a/src/web/infrastructure/django_apps/users/admin.py
+++ b/src/web/infrastructure/django_apps/users/admin.py
@@ -1,6 +1,11 @@
 from django.contrib import admin
 
-from infrastructure.django_apps.users.models import UserModel
+from infrastructure.django_apps.users.models import (
+    ProfilAgentModel,
+    ProfilCandidatModel,
+    UserModel,
+)
+from infrastructure.django_apps.utils.admin import ReadOnlyAdminMixin
 
 
 @admin.register(UserModel)
@@ -17,3 +22,17 @@ class UserModelAdmin(admin.ModelAdmin):
     search_fields = ("email",)
     readonly_fields = ["username", "id", "date_joined", "last_login", "password"]
     filter_horizontal = ("sources",)
+
+
+@admin.register(ProfilCandidatModel)
+class ProfilCandidatAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = ("utilisateur", "created_at", "updated_at")
+    search_fields = ("utilisateur__email",)
+    date_hierarchy = "created_at"
+
+
+@admin.register(ProfilAgentModel)
+class ProfilAgentAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
+    list_display = ("utilisateur", "intitule_poste", "created_at", "updated_at")
+    search_fields = ("utilisateur__email", "intitule_poste")
+    date_hierarchy = "created_at"

--- a/src/web/infrastructure/django_apps/users/models.py
+++ b/src/web/infrastructure/django_apps/users/models.py
@@ -52,7 +52,7 @@ class UserModel(AbstractUser):
         )
 
     def __str__(self):
-        return self.username
+        return self.email
 
 
 class ProfilCandidatModel(models.Model):
@@ -89,7 +89,7 @@ class ProfilCandidatModel(models.Model):
         )
 
     def __str__(self):
-        return self.utilisateur_id
+        return self.utilisateur.email
 
 
 class ProfilAgentModel(models.Model):
@@ -124,4 +124,4 @@ class ProfilAgentModel(models.Model):
         )
 
     def __str__(self):
-        return self.utilisateur_id
+        return self.utilisateur.email


### PR DESCRIPTION
## 📝 Description
🎸 ajout des admins pour `ProfilAgent` et `ProfilCandidat` : permet de rendre cliquable les liens reférençant ces objets ETQ PK
🎸 modification des méthodes `__str__()` pour rendre les emails des utilisateurs au lieu des uuid


## 🏷️ Type de changement
- [x] 🔧 Changement technique


💡 impact positif sur #913 

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
