### PR TITLE
♻️(ats-presentation) migrate candidatures data to shared colada query

### DIFF
--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
@@ -1,9 +1,14 @@
 import type { PaginatedCandidatureListeList, RecrutementDetailKanban } from '../types'
+import { PiniaColada, useQueryCache } from '@pinia/colada'
 import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { RECRUTEMENTS_QUERY_KEYS } from '@/features/recrutements/queries'
 import { getCandidatureListe, getRecrutementKanban } from '../api'
-import { provideCandidatures, useCandidatures } from './useCandidatures'
+import { CANDIDATURES_QUERY_KEYS } from '../queries'
+import { useCandidatures } from './useCandidatures'
 
 vi.mock('../api', () => ({
   getRecrutementKanban: vi.fn(),
@@ -12,6 +17,9 @@ vi.mock('../api', () => ({
 
 const ORGANISME_UUID = '00000000-0000-0000-0000-000000000000'
 const RECRUTEMENT_UUID = 'aaaaaaaa-0001-0001-0001-000000000001'
+const ETAPE_RECEPTION = 'cccccccc-0001-0001-0001-000000000001'
+const ETAPE_PRESELECTION = 'cccccccc-0001-0001-0001-000000000002'
+const CANDIDATURE_ALICE = 'dddddddd-0001-0001-0001-000000000001'
 
 const MOCK_KANBAN: RecrutementDetailKanban = {
   offer_id: RECRUTEMENT_UUID,
@@ -93,6 +101,39 @@ const MOCK_LISTE: PaginatedCandidatureListeList = {
   ],
 }
 
+const StubView = defineComponent({ render: () => h('div') })
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: StubView },
+      { path: '/mes-recrutements/:recrutementUuid', component: StubView },
+    ],
+  })
+}
+
+async function mountCandidatures(onSetup?: () => void) {
+  const router = makeRouter()
+  await router.push(`/mes-recrutements/${RECRUTEMENT_UUID}`)
+
+  let context!: ReturnType<typeof useCandidatures>
+
+  mount(defineComponent({
+    setup() {
+      onSetup?.()
+      context = useCandidatures()
+      return () => h('div')
+    },
+  }), {
+    global: {
+      plugins: [createPinia(), PiniaColada, router],
+    },
+  })
+
+  return { context, router }
+}
+
 describe('useCandidatures', () => {
   beforeEach(() => {
     vi.mocked(getRecrutementKanban).mockReset()
@@ -101,9 +142,9 @@ describe('useCandidatures', () => {
     vi.mocked(getCandidatureListe).mockResolvedValue(MOCK_LISTE)
   })
 
-  describe('provideCandidatures', () => {
+  describe('data', () => {
     it('computes totalCount from etapes', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -113,7 +154,7 @@ describe('useCandidatures', () => {
     it('exposes error on api failure', async () => {
       vi.mocked(getRecrutementKanban).mockRejectedValue(new Error('API error'))
 
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -121,186 +162,180 @@ describe('useCandidatures', () => {
     })
 
     it('moves a candidature between etapes', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
-      const sourceColumnId = 'cccccccc-0001-0001-0001-000000000001'
-      const targetColumnId = 'cccccccc-0001-0001-0001-000000000002'
-      const cardId = 'dddddddd-0001-0001-0001-000000000001'
+      context.moveCandidature({
+        sourceColumnId: ETAPE_RECEPTION,
+        targetColumnId: ETAPE_PRESELECTION,
+        cardId: CANDIDATURE_ALICE,
+      })
 
+      const source = context.etapes.value.find(e => e.etape_uuid === ETAPE_RECEPTION)
+      const target = context.etapes.value.find(e => e.etape_uuid === ETAPE_PRESELECTION)
+
+      expect(source?.candidatures).toHaveLength(1)
+      expect(target?.candidatures).toHaveLength(2)
+    })
+
+    it.each([
+      { when: 'source and target are the same', sourceColumnId: ETAPE_RECEPTION, targetColumnId: ETAPE_RECEPTION, cardId: CANDIDATURE_ALICE },
+      { when: 'the source column is unknown', sourceColumnId: 'unknown', targetColumnId: ETAPE_PRESELECTION, cardId: CANDIDATURE_ALICE },
+      { when: 'the target column is unknown', sourceColumnId: ETAPE_RECEPTION, targetColumnId: 'unknown', cardId: CANDIDATURE_ALICE },
+      { when: 'the card is not in the source column', sourceColumnId: ETAPE_RECEPTION, targetColumnId: ETAPE_PRESELECTION, cardId: 'unknown' },
+    ])('leaves etapes untouched when $when', async ({ sourceColumnId, targetColumnId, cardId }) => {
+      const { context } = await mountCandidatures()
+
+      await vi.waitFor(() => expect(context.pending.value).toBe(false))
+
+      const before = structuredClone(context.etapes.value)
       context.moveCandidature({ sourceColumnId, targetColumnId, cardId })
 
-      const sourceEtape = context.etapes.value.find(e => e.etape_uuid === sourceColumnId)
-      const targetEtape = context.etapes.value.find(e => e.etape_uuid === targetColumnId)
-
-      expect(sourceEtape?.candidatures).toHaveLength(1)
-      expect(targetEtape?.candidatures).toHaveLength(2)
+      expect(context.etapes.value).toEqual(before)
     })
 
-    it('ignores move when source and target are the same', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+    it('leaves etapes empty when the kanban data is not loaded', async () => {
+      vi.mocked(getRecrutementKanban).mockImplementation(() => new Promise(() => {}))
 
-      await vi.waitFor(() => expect(context.pending.value).toBe(false))
-
-      const columnId = 'cccccccc-0001-0001-0001-000000000001'
-      const cardId = 'dddddddd-0001-0001-0001-000000000001'
-      const etapesBefore = structuredClone(context.etapes.value)
-
-      context.moveCandidature({ sourceColumnId: columnId, targetColumnId: columnId, cardId })
-
-      expect(context.etapes.value).toEqual(etapesBefore)
-    })
-
-    it('ignores move when source column is unknown', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
-
-      await vi.waitFor(() => expect(context.pending.value).toBe(false))
-
-      const etapesBefore = structuredClone(context.etapes.value)
+      const { context } = await mountCandidatures()
 
       context.moveCandidature({
-        sourceColumnId: 'unknown-source',
-        targetColumnId: 'cccccccc-0001-0001-0001-000000000002',
-        cardId: 'dddddddd-0001-0001-0001-000000000001',
+        sourceColumnId: ETAPE_RECEPTION,
+        targetColumnId: ETAPE_PRESELECTION,
+        cardId: CANDIDATURE_ALICE,
       })
 
-      expect(context.etapes.value).toEqual(etapesBefore)
+      expect(context.etapes.value).toEqual([])
     })
+  })
 
-    it('ignores move when target column is unknown', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+  describe('intitule', () => {
+    it('exposes the intitule from the loaded detail', async () => {
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
-      const etapesBefore = structuredClone(context.etapes.value)
-
-      context.moveCandidature({
-        sourceColumnId: 'cccccccc-0001-0001-0001-000000000001',
-        targetColumnId: 'unknown-target',
-        cardId: 'dddddddd-0001-0001-0001-000000000001',
-      })
-
-      expect(context.etapes.value).toEqual(etapesBefore)
+      expect(context.intitule.value).toBe('Chargé de mission numérique')
     })
 
-    it('ignores move when card is not in source column', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+    it('seeds the intitule from the recrutements list cache while pending', async () => {
+      vi.mocked(getRecrutementKanban).mockImplementation(() => new Promise(() => {}))
+      vi.mocked(getCandidatureListe).mockImplementation(() => new Promise(() => {}))
 
-      await vi.waitFor(() => expect(context.pending.value).toBe(false))
-
-      const etapesBefore = structuredClone(context.etapes.value)
-
-      context.moveCandidature({
-        sourceColumnId: 'cccccccc-0001-0001-0001-000000000001',
-        targetColumnId: 'cccccccc-0001-0001-0001-000000000002',
-        cardId: 'unknown-card',
+      const { context } = await mountCandidatures(() => {
+        const queryCache = useQueryCache()
+        queryCache.setQueryData(
+          RECRUTEMENTS_QUERY_KEYS.actifs(ORGANISME_UUID),
+          {
+            count: 1,
+            next: null,
+            previous: null,
+            results: [{ offer_id: RECRUTEMENT_UUID, intitule: 'Chargé de mission numérique' }],
+          },
+        )
       })
 
-      expect(context.etapes.value).toEqual(etapesBefore)
+      expect(context.pending.value).toBe(true)
+      expect(context.intitule.value).toBe('Chargé de mission numérique')
+    })
+
+    it('has no intitule while pending without cached list', async () => {
+      vi.mocked(getRecrutementKanban).mockImplementation(() => new Promise(() => {}))
+
+      const { context } = await mountCandidatures()
+
+      expect(context.intitule.value).toBeNull()
     })
   })
 
   describe('filters', () => {
-    it('exposes unfiltered data when no filter is active', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+    // La logique des filtres est couverte en isolation dans
+    // useCandidaturesFilters.test.ts ; ici on vérifie seulement le câblage sur
+    // les données live de la query.
+    it('applies filters to the live kanban and liste data', async () => {
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
-      expect(context.filters.filteredEtapes.value).toHaveLength(2)
-      expect(context.filters.filteredCandidatures.value).toHaveLength(3)
-      expect(context.filters.activeFiltersCount.value).toBe(0)
-    })
-
-    it('filters kanban and liste by candidat name', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
-
-      await vi.waitFor(() => expect(context.pending.value).toBe(false))
-
-      context.filters.search.value = 'alice dup'
-      context.filters.flushSearch()
-
-      const [reception, preselection] = context.filters.filteredEtapes.value
-      expect(reception?.candidatures.map(c => c.candidat.nom)).toEqual(['Dupont'])
-      expect(preselection?.candidatures).toHaveLength(0)
-      expect(context.filters.filteredCandidatures.value.map(c => c.candidat.nom)).toEqual(['Dupont'])
-    })
-
-    it('filters kanban columns and liste rows by etape', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
-
-      await vi.waitFor(() => expect(context.pending.value).toBe(false))
-
-      context.filters.draft.etapes = ['cccccccc-0001-0001-0001-000000000002']
+      context.filters.draft.etapes = [ETAPE_PRESELECTION]
       context.filters.apply()
 
       expect(context.filters.filteredEtapes.value.map(e => e.nom)).toEqual(['Présélection'])
       expect(context.filters.filteredCandidatures.value.map(c => c.candidat.nom)).toEqual(['Bernard'])
-      expect(context.filters.activeFiltersCount.value).toBe(1)
-    })
-
-    it('combines etape filter and search', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
-
-      await vi.waitFor(() => expect(context.pending.value).toBe(false))
-
-      context.filters.draft.etapes = ['cccccccc-0001-0001-0001-000000000001']
-      context.filters.apply()
-      context.filters.search.value = 'martin'
-      context.filters.flushSearch()
-
-      expect(context.filters.filteredEtapes.value).toHaveLength(1)
-      expect(context.filters.filteredEtapes.value[0]?.candidatures.map(c => c.candidat.nom)).toEqual(['Martin'])
-      expect(context.filters.filteredCandidatures.value.map(c => c.candidat.nom)).toEqual(['Martin'])
-    })
-
-    it('clears filters and search on reset', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
-
-      await vi.waitFor(() => expect(context.pending.value).toBe(false))
-
-      context.filters.draft.etapes = ['cccccccc-0001-0001-0001-000000000002']
-      context.filters.apply()
-      context.filters.search.value = 'alice'
-      context.filters.flushSearch()
-
-      context.filters.reset()
-
-      expect(context.filters.filteredEtapes.value).toHaveLength(2)
-      expect(context.filters.filteredCandidatures.value).toHaveLength(3)
-      expect(context.filters.search.value).toBe('')
-      expect(context.filters.canReset.value).toBe(false)
     })
   })
 
-  describe('useCandidatures', () => {
-    it('throws if called outside provider', () => {
-      expect(() => useCandidatures()).toThrow('useCandidatures must be used within CandidaturesView')
-    })
+  describe('shared instance', () => {
+    it('shares the same state across components', async () => {
+      const router = makeRouter()
+      await router.push(`/mes-recrutements/${RECRUTEMENT_UUID}`)
 
-    it('returns context when used within provider', async () => {
-      let injectedContext: ReturnType<typeof useCandidatures> | undefined
+      const contexts: ReturnType<typeof useCandidatures>[] = []
 
       const Child = defineComponent({
         setup() {
-          injectedContext = useCandidatures()
+          contexts.push(useCandidatures())
           return () => h('div')
         },
       })
 
-      const Parent = defineComponent({
+      mount(defineComponent({
         setup() {
-          provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+          contexts.push(useCandidatures())
           return () => h(Child)
+        },
+      }), {
+        global: {
+          plugins: [createPinia(), PiniaColada, router],
         },
       })
 
-      mount(Parent)
+      await vi.waitFor(() => expect(contexts[0]?.pending.value).toBe(false))
 
-      await vi.waitFor(() => expect(injectedContext?.pending.value).toBe(false))
+      expect(contexts[0]?.filters).toBe(contexts[1]?.filters)
+      expect(contexts[0]?.recrutementUuid.value).toBe(RECRUTEMENT_UUID)
+      expect(contexts[1]?.totalCount.value).toBe(3)
+    })
+  })
 
-      expect(injectedContext?.recrutementUuid).toBe(RECRUTEMENT_UUID)
-      expect(injectedContext?.totalCount.value).toBe(3)
+  describe('route changes', () => {
+    it('resyncs etapes when the kanban data changes', async () => {
+      let queryCache!: ReturnType<typeof useQueryCache>
+      const { context } = await mountCandidatures(() => {
+        queryCache = useQueryCache()
+      })
+
+      await vi.waitFor(() => expect(context.pending.value).toBe(false))
+      expect(context.totalCount.value).toBe(3)
+
+      queryCache.setQueryData(
+        CANDIDATURES_QUERY_KEYS.kanban(ORGANISME_UUID, RECRUTEMENT_UUID),
+        { ...MOCK_KANBAN, etapes: [MOCK_KANBAN.etapes[0]!] },
+      )
+
+      await vi.waitFor(() => expect(context.totalCount.value).toBe(2))
+      expect(context.etapes.value).toHaveLength(1)
+    })
+
+    it('resets filters when navigating to another recrutement', async () => {
+      const { context, router } = await mountCandidatures()
+
+      await vi.waitFor(() => expect(context.pending.value).toBe(false))
+
+      context.filters.search.value = 'alice'
+      context.filters.flushSearch()
+      context.filters.draft.etapes = [ETAPE_RECEPTION]
+      context.filters.apply()
+      expect(context.filters.activeFiltersCount.value).toBe(1)
+
+      await router.push('/mes-recrutements/aaaaaaaa-0001-0001-0001-000000000002')
+
+      await vi.waitFor(() => {
+        expect(context.filters.search.value).toBe('')
+        expect(context.filters.activeFiltersCount.value).toBe(0)
+      })
+      expect(context.recrutementUuid.value).toBe('aaaaaaaa-0001-0001-0001-000000000002')
     })
   })
 })

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
@@ -1,14 +1,13 @@
-import type { InjectionKey, Ref, ShallowRef } from 'vue'
 import type {
   Candidature,
-  EtapeRecrutementDetailedCandidatures,
-  PaginatedCandidatureListeList,
   RecrutementDetailKanban,
 } from '../types'
-import type { CandidaturesFiltersContext } from './useCandidaturesFilters'
-import { computed, inject, provide, ref, shallowRef } from 'vue'
-import { useAsyncState } from '@/composables/async/useAsyncState'
-import { getCandidatureListe, getRecrutementKanban } from '../api'
+import { defineQuery, useQuery, useQueryCache } from '@pinia/colada'
+import { computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
+import { peekRecrutementIntitule } from '@/features/recrutements/queries'
+import { candidatureListeQuery, recrutementKanbanQuery } from '../queries'
 import { useCandidaturesFilters } from './useCandidaturesFilters'
 
 export interface MoveCandidatureParams {
@@ -17,45 +16,51 @@ export interface MoveCandidatureParams {
   cardId: string
 }
 
-export interface CandidaturesContext {
-  recrutementUuid: string
-  recrutementDetail: Ref<RecrutementDetailKanban | null>
-  candidatureListe: Ref<PaginatedCandidatureListeList | undefined>
-  etapes: ShallowRef<EtapeRecrutementDetailedCandidatures[]>
-  totalCount: Ref<number>
-  pending: Ref<boolean>
-  error: Ref<unknown>
-  moveCandidature: (params: MoveCandidatureParams) => void
-  filters: CandidaturesFiltersContext
-}
+export const useCandidatures = defineQuery(() => {
+  const route = useRoute()
+  const recrutementUuid = computed<string | null>(() => {
+    const param = route.params.recrutementUuid
+    return typeof param === 'string' && param !== '' ? param : null
+  })
 
-const CANDIDATURES_KEY: InjectionKey<CandidaturesContext> = Symbol('candidatures')
+  const queryCache = useQueryCache()
 
-export function provideCandidatures(
-  organismeUuid: string,
-  recrutementUuid: string,
-): CandidaturesContext {
-  const { pending, error, run } = useAsyncState(true)
-  const recrutementDetail = ref<RecrutementDetailKanban | null>(null)
-  const candidatureListe = ref<PaginatedCandidatureListeList>()
-  const etapes = shallowRef<EtapeRecrutementDetailedCandidatures[]>([])
+  const kanban = useQuery(() => ({
+    ...recrutementKanbanQuery({
+      organismeUuid: TEMP_ORGANISME_UUID,
+      recrutementUuid: recrutementUuid.value ?? '',
+    }),
+    enabled: recrutementUuid.value !== null,
+  }))
+
+  const liste = useQuery(() => ({
+    ...candidatureListeQuery({
+      organismeUuid: TEMP_ORGANISME_UUID,
+      recrutementUuid: recrutementUuid.value ?? '',
+    }),
+    enabled: recrutementUuid.value !== null,
+  }))
+
+  const recrutementDetail = computed<RecrutementDetailKanban | null>(
+    () => kanban.data.value ?? null,
+  )
+  const candidatureListe = liste.data
+
+  const intitule = computed<string | null>(() =>
+    recrutementDetail.value?.intitule
+    ?? (recrutementUuid.value
+      ? peekRecrutementIntitule(queryCache, TEMP_ORGANISME_UUID, recrutementUuid.value)
+      : null),
+  )
+
+  const etapes = computed(() => kanban.data.value?.etapes ?? [])
+
+  const pending = computed(() => kanban.isPending.value || liste.isPending.value)
+  const error = computed<unknown>(() => kanban.error.value ?? liste.error.value)
 
   const totalCount = computed(() =>
     etapes.value.reduce((sum, etape) => sum + etape.candidatures.length, 0),
   )
-
-  async function load(): Promise<void> {
-    await run(async () => {
-      const [kanban, liste] = await Promise.all([
-        getRecrutementKanban(organismeUuid, recrutementUuid),
-        getCandidatureListe(organismeUuid, recrutementUuid),
-      ])
-
-      recrutementDetail.value = kanban
-      etapes.value = structuredClone(kanban.etapes)
-      candidatureListe.value = liste
-    })
-  }
 
   function moveCandidature(params: MoveCandidatureParams): void {
     const { sourceColumnId, targetColumnId, cardId } = params
@@ -63,8 +68,12 @@ export function provideCandidatures(
     if (sourceColumnId === targetColumnId)
       return
 
-    const sourceEtape = etapes.value.find(e => e.etape_uuid === sourceColumnId)
-    const targetEtape = etapes.value.find(e => e.etape_uuid === targetColumnId)
+    const detail = kanban.data.value
+    if (!detail)
+      return
+
+    const sourceEtape = detail.etapes.find(e => e.etape_uuid === sourceColumnId)
+    const targetEtape = detail.etapes.find(e => e.etape_uuid === targetColumnId)
 
     if (!sourceEtape || !targetEtape)
       return
@@ -75,7 +84,7 @@ export function provideCandidatures(
 
     const candidature = sourceEtape.candidatures[candidatureIndex] as Candidature
 
-    const newEtapes = etapes.value.map((etape) => {
+    const newEtapes = detail.etapes.map((etape) => {
       if (etape.etape_uuid === sourceColumnId) {
         return {
           ...etape,
@@ -91,16 +100,23 @@ export function provideCandidatures(
       return etape
     })
 
-    etapes.value = newEtapes
+    const { key } = recrutementKanbanQuery({
+      organismeUuid: TEMP_ORGANISME_UUID,
+      recrutementUuid: recrutementUuid.value!,
+    })
+    queryCache.setQueryData(key, { ...detail, etapes: newEtapes })
   }
 
   const filters = useCandidaturesFilters(etapes, candidatureListe)
 
-  void load()
+  watch(recrutementUuid, () => {
+    filters.reset()
+  })
 
-  const context: CandidaturesContext = {
+  return {
     recrutementUuid,
     recrutementDetail,
+    intitule,
     candidatureListe,
     etapes,
     totalCount,
@@ -109,16 +125,4 @@ export function provideCandidatures(
     moveCandidature,
     filters,
   }
-
-  provide(CANDIDATURES_KEY, context)
-
-  return context
-}
-
-export function useCandidatures(): CandidaturesContext {
-  const context = inject(CANDIDATURES_KEY)
-  if (!context) {
-    throw new Error('useCandidatures must be used within CandidaturesView')
-  }
-  return context
-}
+})

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidaturesFilters.test.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidaturesFilters.test.ts
@@ -1,0 +1,161 @@
+import type {
+  EtapeRecrutementDetailedCandidatures,
+  PaginatedCandidatureListeList,
+} from '../types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref, shallowRef } from 'vue'
+import { useCandidaturesFilters } from './useCandidaturesFilters'
+
+const ETAPE_RECEPTION = 'cccccccc-0001-0001-0001-000000000001'
+const ETAPE_PRESELECTION = 'cccccccc-0001-0001-0001-000000000002'
+
+function makeEtapes(): EtapeRecrutementDetailedCandidatures[] {
+  return [
+    {
+      etape_uuid: ETAPE_RECEPTION,
+      nom: 'Réception des candidatures',
+      categorie: 'ENTREE',
+      candidatures: [
+        {
+          uuid: 'dddddddd-0001-0001-0001-000000000001',
+          date_soumission: '2025-06-10T09:15:00Z',
+          date_derniere_activite: '2025-06-11T10:00:00Z',
+          candidat: { uuid: 'eeeeeeee-0001', nom: 'Dupont', prenom: 'Alice' },
+        },
+        {
+          uuid: 'dddddddd-0001-0001-0001-000000000002',
+          date_soumission: '2025-06-11T14:30:00Z',
+          date_derniere_activite: '2025-06-12T09:15:00Z',
+          candidat: { uuid: 'eeeeeeee-0002', nom: 'Martin', prenom: 'Bruno' },
+        },
+      ],
+    },
+    {
+      etape_uuid: ETAPE_PRESELECTION,
+      nom: 'Présélection',
+      categorie: 'EN_COURS',
+      candidatures: [
+        {
+          uuid: 'dddddddd-0001-0001-0001-000000000005',
+          date_soumission: '2025-06-08T10:00:00Z',
+          date_derniere_activite: '2025-06-11T10:00:00Z',
+          candidat: { uuid: 'eeeeeeee-0005', nom: 'Bernard', prenom: 'Élise' },
+        },
+      ],
+    },
+  ]
+}
+
+function makeListe(): PaginatedCandidatureListeList {
+  return {
+    count: 3,
+    next: null,
+    previous: null,
+    results: [
+      {
+        uuid: 'dddddddd-0001-0001-0001-000000000001',
+        date_soumission: '2025-06-10T09:15:00Z',
+        date_derniere_activite: '2025-06-11T10:00:00Z',
+        candidat: { uuid: 'eeeeeeee-0001', nom: 'Dupont', prenom: 'Alice' },
+        etape: { etape_uuid: ETAPE_RECEPTION, nom: 'Réception des candidatures', categorie: 'ENTREE' },
+      },
+      {
+        uuid: 'dddddddd-0001-0001-0001-000000000002',
+        date_soumission: '2025-06-11T14:30:00Z',
+        date_derniere_activite: '2025-06-12T09:15:00Z',
+        candidat: { uuid: 'eeeeeeee-0002', nom: 'Martin', prenom: 'Bruno' },
+        etape: { etape_uuid: ETAPE_RECEPTION, nom: 'Réception des candidatures', categorie: 'ENTREE' },
+      },
+      {
+        uuid: 'dddddddd-0001-0001-0001-000000000005',
+        date_soumission: '2025-06-08T10:00:00Z',
+        date_derniere_activite: '2025-06-11T10:00:00Z',
+        candidat: { uuid: 'eeeeeeee-0005', nom: 'Bernard', prenom: 'Élise' },
+        etape: { etape_uuid: ETAPE_PRESELECTION, nom: 'Présélection', categorie: 'EN_COURS' },
+      },
+    ],
+  }
+}
+
+function setup() {
+  const etapes = shallowRef(makeEtapes())
+  const liste = ref<PaginatedCandidatureListeList | undefined>(makeListe())
+  return { etapes, liste, filters: useCandidaturesFilters(etapes, liste) }
+}
+
+describe('useCandidaturesFilters', () => {
+  it('exposes unfiltered data when no filter is active', () => {
+    const { filters } = setup()
+    expect(filters.filteredEtapes.value).toHaveLength(2)
+    expect(filters.filteredCandidatures.value).toHaveLength(3)
+    expect(filters.activeFiltersCount.value).toBe(0)
+  })
+
+  it('builds etape options from the etapes list', () => {
+    const { filters } = setup()
+    expect(filters.etapeOptions.value).toEqual([
+      { value: ETAPE_RECEPTION, label: 'Réception des candidatures' },
+      { value: ETAPE_PRESELECTION, label: 'Présélection' },
+    ])
+  })
+
+  it('filters kanban columns and liste rows by etape once applied', () => {
+    const { filters } = setup()
+    filters.draft.etapes = [ETAPE_PRESELECTION]
+    expect(filters.filteredEtapes.value).toHaveLength(2)
+
+    filters.apply()
+    expect(filters.filteredEtapes.value.map(e => e.nom)).toEqual(['Présélection'])
+    expect(filters.filteredCandidatures.value.map(c => c.candidat.nom)).toEqual(['Bernard'])
+    expect(filters.activeFiltersCount.value).toBe(1)
+  })
+
+  it('flushes search immediately without waiting for the debounce', () => {
+    const { filters } = setup()
+    filters.search.value = 'martin'
+    filters.flushSearch()
+
+    expect(filters.filteredCandidatures.value.map(c => c.candidat.nom)).toEqual(['Martin'])
+  })
+
+  it('falls back to an empty list when candidatureListe is undefined', () => {
+    const etapes = shallowRef(makeEtapes())
+    const liste = ref<PaginatedCandidatureListeList | undefined>(undefined)
+    const filters = useCandidaturesFilters(etapes, liste)
+
+    expect(filters.filteredCandidatures.value).toEqual([])
+  })
+
+  it('clears etape filter and search on reset', () => {
+    const { filters } = setup()
+    filters.draft.etapes = [ETAPE_PRESELECTION]
+    filters.apply()
+    filters.search.value = 'alice'
+    filters.flushSearch()
+
+    filters.reset()
+
+    expect(filters.filteredEtapes.value).toHaveLength(2)
+    expect(filters.filteredCandidatures.value).toHaveLength(3)
+    expect(filters.search.value).toBe('')
+    expect(filters.canReset.value).toBe(false)
+  })
+})
+
+describe('useCandidaturesFilters: debounced search', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('applies the search term after the debounce delay', async () => {
+    const { filters } = setup()
+    filters.search.value = 'alice'
+    await nextTick()
+    expect(filters.filteredCandidatures.value).toHaveLength(3)
+
+    vi.advanceTimersByTime(500)
+    await nextTick()
+
+    expect(filters.filteredCandidatures.value.map(c => c.candidat.nom)).toEqual(['Dupont'])
+    expect(filters.filteredEtapes.value[0]?.candidatures.map(c => c.candidat.nom)).toEqual(['Dupont'])
+  })
+})

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidaturesFilters.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidaturesFilters.ts
@@ -1,4 +1,4 @@
-import type { Ref, ShallowRef } from 'vue'
+import type { Ref } from 'vue'
 import type {
   EtapeRecrutementDetailedCandidatures,
   PaginatedCandidatureListeList,
@@ -19,7 +19,7 @@ const SEARCH_DEBOUNCE_MS = 500
 export type CandidaturesFiltersContext = ReturnType<typeof useCandidaturesFilters>
 
 export function useCandidaturesFilters(
-  etapes: ShallowRef<EtapeRecrutementDetailedCandidatures[]>,
+  etapes: Readonly<Ref<EtapeRecrutementDetailedCandidatures[]>>,
   candidatureListe: Ref<PaginatedCandidatureListeList | undefined>,
 ) {
   const {

--- a/src/web/presentation/frontend/src/features/candidatures/queries.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/queries.ts
@@ -1,0 +1,31 @@
+import { defineQueryOptions } from '@pinia/colada'
+import { getCandidatureListe, getRecrutementKanban } from './api'
+
+export const CANDIDATURES_QUERY_KEYS = {
+  root: ['candidatures'] as const,
+  recrutement: (organismeUuid: string, recrutementUuid: string) =>
+    [...CANDIDATURES_QUERY_KEYS.root, organismeUuid, recrutementUuid] as const,
+  kanban: (organismeUuid: string, recrutementUuid: string) =>
+    [...CANDIDATURES_QUERY_KEYS.recrutement(organismeUuid, recrutementUuid), 'kanban'] as const,
+  liste: (organismeUuid: string, recrutementUuid: string) =>
+    [...CANDIDATURES_QUERY_KEYS.recrutement(organismeUuid, recrutementUuid), 'liste'] as const,
+}
+
+export interface CandidaturesQueryParams {
+  organismeUuid: string
+  recrutementUuid: string
+}
+
+export const recrutementKanbanQuery = defineQueryOptions(
+  ({ organismeUuid, recrutementUuid }: CandidaturesQueryParams) => ({
+    key: CANDIDATURES_QUERY_KEYS.kanban(organismeUuid, recrutementUuid),
+    query: () => getRecrutementKanban(organismeUuid, recrutementUuid),
+  }),
+)
+
+export const candidatureListeQuery = defineQueryOptions(
+  ({ organismeUuid, recrutementUuid }: CandidaturesQueryParams) => ({
+    key: CANDIDATURES_QUERY_KEYS.liste(organismeUuid, recrutementUuid),
+    query: () => getCandidatureListe(organismeUuid, recrutementUuid),
+  }),
+)

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
@@ -18,7 +18,7 @@ const { filteredEtapes } = filters
 
 const showSkeleton = useMinimumPending(pending)
 
-const boardId = computed(() => `kanban-${recrutementUuid}`)
+const boardId = computed(() => `kanban-${recrutementUuid.value}`)
 
 function handleMove(event: KanbanDropEvent) {
   moveCandidature({

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -14,10 +14,9 @@ import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContai
 import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
 import { useDisclosure } from '@/composables/ui/useDisclosure'
-import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import CandidaturesFiltersDrawer from '../components/CandidaturesFiltersDrawer.vue'
 import CandidaturesViewSwitch from '../components/CandidaturesViewSwitch.vue'
-import { provideCandidatures } from '../composables/useCandidatures'
+import { useCandidatures } from '../composables/useCandidatures'
 import { formatRecrutementMeta } from '../format'
 
 const route = useRoute()
@@ -25,10 +24,11 @@ const recrutementUuid = route.params.recrutementUuid as string
 
 const {
   recrutementDetail,
+  intitule,
   pending,
   error,
   filters,
-} = provideCandidatures(TEMP_ORGANISME_UUID, recrutementUuid)
+} = useCandidatures()
 
 const showSkeleton = useMinimumPending(pending)
 
@@ -56,12 +56,12 @@ function applyFilters() {
   closeFiltersDrawer()
 }
 
-const title = computed(() => recrutementDetail.value?.intitule ?? 'Candidatures')
+const title = computed(() => intitule.value ?? 'Candidatures')
 
 const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
   { label: 'Accueil', to: { name: 'home' } },
   { label: 'Mes recrutements', to: { name: 'mes-recrutements' } },
-  ...(recrutementDetail.value ? [{ label: recrutementDetail.value.intitule }] : []),
+  ...(intitule.value ? [{ label: intitule.value }] : []),
 ])
 
 const metaItems = computed(() =>
@@ -96,7 +96,7 @@ const activeTab = ref<'candidatures' | 'activites-et-taches'>('candidatures')
     >
       <template #title>
         <CspSkeleton
-          v-if="showSkeleton"
+          v-if="showSkeleton && !intitule"
           width="20rem"
           height="2rem"
         />

--- a/src/web/presentation/frontend/src/features/recrutements/queries.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/queries.ts
@@ -1,3 +1,8 @@
+import type { useQueryCache } from '@pinia/colada'
+import type {
+  PaginatedRecrutementsActifsResponse,
+  PaginatedRecrutementsArchivesResponse,
+} from './types'
 import { defineQueryOptions } from '@pinia/colada'
 import { getRecrutementsActifs, getRecrutementsArchives } from './api'
 
@@ -22,3 +27,26 @@ export const recrutementsArchivesQuery = defineQueryOptions(
     query: () => getRecrutementsArchives(organismeUuid),
   }),
 )
+
+export function peekRecrutementIntitule(
+  queryCache: ReturnType<typeof useQueryCache>,
+  organismeUuid: string,
+  offerId: string,
+): string | null {
+  const lists = [
+    queryCache.getQueryData<PaginatedRecrutementsActifsResponse>(
+      RECRUTEMENTS_QUERY_KEYS.actifs(organismeUuid),
+    ),
+    queryCache.getQueryData<PaginatedRecrutementsArchivesResponse>(
+      RECRUTEMENTS_QUERY_KEYS.archives(organismeUuid),
+    ),
+  ]
+
+  for (const list of lists) {
+    const row = list?.results?.find(r => r.offer_id === offerId)
+    if (row) {
+      return row.intitule
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## 📝 Description
🎸 Migration vers pinia-colada de la gestion des données candidatures (kanban + liste), qui permet notamment : 
- navigation retour instantanée grâce au cache,
- affichage instantané du titre d'une offre quand on vient de la liste, en le lisant dans le cache de celle-ci. Le titre continue de rendre un skeleton en cas d'accès direct à la page
- queryCache.setQueryData en attendant l'endpoint de mutation backend

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
