### PR TITLE
✨(recruteur-rbac) Mise en place du RBAC sur les organismes recruteurs

### DIFF
--- a/src/web/application/recruteur/usecases/get_organisme_recruteur.py
+++ b/src/web/application/recruteur/usecases/get_organisme_recruteur.py
@@ -17,6 +17,7 @@ from domain.recruteur.value_objects.organisme_action import OrganismeAction
 class GetOrganismeRecruteurQuery:
     organisme_id: UUID
     utilisateur_id: UUID
+    est_staff: bool = False
 
 
 class GetOrganismeRecruteurUsecase(
@@ -35,5 +36,6 @@ class GetOrganismeRecruteurUsecase(
             action=OrganismeAction.GET_ORGANISME,
             organisme_id=command.organisme_id,
             agent_id=command.utilisateur_id,
+            est_staff=command.est_staff,
         )
         return self.organisme_repository.get_by_id(command.organisme_id)

--- a/src/web/application/recruteur/usecases/get_organisme_recruteur.py
+++ b/src/web/application/recruteur/usecases/get_organisme_recruteur.py
@@ -7,18 +7,33 @@ from domain.recruteur.entities.organisme_recruteur import OrganismeRecruteur
 from domain.recruteur.repositories.organisme_repository_interface import (
     IOrganismeRecruteurRepository,
 )
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @dataclass
 class GetOrganismeRecruteurQuery:
     organisme_id: UUID
+    utilisateur_id: UUID
 
 
 class GetOrganismeRecruteurUsecase(
     IUseCase[GetOrganismeRecruteurQuery, OrganismeRecruteur]
 ):
-    def __init__(self, organisme_repository: IOrganismeRecruteurRepository):
+    def __init__(
+        self,
+        organisme_repository: IOrganismeRecruteurRepository,
+        organisme_permission_service: OrganismePermissionService,
+    ):
         self.organisme_repository = organisme_repository
+        self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: GetOrganismeRecruteurQuery) -> OrganismeRecruteur:
+        self.organisme_permission_service.est_autorise(
+            action=OrganismeAction.GET_ORGANISME,
+            organisme_id=command.organisme_id,
+            agent_id=command.utilisateur_id,
+        )
         return self.organisme_repository.get_by_id(command.organisme_id)

--- a/src/web/application/recruteur/usecases/initialize_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/initialize_organisme_steps.py
@@ -17,6 +17,7 @@ from domain.recruteur.value_objects.organisme_action import OrganismeAction
 class InitializeOrganismeStepsCommand:
     organisme_id: UUID
     utilisateur_id: UUID
+    est_staff: bool = False
 
 
 class InitializeOrganismeStepsUsecase(
@@ -35,6 +36,7 @@ class InitializeOrganismeStepsUsecase(
             action=OrganismeAction.INITIALIZE_ORGANISME_STEPS,
             organisme_id=command.organisme_id,
             agent_id=command.utilisateur_id,
+            est_staff=command.est_staff,
         )
         organisme = self.organisme_repository.get_by_id(command.organisme_id)
         organisme.initialiser_etapes()

--- a/src/web/application/recruteur/usecases/initialize_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/initialize_organisme_steps.py
@@ -7,20 +7,35 @@ from domain.recruteur.entities.organisme_recruteur import OrganismeRecruteur
 from domain.recruteur.repositories.organisme_repository_interface import (
     IOrganismeRecruteurRepository,
 )
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @dataclass
 class InitializeOrganismeStepsCommand:
     organisme_id: UUID
+    utilisateur_id: UUID
 
 
 class InitializeOrganismeStepsUsecase(
     IUseCase[InitializeOrganismeStepsCommand, OrganismeRecruteur]
 ):
-    def __init__(self, organisme_repository: IOrganismeRecruteurRepository):
+    def __init__(
+        self,
+        organisme_repository: IOrganismeRecruteurRepository,
+        organisme_permission_service: OrganismePermissionService,
+    ):
         self.organisme_repository = organisme_repository
+        self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: InitializeOrganismeStepsCommand) -> OrganismeRecruteur:
+        self.organisme_permission_service.est_autorise(
+            action=OrganismeAction.INITIALIZE_ORGANISME_STEPS,
+            organisme_id=command.organisme_id,
+            agent_id=command.utilisateur_id,
+        )
         organisme = self.organisme_repository.get_by_id(command.organisme_id)
         organisme.initialiser_etapes()
         self.organisme_repository.save(organisme)

--- a/src/web/application/recruteur/usecases/update_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/update_organisme_steps.py
@@ -33,6 +33,7 @@ class UpdateOrganismeStepsCommand:
     organisme_id: UUID
     utilisateur_id: UUID
     etapes: list[EtapeData]
