### PR TITLE
✨(ingestion) transmettre les coordonnées GPS des offres vers l'API web

### DIFF
--- a/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
+++ b/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
@@ -104,6 +104,8 @@ class OfferUpsertPayload(BaseModel):
                     pays=str(offer.localisation.country),
                     region=offer.localisation.region.code,
                     departement=offer.localisation.department.code,
+                    latitude=offer.localisation.latitude,
+                    longitude=offer.localisation.longitude,
                 )
             ]
 

--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -67,11 +67,14 @@ class OffersCleaner:
             else None
         )
 
+        coordinates = self._extract_coordinates(talentsoft_offer)
+
         localisation = self._map_localisation_from_arrays(
             talentsoft_offer.geographicalLocation,
             talentsoft_offer.country,
             talentsoft_offer.region,
             talentsoft_offer.department,
+            coordinates,
         )
 
         offer_url = self._parse_url(talentsoft_offer.offerUrl)
@@ -201,9 +204,35 @@ class OffersCleaner:
 
         return self._CONTRACT_KIND_MAPPING.get(contract_kind_upper)
 
+    def _extract_coordinates(
+        self, talentsoft_offer: TalentsoftDetailOffer
+    ) -> tuple[Optional[float], Optional[float]]:
+        if talentsoft_offer.geolocation:
+            return (
+                talentsoft_offer.geolocation.latitude,
+                talentsoft_offer.geolocation.longitude,
+            )
+        if (
+            talentsoft_offer.latitude is not None
+            and talentsoft_offer.longitude is not None
+        ):
+            return talentsoft_offer.latitude, talentsoft_offer.longitude
+        if talentsoft_offer.organisation and talentsoft_offer.organisation.geolocation:
+            return (
+                talentsoft_offer.organisation.geolocation.latitude,
+                talentsoft_offer.organisation.geolocation.longitude,
+            )
+        return None, None
+
     def _map_localisation_from_arrays(
-        self, areas: List, countries: List, regions: List, departments: List
+        self,
+        areas: List,
+        countries: List,
+        regions: List,
+        departments: List,
+        coordinates: tuple[Optional[float], Optional[float]] = (None, None),
     ) -> Optional[Localisation]:
+        latitude, longitude = coordinates
         area_code = areas[0].clientCode if areas else None
         country_code = countries[0].clientCode if countries else None
         region_code = regions[0].clientCode if regions else None
@@ -234,6 +263,8 @@ class OffersCleaner:
                 country=Country(country_code),
                 region=Region(code=insee_region_code),
                 department=Department(code=insee_department_code),
+                latitude=latitude,
+                longitude=longitude,
             )
         except (ValueError, ValidationError) as e:
             logger.warning(

--- a/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
+++ b/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
@@ -21,6 +21,8 @@ from tests.factories.talentsoft_factories import (
     TalentsoftCustomFieldsFactory,
     TalentsoftDescriptionCustomFieldsFactory,
     TalentsoftDetailOfferFactory,
+    TalentsoftGeolocationFactory,
+    TalentsoftOrganisationFactory,
 )
 
 REFERENCE = "2024-OFFER-001"
@@ -514,6 +516,110 @@ def test_clean_maps_raw_region_code_without_prefix(cleaner):
 
     assert offer.localisation is not None
     assert offer.localisation.region.code == "11"
+
+
+def _valid_localisation_kwargs() -> dict:
+    return {
+        "geographicalLocation": [
+            TalentsoftCodedObjectFactory.build(
+                clientCode="_TS_CO_GeographicalArea_Europe",
+                type="offerGeographicalLocation",
+            )
+        ],
+        "country": [
+            TalentsoftCodedObjectFactory.build(clientCode="FRA", type="offerCountry")
+        ],
+        "region": [
+            TalentsoftCodedObjectFactory.build(clientCode="R24", type="offerRegion")
+        ],
+        "department": [
+            TalentsoftCodedObjectFactory.build(clientCode="41", type="offerDepartment")
+        ],
+    }
+
+
+def test_clean_maps_coordinates_from_offer_geolocation(cleaner):
+    raw_offer = _make_raw_offer(
+        **_valid_localisation_kwargs(),
+        geolocation=TalentsoftGeolocationFactory.build(latitude=48.85, longitude=2.35),
+        latitude=None,
+        longitude=None,
+        organisation=None,
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is not None
+    assert offer.localisation.latitude == 48.85
+    assert offer.localisation.longitude == 2.35
+
+
+def test_clean_maps_coordinates_from_flat_fields_when_geolocation_absent(cleaner):
+    raw_offer = _make_raw_offer(
+        **_valid_localisation_kwargs(),
+        geolocation=None,
+        latitude=45.75,
+        longitude=4.85,
+        organisation=None,
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is not None
+    assert offer.localisation.latitude == 45.75
+    assert offer.localisation.longitude == 4.85
+
+
+def test_clean_prefers_offer_geolocation_over_flat_fields(cleaner):
+    raw_offer = _make_raw_offer(
+        **_valid_localisation_kwargs(),
+        geolocation=TalentsoftGeolocationFactory.build(latitude=48.85, longitude=2.35),
+        latitude=45.75,
+        longitude=4.85,
+        organisation=None,
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is not None
+    assert offer.localisation.latitude == 48.85
+    assert offer.localisation.longitude == 2.35
+
+
+def test_clean_maps_coordinates_from_organisation_geolocation_as_last_resort(cleaner):
+    raw_offer = _make_raw_offer(
+        **_valid_localisation_kwargs(),
+        geolocation=None,
+        latitude=None,
+        longitude=None,
+        organisation=TalentsoftOrganisationFactory.build(
+            geolocation=TalentsoftGeolocationFactory.build(
+                latitude=43.29, longitude=5.37
+            )
+        ),
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is not None
+    assert offer.localisation.latitude == 43.29
+    assert offer.localisation.longitude == 5.37
+
+
+def test_clean_returns_none_coordinates_when_no_source_available(cleaner):
+    raw_offer = _make_raw_offer(
+        **_valid_localisation_kwargs(),
+        geolocation=None,
+        latitude=None,
+        longitude=None,
+        organisation=TalentsoftOrganisationFactory.build(geolocation=None),
+    )
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.localisation is not None
+    assert offer.localisation.latitude is None
+    assert offer.localisation.longitude is None
 
 
 def test_clean_returns_none_localisation_on_invalid_region_code(cleaner):


### PR DESCRIPTION
## 📝 Description

Ajoute une logique de repli pour extraire latitude/longitude des offres Talentsoft (geolocation offre > champs plats > geolocation organisation) et les transmet dans le payload envoyé à l'API web.

#779 

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
