### PR TITLE
♻️(ats-presentation) replace candidatures context with shared colada query

### DIFF
--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
@@ -1,5 +1,7 @@
 import type { PaginatedCandidatureListeList, RecrutementDetailKanban } from '../types'
+import { PiniaColada } from '@pinia/colada'
 import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { getCandidatureListe, getRecrutementKanban } from '../api'
@@ -93,6 +95,23 @@ const MOCK_LISTE: PaginatedCandidatureListeList = {
   ],
 }
 
+function mountProvider() {
+  let context!: ReturnType<typeof provideCandidatures>
+
+  mount(defineComponent({
+    setup() {
+      context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      return () => h('div')
+    },
+  }), {
+    global: {
+      plugins: [createPinia(), PiniaColada],
+    },
+  })
+
+  return context
+}
+
 describe('useCandidatures', () => {
   beforeEach(() => {
     vi.mocked(getRecrutementKanban).mockReset()
@@ -103,7 +122,7 @@ describe('useCandidatures', () => {
 
   describe('provideCandidatures', () => {
     it('computes totalCount from etapes', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -113,7 +132,7 @@ describe('useCandidatures', () => {
     it('exposes error on api failure', async () => {
       vi.mocked(getRecrutementKanban).mockRejectedValue(new Error('API error'))
 
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -121,7 +140,7 @@ describe('useCandidatures', () => {
     })
 
     it('moves a candidature between etapes', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -139,7 +158,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when source and target are the same', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -153,7 +172,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when source column is unknown', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -169,7 +188,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when target column is unknown', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -185,7 +204,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when card is not in source column', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -203,7 +222,7 @@ describe('useCandidatures', () => {
 
   describe('filters', () => {
     it('exposes unfiltered data when no filter is active', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -213,7 +232,7 @@ describe('useCandidatures', () => {
     })
 
     it('filters kanban and liste by candidat name', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -227,7 +246,7 @@ describe('useCandidatures', () => {
     })
 
     it('filters kanban columns and liste rows by etape', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -240,7 +259,7 @@ describe('useCandidatures', () => {
     })
 
     it('combines etape filter and search', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -255,7 +274,7 @@ describe('useCandidatures', () => {
     })
 
     it('clears filters and search on reset', async () => {
-      const context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      const context = mountProvider()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -295,7 +314,11 @@ describe('useCandidatures', () => {
         },
       })
 
-      mount(Parent)
+      mount(Parent, {
+        global: {
+          plugins: [createPinia(), PiniaColada],
+        },
+      })
 
       await vi.waitFor(() => expect(injectedContext?.pending.value).toBe(false))
 

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
@@ -1,9 +1,10 @@
 import type { PaginatedCandidatureListeList, RecrutementDetailKanban } from '../types'
-import { PiniaColada } from '@pinia/colada'
+import { PiniaColada, useQueryCache } from '@pinia/colada'
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
+import { RECRUTEMENTS_QUERY_KEYS } from '@/features/recrutements/queries'
 import { getCandidatureListe, getRecrutementKanban } from '../api'
 import { provideCandidatures, useCandidatures } from './useCandidatures'
 
@@ -95,11 +96,12 @@ const MOCK_LISTE: PaginatedCandidatureListeList = {
   ],
 }
 
-function mountProvider() {
+function mountProvider(onSetup?: () => void) {
   let context!: ReturnType<typeof provideCandidatures>
 
   mount(defineComponent({
     setup() {
+      onSetup?.()
       context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
       return () => h('div')
     },
@@ -217,6 +219,45 @@ describe('useCandidatures', () => {
       })
 
       expect(context.etapes.value).toEqual(etapesBefore)
+    })
+  })
+
+  describe('intitule', () => {
+    it('exposes the intitule from the loaded detail', async () => {
+      const context = mountProvider()
+
+      await vi.waitFor(() => expect(context.pending.value).toBe(false))
+
+      expect(context.intitule.value).toBe('Chargé de mission numérique')
+    })
+
+    it('seeds the intitule from the recrutements list cache while pending', async () => {
+      vi.mocked(getRecrutementKanban).mockImplementation(() => new Promise(() => {}))
+      vi.mocked(getCandidatureListe).mockImplementation(() => new Promise(() => {}))
+
+      const context = mountProvider(() => {
+        const queryCache = useQueryCache()
+        queryCache.setQueryData(
+          RECRUTEMENTS_QUERY_KEYS.actifs(ORGANISME_UUID),
+          {
+            count: 1,
+            next: null,
+            previous: null,
+            results: [{ offer_id: RECRUTEMENT_UUID, intitule: 'Chargé de mission numérique' }],
+          },
+        )
+      })
+
+      expect(context.pending.value).toBe(true)
+      expect(context.intitule.value).toBe('Chargé de mission numérique')
+    })
+
+    it('has no intitule while pending without cached list', () => {
+      vi.mocked(getRecrutementKanban).mockImplementation(() => new Promise(() => {}))
+
+      const context = mountProvider()
+
+      expect(context.intitule.value).toBeNull()
     })
   })
 

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
@@ -4,9 +4,11 @@ import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
 import { RECRUTEMENTS_QUERY_KEYS } from '@/features/recrutements/queries'
 import { getCandidatureListe, getRecrutementKanban } from '../api'
-import { provideCandidatures, useCandidatures } from './useCandidatures'
+import { CANDIDATURES_QUERY_KEYS } from '../queries'
+import { useCandidatures } from './useCandidatures'
 
 vi.mock('../api', () => ({
   getRecrutementKanban: vi.fn(),
@@ -96,22 +98,37 @@ const MOCK_LISTE: PaginatedCandidatureListeList = {
   ],
 }
 
-function mountProvider(onSetup?: () => void) {
-  let context!: ReturnType<typeof provideCandidatures>
+const StubView = defineComponent({ render: () => h('div') })
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: StubView },
+      { path: '/mes-recrutements/:recrutementUuid', component: StubView },
+    ],
+  })
+}
+
+async function mountCandidatures(onSetup?: () => void) {
+  const router = makeRouter()
+  await router.push(`/mes-recrutements/${RECRUTEMENT_UUID}`)
+
+  let context!: ReturnType<typeof useCandidatures>
 
   mount(defineComponent({
     setup() {
       onSetup?.()
-      context = provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+      context = useCandidatures()
       return () => h('div')
     },
   }), {
     global: {
-      plugins: [createPinia(), PiniaColada],
+      plugins: [createPinia(), PiniaColada, router],
     },
   })
 
-  return context
+  return { context, router }
 }
 
 describe('useCandidatures', () => {
@@ -122,9 +139,9 @@ describe('useCandidatures', () => {
     vi.mocked(getCandidatureListe).mockResolvedValue(MOCK_LISTE)
   })
 
-  describe('provideCandidatures', () => {
+  describe('data', () => {
     it('computes totalCount from etapes', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -134,7 +151,7 @@ describe('useCandidatures', () => {
     it('exposes error on api failure', async () => {
       vi.mocked(getRecrutementKanban).mockRejectedValue(new Error('API error'))
 
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -142,7 +159,7 @@ describe('useCandidatures', () => {
     })
 
     it('moves a candidature between etapes', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -160,7 +177,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when source and target are the same', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -174,7 +191,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when source column is unknown', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -190,7 +207,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when target column is unknown', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -206,7 +223,7 @@ describe('useCandidatures', () => {
     })
 
     it('ignores move when card is not in source column', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -224,7 +241,7 @@ describe('useCandidatures', () => {
 
   describe('intitule', () => {
     it('exposes the intitule from the loaded detail', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -235,7 +252,7 @@ describe('useCandidatures', () => {
       vi.mocked(getRecrutementKanban).mockImplementation(() => new Promise(() => {}))
       vi.mocked(getCandidatureListe).mockImplementation(() => new Promise(() => {}))
 
-      const context = mountProvider(() => {
+      const { context } = await mountCandidatures(() => {
         const queryCache = useQueryCache()
         queryCache.setQueryData(
           RECRUTEMENTS_QUERY_KEYS.actifs(ORGANISME_UUID),
@@ -252,10 +269,10 @@ describe('useCandidatures', () => {
       expect(context.intitule.value).toBe('Chargé de mission numérique')
     })
 
-    it('has no intitule while pending without cached list', () => {
+    it('has no intitule while pending without cached list', async () => {
       vi.mocked(getRecrutementKanban).mockImplementation(() => new Promise(() => {}))
 
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       expect(context.intitule.value).toBeNull()
     })
@@ -263,7 +280,7 @@ describe('useCandidatures', () => {
 
   describe('filters', () => {
     it('exposes unfiltered data when no filter is active', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -273,7 +290,7 @@ describe('useCandidatures', () => {
     })
 
     it('filters kanban and liste by candidat name', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -287,7 +304,7 @@ describe('useCandidatures', () => {
     })
 
     it('filters kanban columns and liste rows by etape', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -300,7 +317,7 @@ describe('useCandidatures', () => {
     })
 
     it('combines etape filter and search', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -315,7 +332,7 @@ describe('useCandidatures', () => {
     })
 
     it('clears filters and search on reset', async () => {
-      const context = mountProvider()
+      const { context } = await mountCandidatures()
 
       await vi.waitFor(() => expect(context.pending.value).toBe(false))
 
@@ -333,38 +350,76 @@ describe('useCandidatures', () => {
     })
   })
 
-  describe('useCandidatures', () => {
-    it('throws if called outside provider', () => {
-      expect(() => useCandidatures()).toThrow('useCandidatures must be used within CandidaturesView')
-    })
+  describe('shared instance', () => {
+    it('shares the same state across components', async () => {
+      const router = makeRouter()
+      await router.push(`/mes-recrutements/${RECRUTEMENT_UUID}`)
 
-    it('returns context when used within provider', async () => {
-      let injectedContext: ReturnType<typeof useCandidatures> | undefined
+      const contexts: ReturnType<typeof useCandidatures>[] = []
 
       const Child = defineComponent({
         setup() {
-          injectedContext = useCandidatures()
+          contexts.push(useCandidatures())
           return () => h('div')
         },
       })
 
-      const Parent = defineComponent({
+      mount(defineComponent({
         setup() {
-          provideCandidatures(ORGANISME_UUID, RECRUTEMENT_UUID)
+          contexts.push(useCandidatures())
           return () => h(Child)
         },
-      })
-
-      mount(Parent, {
+      }), {
         global: {
-          plugins: [createPinia(), PiniaColada],
+          plugins: [createPinia(), PiniaColada, router],
         },
       })
 
-      await vi.waitFor(() => expect(injectedContext?.pending.value).toBe(false))
+      await vi.waitFor(() => expect(contexts[0]?.pending.value).toBe(false))
 
-      expect(injectedContext?.recrutementUuid).toBe(RECRUTEMENT_UUID)
-      expect(injectedContext?.totalCount.value).toBe(3)
+      expect(contexts[0]?.filters).toBe(contexts[1]?.filters)
+      expect(contexts[0]?.recrutementUuid.value).toBe(RECRUTEMENT_UUID)
+      expect(contexts[1]?.totalCount.value).toBe(3)
+    })
+  })
+
+  describe('route changes', () => {
+    it('resyncs etapes when the kanban data changes', async () => {
+      let queryCache!: ReturnType<typeof useQueryCache>
+      const { context } = await mountCandidatures(() => {
+        queryCache = useQueryCache()
+      })
+
+      await vi.waitFor(() => expect(context.pending.value).toBe(false))
+      expect(context.totalCount.value).toBe(3)
+
+      queryCache.setQueryData(
+        CANDIDATURES_QUERY_KEYS.kanban(ORGANISME_UUID, RECRUTEMENT_UUID),
+        { ...MOCK_KANBAN, etapes: [MOCK_KANBAN.etapes[0]!] },
+      )
+
+      await vi.waitFor(() => expect(context.totalCount.value).toBe(2))
+      expect(context.etapes.value).toHaveLength(1)
+    })
+
+    it('resets filters when navigating to another recrutement', async () => {
+      const { context, router } = await mountCandidatures()
+
+      await vi.waitFor(() => expect(context.pending.value).toBe(false))
+
+      context.filters.search.value = 'alice'
+      context.filters.flushSearch()
+      context.filters.draft.etapes = ['cccccccc-0001-0001-0001-000000000001']
+      context.filters.apply()
+      expect(context.filters.activeFiltersCount.value).toBe(1)
+
+      await router.push('/mes-recrutements/aaaaaaaa-0001-0001-0001-000000000002')
+
+      await vi.waitFor(() => {
+        expect(context.filters.search.value).toBe('')
+        expect(context.filters.activeFiltersCount.value).toBe(0)
+      })
+      expect(context.recrutementUuid.value).toBe('aaaaaaaa-0001-0001-0001-000000000002')
     })
   })
 })

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
@@ -6,9 +6,9 @@ import type {
   RecrutementDetailKanban,
 } from '../types'
 import type { CandidaturesFiltersContext } from './useCandidaturesFilters'
-import { computed, inject, provide, ref, shallowRef } from 'vue'
-import { useAsyncState } from '@/composables/async/useAsyncState'
-import { getCandidatureListe, getRecrutementKanban } from '../api'
+import { useQuery } from '@pinia/colada'
+import { computed, inject, provide, shallowRef, watch } from 'vue'
+import { candidatureListeQuery, recrutementKanbanQuery } from '../queries'
 import { useCandidaturesFilters } from './useCandidaturesFilters'
 
 export interface MoveCandidatureParams {
@@ -35,27 +35,25 @@ export function provideCandidatures(
   organismeUuid: string,
   recrutementUuid: string,
 ): CandidaturesContext {
-  const { pending, error, run } = useAsyncState(true)
-  const recrutementDetail = ref<RecrutementDetailKanban | null>(null)
-  const candidatureListe = ref<PaginatedCandidatureListeList>()
+  const kanban = useQuery(recrutementKanbanQuery({ organismeUuid, recrutementUuid }))
+  const liste = useQuery(candidatureListeQuery({ organismeUuid, recrutementUuid }))
+
+  const recrutementDetail = computed<RecrutementDetailKanban | null>(
+    () => kanban.data.value ?? null,
+  )
+  const candidatureListe = liste.data as Ref<PaginatedCandidatureListeList | undefined>
   const etapes = shallowRef<EtapeRecrutementDetailedCandidatures[]>([])
+
+  watch(kanban.data, (data) => {
+    etapes.value = data ? structuredClone(data.etapes) : []
+  }, { immediate: true })
+
+  const pending = computed(() => kanban.isPending.value || liste.isPending.value)
+  const error = computed<unknown>(() => kanban.error.value ?? liste.error.value)
 
   const totalCount = computed(() =>
     etapes.value.reduce((sum, etape) => sum + etape.candidatures.length, 0),
   )
-
-  async function load(): Promise<void> {
-    await run(async () => {
-      const [kanban, liste] = await Promise.all([
-        getRecrutementKanban(organismeUuid, recrutementUuid),
-        getCandidatureListe(organismeUuid, recrutementUuid),
-      ])
-
-      recrutementDetail.value = kanban
-      etapes.value = structuredClone(kanban.etapes)
-      candidatureListe.value = liste
-    })
-  }
 
   function moveCandidature(params: MoveCandidatureParams): void {
     const { sourceColumnId, targetColumnId, cardId } = params
@@ -95,8 +93,6 @@ export function provideCandidatures(
   }
 
   const filters = useCandidaturesFilters(etapes, candidatureListe)
-
-  void load()
 
   const context: CandidaturesContext = {
     recrutementUuid,

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
@@ -1,13 +1,12 @@
-import type { InjectionKey, Ref, ShallowRef } from 'vue'
 import type {
   Candidature,
   EtapeRecrutementDetailedCandidatures,
-  PaginatedCandidatureListeList,
   RecrutementDetailKanban,
 } from '../types'
-import type { CandidaturesFiltersContext } from './useCandidaturesFilters'
-import { useQuery, useQueryCache } from '@pinia/colada'
-import { computed, inject, provide, shallowRef, watch } from 'vue'
+import { defineQuery, useQuery, useQueryCache } from '@pinia/colada'
+import { computed, shallowRef, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import { peekRecrutementIntitule } from '@/features/recrutements/queries'
 import { candidatureListeQuery, recrutementKanbanQuery } from '../queries'
 import { useCandidaturesFilters } from './useCandidaturesFilters'
@@ -18,43 +17,47 @@ export interface MoveCandidatureParams {
   cardId: string
 }
 
-export interface CandidaturesContext {
-  recrutementUuid: string
-  recrutementDetail: Ref<RecrutementDetailKanban | null>
-  intitule: Ref<string | null>
-  candidatureListe: Ref<PaginatedCandidatureListeList | undefined>
-  etapes: ShallowRef<EtapeRecrutementDetailedCandidatures[]>
-  totalCount: Ref<number>
-  pending: Ref<boolean>
-  error: Ref<unknown>
-  moveCandidature: (params: MoveCandidatureParams) => void
-  filters: CandidaturesFiltersContext
-}
+export const useCandidatures = defineQuery(() => {
+  const route = useRoute()
+  const recrutementUuid = computed<string | null>(() => {
+    const param = route.params.recrutementUuid
+    return typeof param === 'string' && param !== '' ? param : null
+  })
 
-const CANDIDATURES_KEY: InjectionKey<CandidaturesContext> = Symbol('candidatures')
+  const kanban = useQuery(() => ({
+    ...recrutementKanbanQuery({
+      organismeUuid: TEMP_ORGANISME_UUID,
+      recrutementUuid: recrutementUuid.value ?? '',
+    }),
+    enabled: recrutementUuid.value !== null,
+  }))
 
-export function provideCandidatures(
-  organismeUuid: string,
-  recrutementUuid: string,
-): CandidaturesContext {
-  const kanban = useQuery(recrutementKanbanQuery({ organismeUuid, recrutementUuid }))
-  const liste = useQuery(candidatureListeQuery({ organismeUuid, recrutementUuid }))
+  const liste = useQuery(() => ({
+    ...candidatureListeQuery({
+      organismeUuid: TEMP_ORGANISME_UUID,
+      recrutementUuid: recrutementUuid.value ?? '',
+    }),
+    enabled: recrutementUuid.value !== null,
+  }))
 
   const recrutementDetail = computed<RecrutementDetailKanban | null>(
     () => kanban.data.value ?? null,
   )
-  const candidatureListe = liste.data as Ref<PaginatedCandidatureListeList | undefined>
+  const candidatureListe = liste.data
+
+  const queryCache = useQueryCache()
+  const intitule = computed<string | null>(() =>
+    recrutementDetail.value?.intitule
+    ?? (recrutementUuid.value
+      ? peekRecrutementIntitule(queryCache, TEMP_ORGANISME_UUID, recrutementUuid.value)
+      : null),
+  )
+
   const etapes = shallowRef<EtapeRecrutementDetailedCandidatures[]>([])
 
   watch(kanban.data, (data) => {
     etapes.value = data ? structuredClone(data.etapes) : []
   }, { immediate: true })
-
-  const queryCache = useQueryCache()
-  const intitule = computed<string | null>(() =>
-    recrutementDetail.value?.intitule
-    ?? peekRecrutementIntitule(queryCache, organismeUuid, recrutementUuid),
-  )
 
   const pending = computed(() => kanban.isPending.value || liste.isPending.value)
   const error = computed<unknown>(() => kanban.error.value ?? liste.error.value)
@@ -102,7 +105,11 @@ export function provideCandidatures(
 
   const filters = useCandidaturesFilters(etapes, candidatureListe)
 
-  const context: CandidaturesContext = {
+  watch(recrutementUuid, () => {
+    filters.reset()
+  })
+
+  return {
     recrutementUuid,
     recrutementDetail,
     intitule,
@@ -114,16 +121,4 @@ export function provideCandidatures(
     moveCandidature,
     filters,
   }
-
-  provide(CANDIDATURES_KEY, context)
-
-  return context
-}
-
-export function useCandidatures(): CandidaturesContext {
-  const context = inject(CANDIDATURES_KEY)
-  if (!context) {
-    throw new Error('useCandidatures must be used within CandidaturesView')
-  }
-  return context
-}
+})

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.ts
@@ -6,8 +6,9 @@ import type {
   RecrutementDetailKanban,
 } from '../types'
 import type { CandidaturesFiltersContext } from './useCandidaturesFilters'
-import { useQuery } from '@pinia/colada'
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { computed, inject, provide, shallowRef, watch } from 'vue'
+import { peekRecrutementIntitule } from '@/features/recrutements/queries'
 import { candidatureListeQuery, recrutementKanbanQuery } from '../queries'
 import { useCandidaturesFilters } from './useCandidaturesFilters'
 
@@ -20,6 +21,7 @@ export interface MoveCandidatureParams {
 export interface CandidaturesContext {
   recrutementUuid: string
   recrutementDetail: Ref<RecrutementDetailKanban | null>
+  intitule: Ref<string | null>
   candidatureListe: Ref<PaginatedCandidatureListeList | undefined>
   etapes: ShallowRef<EtapeRecrutementDetailedCandidatures[]>
   totalCount: Ref<number>
@@ -47,6 +49,12 @@ export function provideCandidatures(
   watch(kanban.data, (data) => {
     etapes.value = data ? structuredClone(data.etapes) : []
   }, { immediate: true })
+
+  const queryCache = useQueryCache()
+  const intitule = computed<string | null>(() =>
+    recrutementDetail.value?.intitule
+    ?? peekRecrutementIntitule(queryCache, organismeUuid, recrutementUuid),
+  )
 
   const pending = computed(() => kanban.isPending.value || liste.isPending.value)
   const error = computed<unknown>(() => kanban.error.value ?? liste.error.value)
@@ -97,6 +105,7 @@ export function provideCandidatures(
   const context: CandidaturesContext = {
     recrutementUuid,
     recrutementDetail,
+    intitule,
     candidatureListe,
     etapes,
     totalCount,

--- a/src/web/presentation/frontend/src/features/candidatures/queries.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/queries.ts
@@ -1,0 +1,31 @@
+import { defineQueryOptions } from '@pinia/colada'
+import { getCandidatureListe, getRecrutementKanban } from './api'
+
+export const CANDIDATURES_QUERY_KEYS = {
+  root: ['candidatures'] as const,
+  recrutement: (organismeUuid: string, recrutementUuid: string) =>
+    [...CANDIDATURES_QUERY_KEYS.root, organismeUuid, recrutementUuid] as const,
+  kanban: (organismeUuid: string, recrutementUuid: string) =>
+    [...CANDIDATURES_QUERY_KEYS.recrutement(organismeUuid, recrutementUuid), 'kanban'] as const,
+  liste: (organismeUuid: string, recrutementUuid: string) =>
+    [...CANDIDATURES_QUERY_KEYS.recrutement(organismeUuid, recrutementUuid), 'liste'] as const,
+}
+
+export interface CandidaturesQueryParams {
+  organismeUuid: string
+  recrutementUuid: string
+}
+
+export const recrutementKanbanQuery = defineQueryOptions(
+  ({ organismeUuid, recrutementUuid }: CandidaturesQueryParams) => ({
+    key: CANDIDATURES_QUERY_KEYS.kanban(organismeUuid, recrutementUuid),
+    query: () => getRecrutementKanban(organismeUuid, recrutementUuid),
+  }),
+)
+
+export const candidatureListeQuery = defineQueryOptions(
+  ({ organismeUuid, recrutementUuid }: CandidaturesQueryParams) => ({
+    key: CANDIDATURES_QUERY_KEYS.liste(organismeUuid, recrutementUuid),
+    query: () => getCandidatureListe(organismeUuid, recrutementUuid),
+  }),
+)

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
@@ -18,7 +18,7 @@ const { filteredEtapes } = filters
 
 const showSkeleton = useMinimumPending(pending)
 
-const boardId = computed(() => `kanban-${recrutementUuid}`)
+const boardId = computed(() => `kanban-${recrutementUuid.value}`)
 
 function handleMove(event: KanbanDropEvent) {
   moveCandidature({

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -25,6 +25,7 @@ const recrutementUuid = route.params.recrutementUuid as string
 
 const {
   recrutementDetail,
+  intitule,
   pending,
   error,
   filters,
@@ -56,12 +57,12 @@ function applyFilters() {
   closeFiltersDrawer()
 }
 
-const title = computed(() => recrutementDetail.value?.intitule ?? 'Candidatures')
+const title = computed(() => intitule.value ?? 'Candidatures')
 
 const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
   { label: 'Accueil', to: { name: 'home' } },
   { label: 'Mes recrutements', to: { name: 'mes-recrutements' } },
-  ...(recrutementDetail.value ? [{ label: recrutementDetail.value.intitule }] : []),
+  ...(intitule.value ? [{ label: intitule.value }] : []),
 ])
 
 const metaItems = computed(() =>
@@ -96,7 +97,7 @@ const activeTab = ref<'candidatures' | 'activites-et-taches'>('candidatures')
     >
       <template #title>
         <CspSkeleton
-          v-if="showSkeleton"
+          v-if="showSkeleton && !intitule"
           width="20rem"
           height="2rem"
         />

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -14,10 +14,9 @@ import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContai
 import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
 import { useDisclosure } from '@/composables/ui/useDisclosure'
-import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import CandidaturesFiltersDrawer from '../components/CandidaturesFiltersDrawer.vue'
 import CandidaturesViewSwitch from '../components/CandidaturesViewSwitch.vue'
-import { provideCandidatures } from '../composables/useCandidatures'
+import { useCandidatures } from '../composables/useCandidatures'
 import { formatRecrutementMeta } from '../format'
 
 const route = useRoute()
@@ -29,7 +28,7 @@ const {
   pending,
   error,
   filters,
-} = provideCandidatures(TEMP_ORGANISME_UUID, recrutementUuid)
+} = useCandidatures()
 
 const showSkeleton = useMinimumPending(pending)
 

--- a/src/web/presentation/frontend/src/features/recrutements/composables/useRecrutements.test.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/composables/useRecrutements.test.ts
@@ -1,4 +1,9 @@
+import type { RecrutementKey } from '../types'
+import { PiniaColada } from '@pinia/colada'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
 import { getRecrutementsActifs, getRecrutementsArchives } from '../api'
 import { RECRUTEMENTS_ACTIFS, RECRUTEMENTS_ARCHIVES } from '../mock'
 import { useRecrutements } from './useRecrutements'
@@ -14,6 +19,23 @@ function buildPaginatedResponse<T>(results: T[]) {
   return { count: results.length, next: null, previous: null, results }
 }
 
+function mountUseRecrutements(activeKey: ReturnType<typeof ref<RecrutementKey>>) {
+  let result!: ReturnType<typeof useRecrutements>
+
+  mount(defineComponent({
+    setup() {
+      result = useRecrutements(ORGANISME_UUID, () => activeKey.value as RecrutementKey)
+      return () => h('div')
+    },
+  }), {
+    global: {
+      plugins: [createPinia(), PiniaColada],
+    },
+  })
+
+  return result
+}
+
 describe('useRecrutements', () => {
   beforeEach(() => {
     vi.mocked(getRecrutementsActifs).mockReset()
@@ -22,37 +44,34 @@ describe('useRecrutements', () => {
     vi.mocked(getRecrutementsArchives).mockResolvedValue(buildPaginatedResponse(RECRUTEMENTS_ARCHIVES))
   })
 
-  it('loads actifs from the api', async () => {
-    const { data, load, pending } = useRecrutements(ORGANISME_UUID)
-    await load()
+  it('loads actifs when the actifs tab is active', async () => {
+    const { data, pending } = mountUseRecrutements(ref<RecrutementKey>('actifs'))
+
+    await vi.waitFor(() => expect(pending.value).toBe(false))
 
     expect(getRecrutementsActifs).toHaveBeenCalledWith(ORGANISME_UUID)
     expect(data.actifs).toEqual(RECRUTEMENTS_ACTIFS)
-    expect(pending.value).toBe(false)
   })
 
-  it('loads archives on demand', async () => {
-    const { data, load } = useRecrutements(ORGANISME_UUID)
-    await load('archives')
+  it('does not load archives until the tab becomes active', async () => {
+    const activeKey = ref<RecrutementKey>('actifs')
+    const { data, pending } = mountUseRecrutements(activeKey)
 
+    await vi.waitFor(() => expect(pending.value).toBe(false))
+    expect(getRecrutementsArchives).not.toHaveBeenCalled()
+
+    activeKey.value = 'archives'
+
+    await vi.waitFor(() => expect(data.archives).toEqual(RECRUTEMENTS_ARCHIVES))
     expect(getRecrutementsArchives).toHaveBeenCalledWith(ORGANISME_UUID)
-    expect(data.archives).toEqual(RECRUTEMENTS_ARCHIVES)
   })
 
-  it('tracks loaded state per tab with has()', async () => {
-    const { has, load } = useRecrutements(ORGANISME_UUID)
-    expect(has('actifs')).toBe(false)
-
-    await load('actifs')
-    expect(has('actifs')).toBe(true)
-    expect(has('archives')).toBe(false)
-  })
-
-  it('stores the error on api failure', async () => {
+  it('exposes the error of the active tab on api failure', async () => {
     vi.mocked(getRecrutementsActifs).mockRejectedValue(new Error('emulated API error'))
 
-    const { error, data, load } = useRecrutements(ORGANISME_UUID)
-    await load()
+    const { error, data, pending } = mountUseRecrutements(ref<RecrutementKey>('actifs'))
+
+    await vi.waitFor(() => expect(pending.value).toBe(false))
 
     expect(error.value).toBeInstanceOf(Error)
     expect(data.actifs).toEqual([])

--- a/src/web/presentation/frontend/src/features/recrutements/composables/useRecrutements.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/composables/useRecrutements.ts
@@ -1,42 +1,36 @@
-import type {
-  RecrutementKey,
-  RecrutementsActifs,
-  RecrutementsArchives,
-} from '../types'
-import { reactive } from 'vue'
-import { useAsyncState } from '@/composables/async/useAsyncState'
-import { getRecrutementsActifs, getRecrutementsArchives } from '../api'
+import type { MaybeRefOrGetter } from 'vue'
+import type { RecrutementKey } from '../types'
+import { useQuery } from '@pinia/colada'
+import { computed, reactive, toValue } from 'vue'
+import { recrutementsActifsQuery, recrutementsArchivesQuery } from '../queries'
 
-export function useRecrutements(organismeUuid: string) {
-  const { pending, error, run } = useAsyncState(true)
+export function useRecrutements(
+  organismeUuid: string,
+  activeKey: MaybeRefOrGetter<RecrutementKey>,
+) {
+  const actifs = useQuery(() => ({
+    ...recrutementsActifsQuery({ organismeUuid }),
+    enabled: toValue(activeKey) === 'actifs',
+  }))
+
+  const archives = useQuery(() => ({
+    ...recrutementsArchivesQuery({ organismeUuid }),
+    enabled: toValue(activeKey) === 'archives',
+  }))
+
+  const active = computed(() => (toValue(activeKey) === 'actifs' ? actifs : archives))
 
   const data = reactive({
-    actifs: [] as RecrutementsActifs[],
-    archives: [] as RecrutementsArchives[],
+    actifs: computed(() => actifs.data.value?.results ?? []),
+    archives: computed(() => archives.data.value?.results ?? []),
   })
 
-  function has(key: RecrutementKey): boolean {
-    return data[key].length > 0
-  }
-
-  async function load(key: RecrutementKey = 'actifs'): Promise<void> {
-    await run(async () => {
-      if (key === 'actifs') {
-        const actifs = await getRecrutementsActifs(organismeUuid)
-        data.actifs = actifs.results as RecrutementsActifs[]
-      }
-      else {
-        const archives = await getRecrutementsArchives(organismeUuid)
-        data.archives = archives.results as RecrutementsArchives[]
-      }
-    })
-  }
+  const pending = computed(() => active.value.isPending.value)
+  const error = computed(() => active.value.error.value)
 
   return {
     pending,
     error,
     data,
-    load,
-    has,
   }
 }

--- a/src/web/presentation/frontend/src/features/recrutements/queries.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/queries.ts
@@ -1,3 +1,8 @@
+import type { useQueryCache } from '@pinia/colada'
+import type {
+  PaginatedRecrutementsActifsResponse,
+  PaginatedRecrutementsArchivesResponse,
+} from './types'
 import { defineQueryOptions } from '@pinia/colada'
 import { getRecrutementsActifs, getRecrutementsArchives } from './api'
 
@@ -22,3 +27,26 @@ export const recrutementsArchivesQuery = defineQueryOptions(
     query: () => getRecrutementsArchives(organismeUuid),
   }),
 )
+
+export function peekRecrutementIntitule(
+  queryCache: ReturnType<typeof useQueryCache>,
+  organismeUuid: string,
+  offerId: string,
+): string | null {
+  const lists = [
+    queryCache.getQueryData<PaginatedRecrutementsActifsResponse>(
+      RECRUTEMENTS_QUERY_KEYS.actifs(organismeUuid),
+    ),
+    queryCache.getQueryData<PaginatedRecrutementsArchivesResponse>(
+      RECRUTEMENTS_QUERY_KEYS.archives(organismeUuid),
+    ),
+  ]
+
+  for (const list of lists) {
+    const row = list?.results?.find(r => r.offer_id === offerId)
+    if (row) {
+      return row.intitule
+    }
+  }
+  return null
+}

--- a/src/web/presentation/frontend/src/features/recrutements/queries.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/queries.ts
@@ -1,0 +1,24 @@
+import { defineQueryOptions } from '@pinia/colada'
+import { getRecrutementsActifs, getRecrutementsArchives } from './api'
+
+export const RECRUTEMENTS_QUERY_KEYS = {
+  root: ['recrutements'] as const,
+  actifs: (organismeUuid: string) =>
+    [...RECRUTEMENTS_QUERY_KEYS.root, organismeUuid, 'actifs'] as const,
+  archives: (organismeUuid: string) =>
+    [...RECRUTEMENTS_QUERY_KEYS.root, organismeUuid, 'archives'] as const,
+}
+
+export const recrutementsActifsQuery = defineQueryOptions(
+  ({ organismeUuid }: { organismeUuid: string }) => ({
+    key: RECRUTEMENTS_QUERY_KEYS.actifs(organismeUuid),
+    query: () => getRecrutementsActifs(organismeUuid),
+  }),
+)
+
+export const recrutementsArchivesQuery = defineQueryOptions(
+  ({ organismeUuid }: { organismeUuid: string }) => ({
+    key: RECRUTEMENTS_QUERY_KEYS.archives(organismeUuid),
+    query: () => getRecrutementsArchives(organismeUuid),
+  }),
+)

--- a/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
+++ b/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
@@ -4,7 +4,7 @@ import type {
 } from '../types'
 import type { CspBreadcrumbItem } from '@/components/base/CspBreadcrumb/CspBreadcrumb.vue'
 import type { CspTabItem } from '@/components/base/CspTabs/CspTabs.vue'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import CspButton from '@/components/base/CspButton/CspButton.vue'
 import CspDataTable from '@/components/base/CspDataTable/CspDataTable.vue'
@@ -40,17 +40,7 @@ const {
   pending: recrutementsPending,
   error: recrutementsError,
   data: recrutementsData,
-  load: loadRecrutements,
-  has: hasRecrutements,
-} = useRecrutements(TEMP_ORGANISME_UUID)
-
-onMounted(() => {
-  watch(activeTab, (newTab) => {
-    if (!hasRecrutements(newTab)) {
-      void loadRecrutements(newTab)
-    }
-  }, { immediate: true })
-})
+} = useRecrutements(TEMP_ORGANISME_UUID, activeTab)
 
 const showSkeleton = useMinimumPending(recrutementsPending)
 


### PR DESCRIPTION
## 📝 Description
🎸 Remplace le contexte provide/inject des candidatures : deux `useQuery` sur la même clé partagent déjà leur cache. `useCandidatures` devient un [`defineQuery`](https://pinia-colada.esm.dev/advanced/reusable-queries.html) partagé appelable depuis n'importe quelle vue.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
