### PR TITLE
🔧(frontend) fixe la version de pnpm dans packageManager racine

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yml
+++ b/.github/actions/setup-pnpm-node/action.yml
@@ -2,9 +2,6 @@ name: Set up pnpm and Node.js
 description: Install pnpm and Node.js with dependency caching.
 
 inputs:
-  pnpm-version:
-    description: pnpm version to install
-    default: "11.1.3"
   node-version:
     description: Node.js version to install
     default: "24"
@@ -17,8 +14,6 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v6
-      with:
-        version: ${{ inputs.pnpm-version }}
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "pnpm@11.1.3"
+}

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,7 +1,6 @@
 {
   "name": "csplab-web",
   "private": true,
-  "packageManager": "pnpm@11.1.3",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## 📝 Description
Fixe la version de pnpm à partir du champ `packageManager` à la racine.

Déplace la déclaration `packageManager` vers le `package.json` racine et supprime
la version codée en dur de l'action `setup-pnpm-node`. Cela évite les échecs
de CI lorsque pnpm publie des versions comportant des bugs.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