+    est_staff: bool = False
 
 
 class UpdateOrganismeStepsUsecase(
@@ -55,6 +56,7 @@ class UpdateOrganismeStepsUsecase(
             action=OrganismeAction.UPDATE_ORGANISME_STEPS,
             organisme_id=command.organisme_id,
             agent_id=command.utilisateur_id,
+            est_staff=command.est_staff,
         )
         # guard, raise OrganismeInexistant if not found
         self.organisme_repository.get_by_id(command.organisme_id)

--- a/src/web/application/recruteur/usecases/update_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/update_organisme_steps.py
@@ -12,9 +12,13 @@ from domain.recruteur.entities.organisme_recruteur import OrganismeRecruteur
 from domain.recruteur.repositories.organisme_repository_interface import (
     IOrganismeRecruteurRepository,
 )
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @dataclass
@@ -39,14 +43,20 @@ class UpdateOrganismeStepsUsecase(
         organisme_repository: IOrganismeRepository,
         organisme_recruteur_repository: IOrganismeRecruteurRepository,
         audit_log_writer: AuditLogWriter,
+        organisme_permission_service: OrganismePermissionService,
     ):
         self.organisme_repository = organisme_repository
         self.organisme_recruteur_repository = organisme_recruteur_repository
         self.audit_log_writer = audit_log_writer
+        self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: UpdateOrganismeStepsCommand) -> OrganismeRecruteur:
+        self.organisme_permission_service.est_autorise(
+            action=OrganismeAction.UPDATE_ORGANISME_STEPS,
+            organisme_id=command.organisme_id,
+            agent_id=command.utilisateur_id,
+        )
         # guard, raise OrganismeInexistant if not found
