### PR TITLE
🐛(ingestion) filter out non-talentsoft sources in WebSourcesGateway

### DIFF
--- a/src/ingestion/infrastructure/external_gateways/web_sources_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/web_sources_gateway.py
@@ -19,4 +19,5 @@ class WebSourcesGateway(BaseWebGateway, ISourcesGateway):
                 }
             )
             for item in response.json()
+            if item["type"] == SourceType.TALENTSOFT.value
         ]

--- a/src/ingestion/tests/integration/test_load_sources_use_case.py
+++ b/src/ingestion/tests/integration/test_load_sources_use_case.py
@@ -44,6 +44,30 @@ async def test_execute_populates_registry(
 
 
 @pytest.mark.asyncio
+async def test_execute_loads_only_talentsoft_sources(
+    load_sources_use_case: LoadSourcesUseCase,
+    sources_repository: SourcesRepository,
+    httpx_mock: HTTPXMock,
+):
+    api_source = {
+        "source_id": "33333333-0000-0000-0000-000000000000",
+        "slug": "api-source",
+        "type": "api",
+    }
+
+    httpx_mock.add_response(
+        method="GET", url=SOURCES_URL, json=[SOURCE_DATA, api_source], status_code=200
+    )
+
+    await load_sources_use_case.execute()
+
+    assert len(sources_repository) == 1
+    source = sources_repository.get_by_client_id_back("client-back-1")
+    assert source is not None
+    assert source.type == SourceType.TALENTSOFT
+
+
+@pytest.mark.asyncio
 async def test_execute_with_empty_response_leaves_registry_empty(
     load_sources_use_case: LoadSourcesUseCase,
     sources_repository: SourcesRepository,


### PR DESCRIPTION
## 📝 Description

Modifie le chargement des sources pour ne charger que les sources de type de type `talentsoft`.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
