### PR TITLE
🐛(ats-presentation) fix app mount crash on production build

### DIFF
--- a/src/web/presentation/frontend/src/app/App.vue
+++ b/src/web/presentation/frontend/src/app/App.vue
@@ -16,7 +16,6 @@ import AppShell from '@/components/layout/AppShell.vue'
         </ErrorBoundary>
       </AppShell>
     </CspToaster>
+    <PiniaColadaDevtools />
   </div>
-
-  <PiniaColadaDevtools />
 </template>


### PR DESCRIPTION
## 📝 Description
🎸 App.vue avait deux nœuds racine (le div #ats-app et le composant PiniaColadaDevtools récemment ajouté), causant un crash du mount en prod a cause d'un nextSibling null (PiniaColadaDevtools n'est pas monté en prod mais est cherché).

Le bug est invisible en dev car la django toolbar injecte des éléments après #ats-app et fournit un nextSibling.

Réparé en [déplaçant PiniaColadaDevtools](https://pinia-colada.esm.dev/guide/installation.html#Keeping-devtools-in-production) à l'intérieur d'une div racine unique.

Pour reporduire et vérifier avec un build de prod servi en local, lancer depuis depuis src/web :
```bash
(cd presentation/frontend && corepack pnpm exec vite build --mode production) && \
  DJANGO_SETTINGS_MODULE=config.settings.base \
  direnv exec . python manage.py collectstatic --noinput --clear && \
  DJANGO_SETTINGS_MODULE=config.settings.base \
  direnv exec . env WEB_ALLOWED_HOSTS=localhost,127.0.0.1 \
  python manage.py runserver 8001 --noreload
```

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