-        # todo: rbac should check organisme id
         self.organisme_repository.get_by_id(command.organisme_id)
         organisme_recruteur = self.organisme_recruteur_repository.get_by_id(
             command.organisme_id

--- a/src/web/domain/recruteur/errors/organisme_permission_errors.py
+++ b/src/web/domain/recruteur/errors/organisme_permission_errors.py
@@ -1,0 +1,13 @@
+from uuid import UUID
+
+from ddd.domain_errors import DomainError
+
+
+class OrganismePermissionError(DomainError):
+    pass
+
+
+class AccesOrganismeRefuse(OrganismePermissionError):
+    def __init__(self, organisme_id: UUID):
+        super().__init__(f"Rôle non autorisé sur l'organisme {organisme_id}")
+        self.organisme_id = organisme_id

--- a/src/web/domain/recruteur/repositories/organisme_agent_repository_interface.py
+++ b/src/web/domain/recruteur/repositories/organisme_agent_repository_interface.py
@@ -1,0 +1,10 @@
+from typing import Protocol
+from uuid import UUID
+
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+
+
+class IOrganismeAgentRepository(Protocol):
+    def get_role(
+        self, *, organisme_id: UUID, agent_id: UUID
+    ) -> AgentOrganismeRole | None: ...

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -1,0 +1,34 @@
+from uuid import UUID
+
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.repositories.organisme_agent_repository_interface import (
+    IOrganismeAgentRepository,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+
+_ROLES_REQUIS: dict[OrganismeAction, AgentOrganismeRole] = {
+    OrganismeAction.GET_ORGANISME: AgentOrganismeRole.RESPONSABLE,
+    OrganismeAction.INITIALIZE_ORGANISME_STEPS: AgentOrganismeRole.RESPONSABLE,
+    OrganismeAction.UPDATE_ORGANISME_STEPS: AgentOrganismeRole.RESPONSABLE,
+}
+
+
+class OrganismePermissionService:
+    def __init__(self, organisme_agent_repository: IOrganismeAgentRepository) -> None:
+        self._organisme_agent_repository = organisme_agent_repository
+
+    def est_autorise(
+        self,
+        *,
+        action: OrganismeAction,
+        organisme_id: UUID,
+        agent_id: UUID,
+        est_staff: bool,
+    ) -> None:
+        role_requis = _ROLES_REQUIS[action]
+        role = self._organisme_agent_repository.get_role(
+            organisme_id=organisme_id, agent_id=agent_id
+        )
+        if role != role_requis:
+            raise AccesOrganismeRefuse(organisme_id)

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -26,6 +26,8 @@ class OrganismePermissionService:
         agent_id: UUID,
         est_staff: bool,
     ) -> None:
+        if est_staff:
+            return
         role_requis = _ROLES_REQUIS[action]
         role = self._organisme_agent_repository.get_role(
             organisme_id=organisme_id, agent_id=agent_id

--- a/src/web/domain/recruteur/value_objects/organisme_action.py
+++ b/src/web/domain/recruteur/value_objects/organisme_action.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class OrganismeAction(Enum):
+    GET_ORGANISME = "get_organisme"
+    INITIALIZE_ORGANISME_STEPS = "initialize_organisme_steps"
+    UPDATE_ORGANISME_STEPS = "update_organisme_steps"

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -19,6 +19,9 @@ from application.recruteur.usecases.update_organisme_steps import (
     UpdateOrganismeStepsUsecase,
 )
 from domain.commons.services.audit_log_writer import AuditLogWriter
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
 from infrastructure.mappers.candidature_mapper import CandidatureMapper
 from infrastructure.repositories.candidate.postgres_candidature_repository import (
     PostgresCandidatureRepository,
@@ -37,6 +40,9 @@ from infrastructure.repositories.recruteur.postgres_note_query_service import (
 )
 from infrastructure.repositories.recruteur.postgres_note_repository import (
     PostgresNoteRepository,
+)
+from infrastructure.repositories.recruteur.postgres_organisme_agent_repository import (
+    PostgresOrganismeAgentRepository,
 )
 from infrastructure.repositories.recruteur.postgres_organisme_repository import (
     PostgresOrganismeRecruteurRepository,
@@ -59,6 +65,13 @@ class RecruteurContainer(containers.DeclarativeContainer):
     postgres_organisme_repository = providers.Singleton(PostgresOrganismeRepository)
     postgres_organisme_recruteur_repository = providers.Singleton(
         PostgresOrganismeRecruteurRepository
+    )
+    postgres_organisme_agent_repository = providers.Singleton(
+        PostgresOrganismeAgentRepository
+    )
+    organisme_permission_service = providers.Factory(
+        OrganismePermissionService,
+        organisme_agent_repository=postgres_organisme_agent_repository,
     )
     candidature_mapper = providers.Factory(CandidatureMapper)
     postgres_recrutement_query_service = providers.Singleton(
@@ -100,11 +113,13 @@ class RecruteurContainer(containers.DeclarativeContainer):
     get_organisme_recruteur_usecase = providers.Factory(
         GetOrganismeRecruteurUsecase,
         organisme_repository=postgres_organisme_recruteur_repository,
+        organisme_permission_service=organisme_permission_service,
     )
 
     initialize_organisme_steps_usecase = providers.Factory(
         InitializeOrganismeStepsUsecase,
         organisme_repository=postgres_organisme_recruteur_repository,
+        organisme_permission_service=organisme_permission_service,
     )
 
     update_organisme_steps_usecase = providers.Factory(
@@ -112,6 +127,7 @@ class RecruteurContainer(containers.DeclarativeContainer):
         organisme_repository=postgres_organisme_repository,
         organisme_recruteur_repository=postgres_organisme_recruteur_repository,
         audit_log_writer=audit_log_writer,
+        organisme_permission_service=organisme_permission_service,
     )
 
     lister_mes_recrutements_usecase = providers.Factory(

--- a/src/web/infrastructure/repositories/recruteur/postgres_organisme_agent_repository.py
+++ b/src/web/infrastructure/repositories/recruteur/postgres_organisme_agent_repository.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+
+from domain.recruteur.repositories.organisme_agent_repository_interface import (
+    IOrganismeAgentRepository,
+)
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from infrastructure.django_apps.recruteur.models.organisme import OrganismeAgentModel
+
+
+class PostgresOrganismeAgentRepository(IOrganismeAgentRepository):
+    def get_role(
+        self, *, organisme_id: UUID, agent_id: UUID
+    ) -> AgentOrganismeRole | None:
+        try:
+            liaison = OrganismeAgentModel.objects.get(
+                organisme_id=organisme_id,
+                agent_id=str(agent_id),  # type: ignore[misc]
+            )
+        except OrganismeAgentModel.DoesNotExist:
+            return None
+        return AgentOrganismeRole(liaison.role)

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -784,6 +784,14 @@ export interface operations {
                     "application/json": components["schemas"]["TokenError"];
                 };
             };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
             404: {
                 headers: {
                     [name: string]: unknown;
@@ -827,6 +835,14 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
                 };
             };
             404: {
@@ -888,6 +904,14 @@ export interface operations {
                     "application/json": components["schemas"]["TokenError"];
                 };
             };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
             404: {
                 headers: {
                     [name: string]: unknown;
@@ -931,6 +955,14 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
                 };
             };
             404: {

--- a/src/web/presentation/recruteur/views/organismes.py
+++ b/src/web/presentation/recruteur/views/organismes.py
@@ -63,7 +63,9 @@ class OrganismeView(APIView):
             usecase = self.container.get_organisme_recruteur_usecase()
             organisme = usecase.execute(
                 GetOrganismeRecruteurQuery(
-                    organisme_id=organisme_uuid, utilisateur_id=utilisateur_id
+                    organisme_id=organisme_uuid,
+                    utilisateur_id=utilisateur_id,
+                    est_staff=request.user.is_staff,
                 )
             )
             serializer = OrganismeSerializer(organisme)
@@ -118,7 +120,9 @@ class EtapesRecrutementOrganismeView(APIView):
             usecase = self.container.get_organisme_recruteur_usecase()
             organisme = usecase.execute(
                 GetOrganismeRecruteurQuery(
-                    organisme_id=organisme_uuid, utilisateur_id=utilisateur_id
+                    organisme_id=organisme_uuid,
+                    utilisateur_id=utilisateur_id,
+                    est_staff=request.user.is_staff,
                 )
             )
             data = EtapesMapper().from_domain(organisme)
@@ -154,7 +158,12 @@ class EtapesRecrutementOrganismeView(APIView):
             utilisateur_id = UUID(request.user.username)
             usecase = self.container.update_organisme_steps_usecase()
             organisme = usecase.execute(
-                UpdateOrganismeStepsCommand(organisme_uuid, utilisateur_id, etapes)
+                UpdateOrganismeStepsCommand(
+                    organisme_id=organisme_uuid,
+                    utilisateur_id=utilisateur_id,
+                    etapes=etapes,
+                    est_staff=request.user.is_staff,
+                )
             )
             data = EtapesMapper().from_domain(organisme)
             out_serializer = EtapeRecrutementSerializer(data, many=True)
@@ -199,7 +208,9 @@ class InitEtapesRecrutementOrganismeView(APIView):
             usecase = self.container.initialize_organisme_steps_usecase()
             organisme = usecase.execute(
                 InitializeOrganismeStepsCommand(
-                    organisme_id=organisme_uuid, utilisateur_id=utilisateur_id
+                    organisme_id=organisme_uuid,
+                    utilisateur_id=utilisateur_id,
+                    est_staff=request.user.is_staff,
                 )
             )
             data = EtapesMapper().from_domain(organisme)

--- a/src/web/presentation/recruteur/views/organismes.py
+++ b/src/web/presentation/recruteur/views/organismes.py
@@ -22,6 +22,7 @@ from domain.recruteur.errors.erreur_recrutement import (
     ConfigurationEtapesInvalide,
     ErreurRecruteur,
 )
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
@@ -43,6 +44,7 @@ from presentation.recruteur.serializers import (
     responses={
         200: OrganismeSerializer,
         401: TokenErrorSerializer,
+        403: GenericErrorSerializer,
         404: GenericErrorSerializer,
         500: GenericErrorSerializer,
     },
@@ -57,12 +59,17 @@ class OrganismeView(APIView):
 
     def get(self, request: Request, organisme_uuid: UUID) -> Response:
         try:
+            utilisateur_id = UUID(request.user.username)
             usecase = self.container.get_organisme_recruteur_usecase()
             organisme = usecase.execute(
-                GetOrganismeRecruteurQuery(organisme_id=organisme_uuid)
+                GetOrganismeRecruteurQuery(
+                    organisme_id=organisme_uuid, utilisateur_id=utilisateur_id
+                )
             )
             serializer = OrganismeSerializer(organisme)
             return Response(serializer.data)
+        except AccesOrganismeRefuse:
+            return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except (ErreurRecruteur, OrganismeNexistePas):
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except Exception:
@@ -79,6 +86,7 @@ class OrganismeView(APIView):
         responses={
             200: EtapeRecrutementSerializer(many=True),
             401: TokenErrorSerializer,
+            403: GenericErrorSerializer,
             404: GenericErrorSerializer,
             500: GenericErrorSerializer,
         },
@@ -91,6 +99,7 @@ class OrganismeView(APIView):
             200: EtapeRecrutementSerializer(many=True),
             400: GenericErrorSerializer,
             401: TokenErrorSerializer,
+            403: GenericErrorSerializer,
             404: GenericErrorSerializer,
             500: GenericErrorSerializer,
         },
@@ -105,13 +114,18 @@ class EtapesRecrutementOrganismeView(APIView):
 
     def get(self, request: Request, organisme_uuid: UUID) -> Response:
         try:
+            utilisateur_id = UUID(request.user.username)
             usecase = self.container.get_organisme_recruteur_usecase()
             organisme = usecase.execute(
-                GetOrganismeRecruteurQuery(organisme_id=organisme_uuid)
+                GetOrganismeRecruteurQuery(
+                    organisme_id=organisme_uuid, utilisateur_id=utilisateur_id
+                )
             )
             data = EtapesMapper().from_domain(organisme)
             serializer = EtapeRecrutementSerializer(data, many=True)
             return Response(serializer.data)
+        except AccesOrganismeRefuse:
+            return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except OrganismeNexistePas:
             return Response(
                 {"organisme_uuid": "Not found."}, status=status.HTTP_404_NOT_FOUND
@@ -147,6 +161,8 @@ class EtapesRecrutementOrganismeView(APIView):
             return Response(out_serializer.data)
         except ConfigurationEtapesInvalide as e:
             return Response({"error": e.raison}, status=status.HTTP_400_BAD_REQUEST)
+        except AccesOrganismeRefuse:
+            return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except OrganismeNexistePas:
             return Response(
                 {"organisme_uuid": "Not found."}, status=status.HTTP_404_NOT_FOUND
@@ -165,6 +181,7 @@ class EtapesRecrutementOrganismeView(APIView):
     responses={
         201: EtapeRecrutementSerializer(many=True),
         401: TokenErrorSerializer,
+        403: GenericErrorSerializer,
         404: GenericErrorSerializer,
         500: GenericErrorSerializer,
     },
@@ -178,13 +195,18 @@ class InitEtapesRecrutementOrganismeView(APIView):
 
     def post(self, request: Request, organisme_uuid: UUID) -> Response:
         try:
+            utilisateur_id = UUID(request.user.username)
             usecase = self.container.initialize_organisme_steps_usecase()
             organisme = usecase.execute(
-                InitializeOrganismeStepsCommand(organisme_id=organisme_uuid)
+                InitializeOrganismeStepsCommand(
+                    organisme_id=organisme_uuid, utilisateur_id=utilisateur_id
+                )
             )
             data = EtapesMapper().from_domain(organisme)
             serializer = EtapeRecrutementSerializer(data, many=True)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except AccesOrganismeRefuse:
+            return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except (ErreurRecruteur, OrganismeNexistePas):
             return Response(
                 {"organisme_uuid": "Not found."}, status=status.HTTP_404_NOT_FOUND

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -227,6 +227,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
         '404':
           content:
             application/json:
@@ -269,6 +275,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
           description: ''
         '404':
           content:
@@ -336,6 +348,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
         '404':
           content:
             application/json:
@@ -378,6 +396,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
           description: ''
         '404':
           content:

--- a/src/web/tests/application/recruteur/test_organisme_steps.py
+++ b/src/web/tests/application/recruteur/test_organisme_steps.py
@@ -1,11 +1,17 @@
 from uuid import uuid4
 
+import pytest
+
+from application.recruteur.usecases.get_organisme_recruteur import (
+    GetOrganismeRecruteurQuery,
+)
 from application.recruteur.usecases.initialize_organisme_steps import (
     InitializeOrganismeStepsCommand,
 )
 from application.recruteur.usecases.update_organisme_steps import (
     UpdateOrganismeStepsCommand,
 )
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from infrastructure.factories.recruteur.etapes_recrutement_factory import (
     EtapeRecrutementFactory,
 )
@@ -19,7 +25,9 @@ def test_get_organisme_steps(get_organisme_recruteur_usecase):
     get_organisme_recruteur_usecase.organisme_repository.save(organisme_before)
 
     organisme = get_organisme_recruteur_usecase.execute(
-        command=InitializeOrganismeStepsCommand(organisme_id=organisme_before.entity_id)
+        command=InitializeOrganismeStepsCommand(
+            organisme_id=organisme_before.entity_id, utilisateur_id=uuid4()
+        )
     )
 
     events = organisme.collect_events()
@@ -32,7 +40,9 @@ def test_initialize_organisme_steps(initialize_organisme_steps_usecase):
     initialize_organisme_steps_usecase.organisme_repository.save(organisme_before)
 
     organisme = initialize_organisme_steps_usecase.execute(
-        command=InitializeOrganismeStepsCommand(organisme_id=organisme_before.entity_id)
+        command=InitializeOrganismeStepsCommand(
+            organisme_id=organisme_before.entity_id, utilisateur_id=uuid4()
+        )
     )
 
     events = organisme.collect_events()
@@ -64,3 +74,60 @@ def test_update_organsime_steps(update_organisme_steps_usecase):
     update_organisme_steps_usecase.audit_log_writer.drain_events.assert_called_once_with(
         utilisateur_id=utilisateur_id, aggregate=organisme
     )
+
+
+def test_get_organisme_steps_raises_when_not_responsable(
+    get_organisme_recruteur_usecase,
+):
+    organisme_before = OrganismeRecruteurFactory.create_entity()
+    get_organisme_recruteur_usecase.organisme_repository.save(organisme_before)
+    permission_service = get_organisme_recruteur_usecase.organisme_permission_service
+    permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
+        organisme_before.entity_id
+    )
+
+    with pytest.raises(AccesOrganismeRefuse):
+        get_organisme_recruteur_usecase.execute(
+            command=GetOrganismeRecruteurQuery(
+                organisme_id=organisme_before.entity_id, utilisateur_id=uuid4()
+            )
+        )
+
+
+def test_initialize_organisme_steps_raises_when_not_responsable(
+    initialize_organisme_steps_usecase,
+):
+    organisme_before = OrganismeRecruteurFactory.create_entity()
+    initialize_organisme_steps_usecase.organisme_repository.save(organisme_before)
+    permission_service = initialize_organisme_steps_usecase.organisme_permission_service
+    permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
+        organisme_before.entity_id
+    )
+
+    with pytest.raises(AccesOrganismeRefuse):
+        initialize_organisme_steps_usecase.execute(
+            command=InitializeOrganismeStepsCommand(
+                organisme_id=organisme_before.entity_id, utilisateur_id=uuid4()
+            )
+        )
+
+
+def test_update_organisme_steps_raises_when_not_responsable(
+    update_organisme_steps_usecase,
+):
+    etapes = EtapeRecrutementFactory.create_entities()
+    organisme_before = OrganismeRecruteurFactory.create_entity(etapes=etapes)
+    update_organisme_steps_usecase.organisme_recruteur_repository.save(organisme_before)
+    permission_service = update_organisme_steps_usecase.organisme_permission_service
+    permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
+        organisme_before.entity_id
+    )
+
+    with pytest.raises(AccesOrganismeRefuse):
+        update_organisme_steps_usecase.execute(
+            command=UpdateOrganismeStepsCommand(
+                utilisateur_id=uuid4(),
+                organisme_id=organisme_before.entity_id,
+                etapes=EtapeRecrutementFactory.to_etape_data_list(etapes),
+            )
+        )

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -25,6 +25,7 @@ def test_est_autorise_passes_when_agent_is_responsable() -> None:
         action=OrganismeAction.GET_ORGANISME,
         organisme_id=organisme_id,
         agent_id=agent_id,
+        est_staff=False,
     )
 
     repository.get_role.assert_called_once_with(
@@ -42,6 +43,7 @@ def test_est_autorise_raises_when_agent_is_membre() -> None:
             action=OrganismeAction.GET_ORGANISME,
             organisme_id=uuid4(),
             agent_id=uuid4(),
+            est_staff=False,
         )
 
 
@@ -55,7 +57,22 @@ def test_est_autorise_raises_when_agent_has_no_role() -> None:
             action=OrganismeAction.GET_ORGANISME,
             organisme_id=uuid4(),
             agent_id=uuid4(),
+            est_staff=False,
         )
+
+
+def test_verifier_responsable_passes_when_staff_even_if_not_responsable() -> None:
+    repository = Mock(spec=IOrganismeAgentRepository)
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    service.est_autorise(
+        action=OrganismeAction.GET_ORGANISME,
+        organisme_id=uuid4(),
+        agent_id=uuid4(),
+        est_staff=True,
+    )
+
+    repository.get_role.assert_not_called()
 
 
 @pytest.mark.parametrize("action", list(OrganismeAction))
@@ -71,4 +88,5 @@ def test_every_organisme_action_currently_requires_responsable(
             action=action,
             organisme_id=uuid4(),
             agent_id=uuid4(),
+            est_staff=False,
         )

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.repositories.organisme_agent_repository_interface import (
+    IOrganismeAgentRepository,
+)
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+
+
+def test_est_autorise_passes_when_agent_is_responsable() -> None:
+    organisme_id = uuid4()
+    agent_id = uuid4()
+    repository = Mock(spec=IOrganismeAgentRepository)
+    repository.get_role.return_value = AgentOrganismeRole.RESPONSABLE
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    service.est_autorise(
+        action=OrganismeAction.GET_ORGANISME,
+        organisme_id=organisme_id,
+        agent_id=agent_id,
+    )
+
+    repository.get_role.assert_called_once_with(
+        organisme_id=organisme_id, agent_id=agent_id
+    )
+
+
+def test_est_autorise_raises_when_agent_is_membre() -> None:
+    repository = Mock(spec=IOrganismeAgentRepository)
+    repository.get_role.return_value = AgentOrganismeRole.MEMBRE
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    with pytest.raises(AccesOrganismeRefuse):
+        service.est_autorise(
+            action=OrganismeAction.GET_ORGANISME,
+            organisme_id=uuid4(),
+            agent_id=uuid4(),
+        )
+
+
+def test_est_autorise_raises_when_agent_has_no_role() -> None:
+    repository = Mock(spec=IOrganismeAgentRepository)
+    repository.get_role.return_value = None
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    with pytest.raises(AccesOrganismeRefuse):
+        service.est_autorise(
+            action=OrganismeAction.GET_ORGANISME,
+            organisme_id=uuid4(),
+            agent_id=uuid4(),
+        )
+
+
+@pytest.mark.parametrize("action", list(OrganismeAction))
+def test_every_organisme_action_currently_requires_responsable(
+    action: OrganismeAction,
+) -> None:
+    repository = Mock(spec=IOrganismeAgentRepository)
+    repository.get_role.return_value = AgentOrganismeRole.MEMBRE
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    with pytest.raises(AccesOrganismeRefuse):
+        service.est_autorise(
+            action=action,
+            organisme_id=uuid4(),
+            agent_id=uuid4(),
+        )

--- a/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
@@ -1,0 +1,61 @@
+from uuid import uuid4
+
+import pytest
+
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from infrastructure.django_apps.recruteur.models.organisme import OrganismeAgentModel
+from infrastructure.factories.identite.agent_factory import AgentFactory
+from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.repositories.recruteur.postgres_organisme_agent_repository import (
+    PostgresOrganismeAgentRepository,
+)
+
+
+@pytest.fixture(name="repository")
+def repository_fixture():
+    return PostgresOrganismeAgentRepository()
+
+
+def test_get_role_returns_responsable(db, repository):
+    organisme_model = OrganismeFactory.create_model()
+    agent = AgentFactory.create_model()
+    OrganismeAgentModel(
+        id=uuid4(),
+        organisme_id=organisme_model.id,
+        agent_id=agent.utilisateur_id,
+        role=AgentOrganismeRole.RESPONSABLE.value,
+    ).save()
+
+    role = repository.get_role(
+        organisme_id=organisme_model.id, agent_id=agent.utilisateur_id
+    )
+
+    assert role == AgentOrganismeRole.RESPONSABLE
+
+
+def test_get_role_returns_membre(db, repository):
+    organisme_model = OrganismeFactory.create_model()
+    agent = AgentFactory.create_model()
+    OrganismeAgentModel(
+        id=uuid4(),
+        organisme_id=organisme_model.id,
+        agent_id=agent.utilisateur_id,
+        role=AgentOrganismeRole.MEMBRE.value,
+    ).save()
+
+    role = repository.get_role(
+        organisme_id=organisme_model.id, agent_id=agent.utilisateur_id
+    )
+
+    assert role == AgentOrganismeRole.MEMBRE
+
+
+def test_get_role_returns_none_when_no_liaison(db, repository):
+    organisme_model = OrganismeFactory.create_model()
+    agent = AgentFactory.create_model()
+
+    role = repository.get_role(
+        organisme_id=organisme_model.id, agent_id=agent.utilisateur_id
+    )
+
+    assert role is None

--- a/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
@@ -14,6 +14,9 @@ from application.recruteur.usecases.update_organisme_steps import (
 )
 from config.app_config import AppConfig
 from domain.commons.services.audit_log_writer import AuditLogWriter
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory
 from infrastructure.factories.recruteur.etapes_recrutement_factory import (
@@ -32,6 +35,9 @@ def recruteur_integration_container_fixture(db):
     container.app_config.override(app_config)
     container.logger_service.override(logger_service)
     container.audit_log_writer.override(MagicMock(spec=AuditLogWriter))
+    container.organisme_permission_service.override(
+        MagicMock(spec=OrganismePermissionService)
+    )
     return container
 
 
@@ -40,7 +46,11 @@ def test_get_organisme_steps(recruteur_integration_container):
     organisme_model.save()
     usecase = recruteur_integration_container.get_organisme_recruteur_usecase()
 
-    organisme = usecase.execute(command=GetOrganismeRecruteurQuery(organisme_model.id))
+    organisme = usecase.execute(
+        command=GetOrganismeRecruteurQuery(
+            organisme_id=organisme_model.id, utilisateur_id=uuid4()
+        )
+    )
     events = organisme.collect_events()
     assert len(events) == 0
     assert organisme.entity_id == organisme_model.id
@@ -51,7 +61,9 @@ def test_initialize_organisme_steps(recruteur_integration_container):
     usecase = recruteur_integration_container.initialize_organisme_steps_usecase()
 
     organisme = usecase.execute(
-        command=InitializeOrganismeStepsCommand(organisme_id=organisme_model.id)
+        command=InitializeOrganismeStepsCommand(
+            organisme_id=organisme_model.id, utilisateur_id=uuid4()
+        )
     )
 
     events = organisme.collect_events()

--- a/src/web/tests/presentation/recruteur/test_views_organismes.py
+++ b/src/web/tests/presentation/recruteur/test_views_organismes.py
@@ -11,6 +11,7 @@ from domain.recruteur.errors.erreur_recrutement import (
     ConfigurationEtapesInvalide,
     ErreurRecruteur,
 )
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
@@ -78,6 +79,22 @@ class TestOrganismeView:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found."}
 
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_returns_403_when_not_responsable(
+        self, mock_recruteur_container, authenticated_client
+    ):
+        mock_usecase = MagicMock()
+        mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
+
+        mock_container = MagicMock()
+        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        response = authenticated_client.get(ORGANISME_URL)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"detail": "Forbidden."}
+
 
 class TestEtapesRecrutementOrganismeView:
     def test_anonymous_access_is_unauthorized(self, api_client):
@@ -99,6 +116,22 @@ class TestEtapesRecrutementOrganismeView:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"organisme_uuid": "Not found."}
+
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_returns_403_when_not_responsable(
+        self, mock_recruteur_container, authenticated_client
+    ):
+        mock_usecase = MagicMock()
+        mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
+
+        mock_container = MagicMock()
+        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        response = authenticated_client.get(ETAPES_URL)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"detail": "Forbidden."}
 
     @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_authenticated_access_is_ok(
@@ -166,6 +199,22 @@ class TestInitEtapesRecrutementOrganismeView:
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json() == {"error": "Unexpected error"}
+
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_returns_403_when_not_responsable(
+        self, mock_recruteur_container, authenticated_client
+    ):
+        mock_usecase = MagicMock()
+        mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
+
+        mock_container = MagicMock()
+        mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        response = authenticated_client.post(INIT_ETAPES_URL)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"detail": "Forbidden."}
 
     @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_authenticated_post_initialize_steps(
@@ -320,6 +369,29 @@ class TestPutEtapesRecrutementOrganismeView:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"organisme_uuid": "Not found."}
+
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_put_returns_403_when_not_responsable(
+        self, mock_recruteur_container, authenticated_client
+    ):
+        mock_usecase = MagicMock()
+        mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
+
+        mock_container = MagicMock()
+        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        payload = [
+            {"nom": "Réception", "categorie": "ENTREE"},
+            {"nom": "Entretien", "categorie": "EN_COURS"},
+            {"nom": "Refus", "categorie": "REFUS"},
+            {"nom": "Recrutement", "categorie": "ACCEPTE"},
+        ]
+
+        response = authenticated_client.put(ETAPES_URL, payload, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"detail": "Forbidden."}
 
     @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_put_returns_500_on_unexpected_error(

--- a/src/web/tests/presentation/recruteur/test_views_organismes.py
+++ b/src/web/tests/presentation/recruteur/test_views_organismes.py
@@ -95,6 +95,28 @@ class TestOrganismeView:
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {"detail": "Forbidden."}
 
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_forwards_est_staff_to_usecase(
+        self, mock_recruteur_container, authenticated_client, test_user
+    ):
+        test_user.is_staff = True
+        test_user.save()
+
+        mock_organisme = MagicMock()
+        mock_organisme.nom = "COMMUNE DE BRIANCON"
+        mock_organisme.siret = "21050023700354"
+        mock_usecase = MagicMock()
+        mock_usecase.execute.return_value = mock_organisme
+
+        mock_container = MagicMock()
+        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        authenticated_client.get(ORGANISME_URL)
+
+        command = mock_usecase.execute.call_args.args[0]
+        assert command.est_staff is True
+
 
 class TestEtapesRecrutementOrganismeView:
     def test_anonymous_access_is_unauthorized(self, api_client):
@@ -161,6 +183,25 @@ class TestEtapesRecrutementOrganismeView:
             ]
 
         assert response.json() == steps
+
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_forwards_est_staff_to_usecase(
+        self, mock_recruteur_container, authenticated_client, test_user
+    ):
+        test_user.is_staff = True
+        test_user.save()
+
+        mock_usecase = MagicMock()
+        mock_usecase.execute.return_value = OrganismeRecruteurFactory.create_entity()
+
+        mock_container = MagicMock()
+        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        authenticated_client.get(ETAPES_URL)
+
+        command = mock_usecase.execute.call_args.args[0]
+        assert command.est_staff is True
 
 
 class TestInitEtapesRecrutementOrganismeView:
@@ -241,6 +282,27 @@ class TestInitEtapesRecrutementOrganismeView:
             }
             for etape in (organisme.etapes or ())
         ]
