### PR TITLE
✨(ats-presentation) keep candidatures page stable while loading

### DIFF
--- a/src/web/presentation/frontend/src/components/base/CspSkeleton/CspSkeleton.stories.ts
+++ b/src/web/presentation/frontend/src/components/base/CspSkeleton/CspSkeleton.stories.ts
@@ -1,0 +1,70 @@
+import type { ComponentPropsAndSlots, StoryObj } from '@storybook/vue3-vite'
+import CspSkeleton from '@/components/base/CspSkeleton/CspSkeleton.vue'
+
+type CspSkeletonProps = ComponentPropsAndSlots<typeof CspSkeleton>
+
+const meta = {
+  title: 'Éléments/Génériques/CspSkeleton',
+  component: CspSkeleton,
+  tags: ['autodocs'],
+  parameters: {
+    controls: {
+      include: ['width', 'height'],
+    },
+    docs: {
+      description: {
+        component: 'Bloc de chargement neutre qui réserve l\'espace du contenu à venir, pour éviter les décalages de mise en page (layout shift). Dimensionner au plus proche du contenu final.',
+      },
+    },
+  },
+  argTypes: {
+    width: {
+      control: { type: 'text' },
+      description: 'Largeur CSS du bloc.',
+      table: {
+        type: {
+          summary: 'string',
+        },
+        defaultValue: {
+          summary: '100%',
+        },
+      },
+    },
+    height: {
+      control: { type: 'text' },
+      description: 'Hauteur CSS du bloc.',
+      table: {
+        type: {
+          summary: 'string',
+        },
+        defaultValue: {
+          summary: '1rem',
+        },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<CspSkeletonProps>
+
+export const Default: Story = {
+  name: 'Par défaut',
+  args: {
+    width: '16rem',
+    height: '1rem',
+  },
+}
+
+export const TitleAndMeta: Story = {
+  name: 'Titre et métadonnées',
+  render: () => ({
+    components: { CspSkeleton },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+        <CspSkeleton width="20rem" height="2rem" />
+        <CspSkeleton width="28rem" height="1.375rem" />
+      </div>
+    `,
+  }),
+}

--- a/src/web/presentation/frontend/src/components/base/CspSkeleton/CspSkeleton.vue
+++ b/src/web/presentation/frontend/src/components/base/CspSkeleton/CspSkeleton.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+export interface CspSkeletonProps {
+  width?: string
+  height?: string
+}
+
+withDefaults(defineProps<CspSkeletonProps>(), {
+  width: '100%',
+  height: '1rem',
+})
+</script>
+
+<template>
+  <span
+    class="csp-skeleton"
+    :style="{ width, height }"
+    aria-hidden="true"
+  />
+</template>
+
+<style scoped lang="scss">
+.csp-skeleton {
+  display: block;
+  max-width: 100%;
+  border-radius: 0.25rem;
+  background: var(--background-alt-grey);
+  animation: csp-skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes csp-skeleton-pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .csp-skeleton {
+    animation: none;
+  }
+}
+</style>

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -6,6 +6,7 @@ import { useRoute } from 'vue-router'
 import CspButton from '@/components/base/CspButton/CspButton.vue'
 import CspInput from '@/components/base/CspInput/CspInput.vue'
 import CspMetaList from '@/components/base/CspMeta/CspMetaList.vue'
+import CspSkeleton from '@/components/base/CspSkeleton/CspSkeleton.vue'
 import CspTabs from '@/components/base/CspTabs/CspTabs.vue'
 import CspTabsList from '@/components/base/CspTabs/CspTabsList.vue'
 import CspTabsPanels from '@/components/base/CspTabs/CspTabsPanels.vue'
@@ -57,7 +58,7 @@ const title = computed(() => recrutementDetail.value?.intitule ?? 'Candidatures'
 const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
   { label: 'Accueil', to: { name: 'home' } },
   { label: 'Mes recrutements', to: { name: 'mes-recrutements' } },
-  { label: title.value },
+  ...(recrutementDetail.value ? [{ label: recrutementDetail.value.intitule }] : []),
 ])
 
 const metaItems = computed(() =>
@@ -85,73 +86,89 @@ const activeTab = ref<'candidatures' | 'activites-et-taches'>('candidatures')
     class="candidatures-view"
   >
     <CspPageHeader
-      :title="title"
       :breadcrumb="breadcrumb"
       :back-to="{ name: 'mes-recrutements' }"
       back-label="Retour à mes recrutements"
       class="candidatures-view__header"
     >
+      <template #title>
+        <CspSkeleton
+          v-if="pending"
+          width="20rem"
+          height="2rem"
+        />
+        <template v-else>
+          {{ title }}
+        </template>
+      </template>
       <template
-        v-if="recrutementDetail"
+        v-if="pending || recrutementDetail"
         #subtitle
       >
-        <CspMetaList :items="metaItems" />
+        <CspSkeleton
+          v-if="pending"
+          width="28rem"
+          height="1.375rem"
+        />
+        <CspMetaList
+          v-else
+          :items="metaItems"
+        />
       </template>
     </CspPageHeader>
 
-    <div
-      v-if="pending"
-      class="candidatures-view__status"
-    >
-      Chargement des candidatures...
-    </div>
-
-    <div
-      v-else-if="isNotFound"
-      class="candidatures-view__status candidatures-view__status--error"
-    >
-      Recrutement introuvable.
-    </div>
-
-    <CspTabs
-      v-else
-      v-model="activeTab"
-    >
+    <CspTabs v-model="activeTab">
       <CspTabsList :tabs="TABS" />
       <CspTabsPanels :tabs="TABS">
         <template #candidatures>
-          <div class="candidatures-view__toolbar">
-            <CandidaturesViewSwitch
-              :recrutement-uuid="recrutementUuid"
-              :current="currentView"
-            />
-            <div class="candidatures-view__actions">
-              <CspInput
-                v-model="search"
-                type="search"
-                aria-label="Rechercher un candidat"
-                placeholder="Rechercher un candidat…"
-                class="candidatures-view__search"
-                @keydown.enter="filters.flushSearch()"
-              />
-              <CspButton
-                :label="activeFiltersCount ? `Filtres (${activeFiltersCount})` : 'Filtres'"
-                variant="tertiary"
-                icon="ri:filter-line"
-                is-icon-left
-                @click="openFilters"
-              />
-            </div>
+          <div
+            v-if="pending"
+            class="candidatures-view__status"
+          >
+            Chargement des candidatures...
           </div>
-          <router-view />
-          <CandidaturesFiltersDrawer
-            v-model:open="isFiltersDrawerOpen"
-            v-model:etapes="filtersDraft.etapes"
-            :etape-options="etapeOptions"
-            :can-reset="canResetFilters"
-            @apply="applyFilters"
-            @reset="filters.reset"
-          />
+
+          <div
+            v-else-if="isNotFound"
+            class="candidatures-view__status candidatures-view__status--error"
+          >
+            Recrutement introuvable.
+          </div>
+
+          <template v-else>
+            <div class="candidatures-view__toolbar">
+              <CandidaturesViewSwitch
+                :recrutement-uuid="recrutementUuid"
+                :current="currentView"
+              />
+              <div class="candidatures-view__actions">
+                <CspInput
+                  v-model="search"
+                  type="search"
+                  aria-label="Rechercher un candidat"
+                  placeholder="Rechercher un candidat…"
+                  class="candidatures-view__search"
+                  @keydown.enter="filters.flushSearch()"
+                />
+                <CspButton
+                  :label="activeFiltersCount ? `Filtres (${activeFiltersCount})` : 'Filtres'"
+                  variant="tertiary"
+                  icon="ri:filter-line"
+                  is-icon-left
+                  @click="openFilters"
+                />
+              </div>
+            </div>
+            <router-view />
+            <CandidaturesFiltersDrawer
+              v-model:open="isFiltersDrawerOpen"
+              v-model:etapes="filtersDraft.etapes"
+              :etape-options="etapeOptions"
+              :can-reset="canResetFilters"
+              @apply="applyFilters"
+              @reset="filters.reset"
+            />
+          </template>
         </template>
         <template #activites-et-taches>
           <div class="candidatures-view__placeholder">


### PR DESCRIPTION
## 📝 Description
🎸 Ajoute un composant de skeleton pour limiter le layout shift sur les composants nécessitant le chargement de données async

Ajoute un skeleton dans la vue candidatures pour minimiser le layout shift au chargement du titre :
⚠️ Ce comportement va être vite peaufiné dans les prochaines PRs cablant pinia-colada avec cette vue

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
