### PR TITLE
⚡️(ingestion-presentation) remove browsable api rendered option in DRF

### DIFF
--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -330,6 +330,9 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 100,
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+    ],
     "DEFAULT_THROTTLE_CLASSES": [
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",


### PR DESCRIPTION
## 📝 Description
🎸 limiter l'utilisation de l'API en mode json, pour éviter de laisser croire au requetage possible via un navigateur web

## 🏷️ Type de changement
- [x] 🔧 Changement technique

## 🔧 Modifications
* déclaration explicite de `DEFAULT_RENDERER_CLASSES` pour désactiver la class `BrowsableAPIRendered`

## 🏝️ Comment tester (si applicable)
* accéder à un endpoint, vérifier l'affichage mode json par defaut


## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