+
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_forwards_est_staff_to_usecase(
+        self, mock_recruteur_container, authenticated_client, test_user
+    ):
+        test_user.is_staff = True
+        test_user.save()
+
+        organisme = OrganismeRecruteurFactory.create_entity()
+        organisme.initialiser_etapes()
+        mock_usecase = MagicMock()
+        mock_usecase.execute.return_value = organisme
+
+        mock_container = MagicMock()
+        mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        authenticated_client.post(INIT_ETAPES_URL)
+
+        command = mock_usecase.execute.call_args.args[0]
+        assert command.est_staff is True
 
 
 class TestPutEtapesRecrutementOrganismeView:
@@ -415,3 +477,29 @@ class TestPutEtapesRecrutementOrganismeView:
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json() == {"error": "Unexpected error"}
+
+    @patch("presentation.recruteur.views.organismes.recruteur_container")
+    def test_forwards_est_staff_to_usecase(
+        self, mock_recruteur_container, authenticated_client, test_user
+    ):
+        test_user.is_staff = True
+        test_user.save()
+
+        mock_usecase = MagicMock()
+        mock_usecase.execute.return_value = OrganismeRecruteurFactory.create_entity()
+
+        mock_container = MagicMock()
+        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
+        mock_recruteur_container.return_value = mock_container
+
+        payload = [
+            {"nom": "Réception", "categorie": "ENTREE"},
+            {"nom": "Entretien", "categorie": "EN_COURS"},
+            {"nom": "Refus", "categorie": "REFUS"},
+            {"nom": "Recrutement", "categorie": "ACCEPTE"},
+        ]
+
+        authenticated_client.put(ETAPES_URL, payload, format="json")
+
+        command = mock_usecase.execute.call_args.args[0]
+        assert command.est_staff is True

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -84,6 +84,9 @@ from domain.ingestion.repositories.vector_repository_interface import IVectorRep
 from domain.recruteur.repositories.organisme_repository_interface import (
     IOrganismeRecruteurRepository,
 )
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
 from infrastructure.di.ingestion.ingestion_container import IngestionContainer
 from infrastructure.di.shared.shared_container import SharedContainer
 from infrastructure.factories.identite.utilisateur_factory import UtilisateurFactory
@@ -515,7 +518,10 @@ def get_organisme_recruteur_usecase():
     organisme_repository = cast(
         IOrganismeRecruteurRepository, create_interface_aware_mock(IOrganismeRepository)
     )
-    return GetOrganismeRecruteurUsecase(organisme_repository=organisme_repository)
+    return GetOrganismeRecruteurUsecase(
+        organisme_repository=organisme_repository,
+        organisme_permission_service=MagicMock(spec=OrganismePermissionService),
+    )
 
 
 @pytest.fixture
@@ -524,7 +530,10 @@ def initialize_organisme_steps_usecase():
         IOrganismeRecruteurRepository,
         create_interface_aware_mock(IOrganismeRecruteurRepository),
     )
-    return InitializeOrganismeStepsUsecase(organisme_repository=repository)
+    return InitializeOrganismeStepsUsecase(
+        organisme_repository=repository,
+        organisme_permission_service=MagicMock(spec=OrganismePermissionService),
+    )
 
 
 @pytest.fixture
@@ -557,4 +566,5 @@ def update_organisme_steps_usecase():
         organisme_repository=organisme_repo,
         organisme_recruteur_repository=organisme_recruteur_repo,
         audit_log_writer=MagicMock(spec=AuditLogWriter),
+        organisme_permission_service=MagicMock(spec=OrganismePermissionService),
     )


### PR DESCRIPTION
## 📝 Description
🎸 mise en place des contrôles d'autorisation pour les endpoints organisme (récupération, initialisation et mise à jour des étapes de recrutement)

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
### Domaine (domain/recruteur)
- OrganismePermissionService : vérifie que l'agent a le rôle RESPONSABLE sur l'organisme pour l'action demandée, sinon lève AccesOrganismeRefuse.
- ** 🔔  Les utilisateurs staff (est_staff=True) court-circuitent la vérification.**

### Infrastructure
- OrganismeFactory (factory de test) : accepte agent_id/role pour créer directement la liaison agent-organisme.

### Application
- Chaque use case appelle organisme_permission_service.est_autorise(...) avant sa logique métier.

### Présentation
- Les vues transmettent utilisateur_id/est_staff et gèrent AccesOrganismeRefuse → 403 Forbidden.
- Schéma OpenAPI interne régénéré (réponse 403 ajoutée sur les 4 endpoints concernés).

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
