### PR TITLE
♻️(recruteur-presentation) refactor tests

### DIFF
--- a/src/web/infrastructure/factories/identite/organisme_factory.py
+++ b/src/web/infrastructure/factories/identite/organisme_factory.py
@@ -11,6 +11,8 @@ from referentiel.value_objects.verse import Verse
 from domain.identite.entities.organisme import Organisme
 from domain.identite.value_objects.siret import SIRET
 from domain.recruteur.entities.etape_recrutement import EtapeRecrutement
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from infrastructure.django_apps.recruteur.models.organisme import OrganismeAgentModel
 from infrastructure.mappers.organisme_identite_mapper import (
     OrganismeIdentiteMapper,
 )
@@ -60,6 +62,8 @@ class OrganismeFactory:
         localisation: Localisation | None = None,
         siret: SIRET | None = None,
         etapes: tuple[EtapeRecrutement, ...] | None = None,
+        agent_id: UUID | None = None,
+        role: AgentOrganismeRole | None = None,
     ):
         organisme = OrganismeFactory.create_entity(
             entity_id=entity_id,
@@ -73,4 +77,11 @@ class OrganismeFactory:
         if etapes is not None:
             model.etapes = OrganismeRecruteurMapper().from_domain(etapes)
         model.save()
+        if agent_id is not None:
+            OrganismeAgentModel(
+                id=uuid4(),
+                organisme_id=model.id,
+                agent_id=agent_id,
+                role=(role or AgentOrganismeRole.MEMBRE).value,
+            ).save()
         return model

--- a/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
@@ -1,9 +1,6 @@
-from uuid import uuid4
-
 import pytest
 
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
-from infrastructure.django_apps.recruteur.models.organisme import OrganismeAgentModel
 from infrastructure.factories.identite.agent_factory import AgentFactory
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory
 from infrastructure.repositories.recruteur.postgres_organisme_agent_repository import (
@@ -17,14 +14,10 @@ def repository_fixture():
 
 
 def test_get_role_returns_responsable(db, repository):
-    organisme_model = OrganismeFactory.create_model()
     agent = AgentFactory.create_model()
-    OrganismeAgentModel(
-        id=uuid4(),
-        organisme_id=organisme_model.id,
-        agent_id=agent.utilisateur_id,
-        role=AgentOrganismeRole.RESPONSABLE.value,
-    ).save()
+    organisme_model = OrganismeFactory.create_model(
+        agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+    )
 
     role = repository.get_role(
         organisme_id=organisme_model.id, agent_id=agent.utilisateur_id
@@ -34,14 +27,8 @@ def test_get_role_returns_responsable(db, repository):
 
 
 def test_get_role_returns_membre(db, repository):
-    organisme_model = OrganismeFactory.create_model()
     agent = AgentFactory.create_model()
-    OrganismeAgentModel(
-        id=uuid4(),
-        organisme_id=organisme_model.id,
-        agent_id=agent.utilisateur_id,
-        role=AgentOrganismeRole.MEMBRE.value,
-    ).save()
+    organisme_model = OrganismeFactory.create_model(agent_id=agent.utilisateur_id)
 
     role = repository.get_role(
         organisme_id=organisme_model.id, agent_id=agent.utilisateur_id

--- a/src/web/tests/presentation/recruteur/test_views_notes.py
+++ b/src/web/tests/presentation/recruteur/test_views_notes.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
+import pytest
 from django.urls import reverse
 from faker import Faker
 from rest_framework import status
@@ -28,37 +29,37 @@ NOTE_DETAIL_URL = reverse(
 )
 
 
+@pytest.fixture
+def container():
+    with patch("presentation.recruteur.views.notes.recruteur_container") as mock:
+        instance = MagicMock()
+        mock.return_value = instance
+        yield instance
+
+
 class TestCandidatureNotesView:
     def test_anonymous_access_is_unauthorized(self, api_client):
         assert api_client.get(NOTES_URL).status_code == status.HTTP_401_UNAUTHORIZED
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_list_notes(self, mock_recruteur_container, authenticated_client):
+    def test_list_notes(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = [
             NoteFactory.create_read_model(message="a"),
             NoteFactory.create_read_model(message="b"),
         ]
-        mock_container = MagicMock()
-        mock_container.lister_notes_candidature_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.lister_notes_candidature_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(NOTES_URL)
 
         assert response.status_code == status.HTTP_200_OK
         assert [n["message"] for n in response.json()] == ["a", "b"]
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_create_note(
-        self, mock_recruteur_container, authenticated_client, test_user
-    ):
+    def test_create_note(self, container, authenticated_client, test_user):
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = NoteFactory.create_entity(
             message="nouvelle note"
         )
-        mock_container = MagicMock()
-        mock_container.creer_note_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.creer_note_usecase.return_value = mock_usecase
 
         response = authenticated_client.post(
             NOTES_URL, data={"message": "nouvelle note"}, format="json"
@@ -74,27 +75,17 @@ class TestCandidatureNotesView:
             )
         )
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_create_note_requires_message(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_container = MagicMock()
-        mock_container.creer_note_usecase.return_value = MagicMock()
-        mock_recruteur_container.return_value = mock_container
+    def test_create_note_requires_message(self, container, authenticated_client):
+        container.creer_note_usecase.return_value = MagicMock()
 
         response = authenticated_client.post(NOTES_URL, data={}, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_create_note_unknown_candidature(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_create_note_unknown_candidature(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = CandidatureIntrouvable(uuid4())
-        mock_container = MagicMock()
-        mock_container.creer_note_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.creer_note_usecase.return_value = mock_usecase
 
         response = authenticated_client.post(
             NOTES_URL, data={"message": "x"}, format="json"
@@ -110,15 +101,12 @@ class TestNoteDetailView:
             == status.HTTP_401_UNAUTHORIZED
         )
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_edit_note(self, mock_recruteur_container, authenticated_client, test_user):
+    def test_edit_note(self, container, authenticated_client, test_user):
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = NoteFactory.create_entity(
             message="modifiée"
         )
-        mock_container = MagicMock()
-        mock_container.editer_note_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.editer_note_usecase.return_value = mock_usecase
 
         response = authenticated_client.patch(
             NOTE_DETAIL_URL, data={"message": "modifiée"}, format="json"
@@ -133,13 +121,10 @@ class TestNoteDetailView:
             )
         )
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_edit_note_not_found(self, mock_recruteur_container, authenticated_client):
+    def test_edit_note_not_found(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = NoteIntrouvable(uuid4())
-        mock_container = MagicMock()
-        mock_container.editer_note_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.editer_note_usecase.return_value = mock_usecase
 
         response = authenticated_client.patch(
             NOTE_DETAIL_URL, data={"message": "x"}, format="json"
@@ -147,15 +132,10 @@ class TestNoteDetailView:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_delete_note(
-        self, mock_recruteur_container, authenticated_client, test_user
-    ):
+    def test_delete_note(self, container, authenticated_client, test_user):
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = None
-        mock_container = MagicMock()
-        mock_container.supprimer_note_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.supprimer_note_usecase.return_value = mock_usecase
 
         response = authenticated_client.delete(NOTE_DETAIL_URL)
 
@@ -167,15 +147,10 @@ class TestNoteDetailView:
             )
         )
 
-    @patch("presentation.recruteur.views.notes.recruteur_container")
-    def test_delete_note_not_found(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_delete_note_not_found(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = NoteIntrouvable(uuid4())
-        mock_container = MagicMock()
-        mock_container.supprimer_note_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.supprimer_note_usecase.return_value = mock_usecase
 
         response = authenticated_client.delete(NOTE_DETAIL_URL)
 

--- a/src/web/tests/presentation/recruteur/test_views_organismes.py
+++ b/src/web/tests/presentation/recruteur/test_views_organismes.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
+import pytest
 from django.urls import reverse
 from faker import Faker
 from rest_framework import status
@@ -34,26 +35,46 @@ INIT_ETAPES_URL = reverse(
     kwargs={"organisme_uuid": ORGANISME_UUID},
 )
 
+VALID_ETAPES_PAYLOAD = [
+    {"nom": "Réception", "categorie": "ENTREE"},
+    {"nom": "Entretien", "categorie": "EN_COURS"},
+    {"nom": "Refus", "categorie": "REFUS"},
+    {"nom": "Recrutement", "categorie": "ACCEPTE"},
+]
+
+
+def etapes_as_json(etapes: tuple[EtapeRecrutement, ...]) -> list[dict]:
+    return [
+        {
+            "etape_uuid": str(etape.entity_id),
+            "nom": etape.nom,
+            "categorie": etape.categorie.name,
+        }
+        for etape in etapes
+    ]
+
+
+@pytest.fixture
+def container():
+    with patch("presentation.recruteur.views.organismes.recruteur_container") as mock:
+        instance = MagicMock()
+        mock.return_value = instance
+        yield instance
+
 
 class TestOrganismeView:
     def test_anonymous_access_is_unauthorized(self, api_client):
         response = api_client.get(ORGANISME_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_authenticated_access_is_ok(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_authenticated_access_is_ok(self, container, authenticated_client):
         mock_organisme = MagicMock()
         mock_organisme.nom = "COMMUNE DE BRIANCON"
         mock_organisme.siret = "21050023700354"
 
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = mock_organisme
-
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.get_organisme_recruteur_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(ORGANISME_URL)
 
@@ -63,41 +84,30 @@ class TestOrganismeView:
             "siret": "21050023700354",
         }
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_returns_404_when_organisme_not_found(
-        self, mock_recruteur_container, authenticated_client
+        self, container, authenticated_client
     ):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = ErreurRecruteur("not found")
-
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.get_organisme_recruteur_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(ORGANISME_URL)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found."}
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_returns_403_when_not_responsable(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_returns_403_when_not_responsable(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
-
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.get_organisme_recruteur_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(ORGANISME_URL)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {"detail": "Forbidden."}
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_forwards_est_staff_to_usecase(
-        self, mock_recruteur_container, authenticated_client, test_user
+        self, container, authenticated_client, test_user
     ):
         test_user.is_staff = True
         test_user.save()
@@ -105,12 +115,11 @@ class TestOrganismeView:
         mock_organisme = MagicMock()
         mock_organisme.nom = "COMMUNE DE BRIANCON"
         mock_organisme.siret = "21050023700354"
+
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = mock_organisme
 
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.get_organisme_recruteur_usecase.return_value = mock_usecase
 
         authenticated_client.get(ORGANISME_URL)
 
@@ -123,80 +132,59 @@ class TestEtapesRecrutementOrganismeView:
         response = api_client.get(ETAPES_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_returns_404_when_organisme_not_found(
-        self, mock_recruteur_container, authenticated_client
+    @pytest.mark.parametrize(
+        ("exception", "expected_status", "expected_body"),
+        [
+            (
+                OrganismeNexistePas("not found"),
+                status.HTTP_404_NOT_FOUND,
+                {"organisme_uuid": "Not found."},
+            ),
+            (
+                AccesOrganismeRefuse(UUID(fake.uuid4())),
+                status.HTTP_403_FORBIDDEN,
+                {"detail": "Forbidden."},
+            ),
+        ],
+    )
+    def test_get_returns_error_from_usecase(
+        self,
+        container,
+        authenticated_client,
+        exception,
+        expected_status,
+        expected_body,
     ):
         mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = OrganismeNexistePas("not found")
-
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        mock_usecase.execute.side_effect = exception
+        container.get_organisme_recruteur_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(ETAPES_URL)
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {"organisme_uuid": "Not found."}
+        assert response.status_code == expected_status
+        assert response.json() == expected_body
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_returns_403_when_not_responsable(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
-
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
-
-        response = authenticated_client.get(ETAPES_URL)
-
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.json() == {"detail": "Forbidden."}
-
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_authenticated_access_is_ok(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_authenticated_access_is_ok(self, container, authenticated_client):
         organisme = OrganismeRecruteurFactory.create_entity()
 
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = organisme
-
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.get_organisme_recruteur_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(ETAPES_URL)
 
         assert response.status_code == status.HTTP_200_OK
-        steps = []
-        if organisme.etapes:
-            steps = [
-                {
-                    "etape_uuid": str(etape.entity_id),
-                    "nom": etape.nom,
-                    "categorie": etape.categorie.name,
-                }
-                for etape in organisme.etapes
-            ]
+        assert response.json() == etapes_as_json(organisme.etapes or ())
 
-        assert response.json() == steps
-
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_forwards_est_staff_to_usecase(
-        self, mock_recruteur_container, authenticated_client, test_user
+        self, container, authenticated_client, test_user
     ):
         test_user.is_staff = True
         test_user.save()
 
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = OrganismeRecruteurFactory.create_entity()
-
-        mock_container = MagicMock()
-        mock_container.get_organisme_recruteur_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.get_organisme_recruteur_usecase.return_value = mock_usecase
 
         authenticated_client.get(ETAPES_URL)
 
@@ -209,83 +197,58 @@ class TestInitEtapesRecrutementOrganismeView:
         response = api_client.post(INIT_ETAPES_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_returns_404_when_organisme_not_found(
-        self, mock_recruteur_container, authenticated_client
+    @pytest.mark.parametrize(
+        ("exception", "expected_status", "expected_body"),
+        [
+            (
+                OrganismeNexistePas("not found"),
+                status.HTTP_404_NOT_FOUND,
+                {"organisme_uuid": "Not found."},
+            ),
+            (
+                AccesOrganismeRefuse(UUID(fake.uuid4())),
+                status.HTTP_403_FORBIDDEN,
+                {"detail": "Forbidden."},
+            ),
+            (
+                Exception("unexpected"),
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                {"error": "Unexpected error"},
+            ),
+        ],
+    )
+    def test_post_returns_error_from_usecase(
+        self,
+        container,
+        authenticated_client,
+        exception,
+        expected_status,
+        expected_body,
     ):
         mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = OrganismeNexistePas("not found")
-
-        mock_container = MagicMock()
-        mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        mock_usecase.execute.side_effect = exception
+        container.initialize_organisme_steps_usecase.return_value = mock_usecase
 
         response = authenticated_client.post(INIT_ETAPES_URL)
 
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {"organisme_uuid": "Not found."}
+        assert response.status_code == expected_status
+        assert response.json() == expected_body
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_returns_500_on_unexpected_error(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = Exception("unexpected")
-
-        mock_container = MagicMock()
-        mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
-
-        response = authenticated_client.post(INIT_ETAPES_URL)
-
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert response.json() == {"error": "Unexpected error"}
-
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_returns_403_when_not_responsable(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
-
-        mock_container = MagicMock()
-        mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
-
-        response = authenticated_client.post(INIT_ETAPES_URL)
-
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.json() == {"detail": "Forbidden."}
-
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_authenticated_post_initialize_steps(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_authenticated_post_initialize_steps(self, container, authenticated_client):
         organisme = OrganismeRecruteurFactory.create_entity()
         organisme.initialiser_etapes()
 
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = organisme
-
-        mock_container = MagicMock()
-        mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.initialize_organisme_steps_usecase.return_value = mock_usecase
 
         response = authenticated_client.post(INIT_ETAPES_URL)
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.json() == [
-            {
-                "etape_uuid": str(etape.entity_id),
-                "nom": etape.nom,
-                "categorie": etape.categorie.name,
-            }
-            for etape in (organisme.etapes or ())
-        ]
+        assert response.json() == etapes_as_json(organisme.etapes or ())
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_forwards_est_staff_to_usecase(
-        self, mock_recruteur_container, authenticated_client, test_user
+        self, container, authenticated_client, test_user
     ):
         test_user.is_staff = True
         test_user.save()
@@ -294,10 +257,7 @@ class TestInitEtapesRecrutementOrganismeView:
         organisme.initialiser_etapes()
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = organisme
-
-        mock_container = MagicMock()
-        mock_container.initialize_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.initialize_organisme_steps_usecase.return_value = mock_usecase
 
         authenticated_client.post(INIT_ETAPES_URL)
 
@@ -326,10 +286,7 @@ class TestPutEtapesRecrutementOrganismeView:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_put_mixed_existing_and_new_etapes(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_put_mixed_existing_and_new_etapes(self, container, authenticated_client):
         existing_uuid = fake.uuid4()
         new_uuid = fake.uuid4()
         other_uuid = fake.uuid4()
@@ -337,17 +294,17 @@ class TestPutEtapesRecrutementOrganismeView:
         organisme = OrganismeRecruteurFactory.create_entity()
         organisme._etapes = (
             EtapeRecrutement.build(
-                entity_id=UUID(str(existing_uuid)),
+                entity_id=UUID(existing_uuid),
                 nom="Réception",
                 categorie=CategorieEtapeRecrutement.ENTREE,
             ),
             EtapeRecrutement.build(
-                entity_id=UUID(str(new_uuid)),
+                entity_id=UUID(new_uuid),
                 nom="Nouvelle étape",
                 categorie=CategorieEtapeRecrutement.EN_COURS,
             ),
             EtapeRecrutement.build(
-                entity_id=UUID(str(other_uuid)),
+                entity_id=UUID(other_uuid),
                 nom="Recrutement",
                 categorie=CategorieEtapeRecrutement.ACCEPTE,
             ),
@@ -355,10 +312,7 @@ class TestPutEtapesRecrutementOrganismeView:
 
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = organisme
-
-        mock_container = MagicMock()
-        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.update_organisme_steps_usecase.return_value = mock_usecase
 
         payload = [
             {
@@ -378,23 +332,17 @@ class TestPutEtapesRecrutementOrganismeView:
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert len(data) == 3  # noqa
+        assert len(data) == len(payload)
         assert data[0]["etape_uuid"] == str(existing_uuid)
         assert data[1]["etape_uuid"] == str(new_uuid)
         assert data[1]["nom"] == "Nouvelle étape"
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_put_returns_400_on_invalid_steps(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_put_returns_400_on_invalid_steps(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = ConfigurationEtapesInvalide(
             "la première étape doit être de catégorie ENTREE"
         )
-
-        mock_container = MagicMock()
-        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.update_organisme_steps_usecase.return_value = mock_usecase
 
         payload = [
             {"nom": "Entretien", "categorie": "EN_COURS"},
@@ -409,97 +357,56 @@ class TestPutEtapesRecrutementOrganismeView:
             "error": "la première étape doit être de catégorie ENTREE"
         }
 
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_put_returns_404_when_organisme_not_found(
-        self, mock_recruteur_container, authenticated_client
+    @pytest.mark.parametrize(
+        ("exception", "expected_status", "expected_body"),
+        [
+            (
+                OrganismeNexistePas("not found"),
+                status.HTTP_404_NOT_FOUND,
+                {"organisme_uuid": "Not found."},
+            ),
+            (
+                AccesOrganismeRefuse(UUID(fake.uuid4())),
+                status.HTTP_403_FORBIDDEN,
+                {"detail": "Forbidden."},
+            ),
+            (
+                Exception("unexpected"),
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                {"error": "Unexpected error"},
+            ),
+        ],
+    )
+    def test_put_returns_error_from_usecase(
+        self,
+        container,
+        authenticated_client,
+        exception,
+        expected_status,
+        expected_body,
     ):
         mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = OrganismeNexistePas("not found")
+        mock_usecase.execute.side_effect = exception
+        container.update_organisme_steps_usecase.return_value = mock_usecase
 
-        mock_container = MagicMock()
-        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        response = authenticated_client.put(
+            ETAPES_URL, VALID_ETAPES_PAYLOAD, format="json"
+        )
 
-        payload = [
-            {"nom": "Réception", "categorie": "ENTREE"},
-            {"nom": "Entretien", "categorie": "EN_COURS"},
-            {"nom": "Refus", "categorie": "REFUS"},
-            {"nom": "Recrutement", "categorie": "ACCEPTE"},
-        ]
+        assert response.status_code == expected_status
+        assert response.json() == expected_body
 
-        response = authenticated_client.put(ETAPES_URL, payload, format="json")
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {"organisme_uuid": "Not found."}
-
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_put_returns_403_when_not_responsable(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = AccesOrganismeRefuse(UUID(fake.uuid4()))
-
-        mock_container = MagicMock()
-        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
-
-        payload = [
-            {"nom": "Réception", "categorie": "ENTREE"},
-            {"nom": "Entretien", "categorie": "EN_COURS"},
-            {"nom": "Refus", "categorie": "REFUS"},
-            {"nom": "Recrutement", "categorie": "ACCEPTE"},
-        ]
-
-        response = authenticated_client.put(ETAPES_URL, payload, format="json")
-
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.json() == {"detail": "Forbidden."}
-
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
-    def test_put_returns_500_on_unexpected_error(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_usecase = MagicMock()
-        mock_usecase.execute.side_effect = Exception("unexpected")
-
-        mock_container = MagicMock()
-        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
-
-        payload = [
-            {"nom": "Réception", "categorie": "ENTREE"},
-            {"nom": "Entretien", "categorie": "EN_COURS"},
-            {"nom": "Refus", "categorie": "REFUS"},
-            {"nom": "Recrutement", "categorie": "ACCEPTE"},
-        ]
-
-        response = authenticated_client.put(ETAPES_URL, payload, format="json")
-
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert response.json() == {"error": "Unexpected error"}
-
-    @patch("presentation.recruteur.views.organismes.recruteur_container")
     def test_forwards_est_staff_to_usecase(
-        self, mock_recruteur_container, authenticated_client, test_user
+        self, container, authenticated_client, test_user
     ):
         test_user.is_staff = True
         test_user.save()
 
         mock_usecase = MagicMock()
         mock_usecase.execute.return_value = OrganismeRecruteurFactory.create_entity()
+        container.update_organisme_steps_usecase.return_value = mock_usecase
 
-        mock_container = MagicMock()
-        mock_container.update_organisme_steps_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
-
-        payload = [
-            {"nom": "Réception", "categorie": "ENTREE"},
-            {"nom": "Entretien", "categorie": "EN_COURS"},
-            {"nom": "Refus", "categorie": "REFUS"},
-            {"nom": "Recrutement", "categorie": "ACCEPTE"},
-        ]
-
-        authenticated_client.put(ETAPES_URL, payload, format="json")
+        authenticated_client.put(ETAPES_URL, VALID_ETAPES_PAYLOAD, format="json")
 
         command = mock_usecase.execute.call_args.args[0]
         assert command.est_staff is True

--- a/src/web/tests/presentation/recruteur/test_views_recrutements.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutements.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
+import pytest
 from django.urls import reverse
 from faker import Faker
 from rest_framework import status
@@ -55,23 +56,26 @@ UNKNOWN_RECRUTEMENT_LISTE_URL = reverse(
 )
 
 
+@pytest.fixture
+def container():
+    with patch("presentation.recruteur.views.recrutements.recruteur_container") as mock:
+        instance = MagicMock()
+        mock.return_value = instance
+        yield instance
+
+
 class TestRecrutementsActifsView:
     def test_anonymous_access_is_unauthorized(self, api_client):
         response = api_client.get(RECRUTEMENTS_ACTIFS_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    @patch("presentation.recruteur.views.recrutements.recruteur_container")
-    def test_pagination_second_page(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_container = MagicMock()
-        mock_usecase = mock_container.lister_mes_recrutements_usecase.return_value
+    def test_pagination_second_page(self, container, authenticated_client):
+        mock_usecase = container.lister_mes_recrutements_usecase.return_value
         mock_usecase.execute.return_value = MagicMock()
         mock_usecase.execute.return_value.count.return_value = 6
         mock_usecase.execute.return_value.slice.return_value = [
             RecrutementFactory.create_actif_read_model() for _ in range(2)
         ]
-        mock_recruteur_container.return_value = mock_container
 
         response = authenticated_client.get(RECRUTEMENTS_ACTIFS_URL + "?size=2&page=2")
         assert response.status_code == status.HTTP_200_OK
@@ -80,12 +84,8 @@ class TestRecrutementsActifsView:
         assert data["next"] is not None
         assert data["previous"] is not None
 
-    @patch("presentation.recruteur.views.recrutements.recruteur_container")
-    def test_candidatures_structure(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_container = MagicMock()
-        mock_usecase = mock_container.lister_mes_recrutements_usecase.return_value
+    def test_candidatures_structure(self, container, authenticated_client):
+        mock_usecase = container.lister_mes_recrutements_usecase.return_value
         mock_usecase.execute.return_value = MagicMock()
         mock_usecase.execute.return_value.count.return_value = 1
         mock_usecase.execute.return_value.slice.return_value = [
@@ -93,7 +93,6 @@ class TestRecrutementsActifsView:
                 candidatures=CandidaturesCompteurDto(total=5, a_traiter=2, en_cours=1),
             )
         ]
-        mock_recruteur_container.return_value = mock_container
 
         response = authenticated_client.get(RECRUTEMENTS_ACTIFS_URL)
         data = response.json()
@@ -102,10 +101,8 @@ class TestRecrutementsActifsView:
         assert "a_traiter" in candidatures
         assert "en_cours" in candidatures
 
-    @patch("presentation.recruteur.views.recrutements.recruteur_container")
-    def test_returns_actifs(self, mock_recruteur_container, authenticated_client):
-        mock_container = MagicMock()
-        mock_usecase = mock_container.lister_mes_recrutements_usecase.return_value
+    def test_returns_actifs(self, container, authenticated_client):
+        mock_usecase = container.lister_mes_recrutements_usecase.return_value
         mock_usecase.execute.return_value = MagicMock()
         mock_usecase.execute.return_value.count.return_value = 1
         mock_usecase.execute.return_value.slice.return_value = [
@@ -116,7 +113,6 @@ class TestRecrutementsActifsView:
                 agents=[AgentDto(nom="Marie Dupont")],
             )
         ]
-        mock_recruteur_container.return_value = mock_container
 
         response = authenticated_client.get(RECRUTEMENTS_ACTIFS_URL)
         assert response.status_code == status.HTTP_200_OK
@@ -132,16 +128,10 @@ class TestRecrutementsActifsView:
         assert "derniere_activite" in first
         assert "candidatures" in first
 
-    @patch("presentation.recruteur.views.recrutements.recruteur_container")
-    def test_returns_404_for_unknown_organisme(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_returns_404_for_unknown_organisme(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = OrganismeNexistePas("not found")
-
-        mock_container = MagicMock()
-        mock_container.lister_mes_recrutements_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.lister_mes_recrutements_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(RECRUTEMENTS_ACTIFS_URL)
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -183,18 +173,13 @@ class TestRecrutementsArchivesView:
         response = api_client.get(RECRUTEMENTS_ARCHIVES_URL)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    @patch("presentation.recruteur.views.recrutements.recruteur_container")
-    def test_pagination_second_page(
-        self, mock_recruteur_container, authenticated_client
-    ):
-        mock_container = MagicMock()
-        mock_usecase = mock_container.lister_mes_recrutements_usecase.return_value
+    def test_pagination_second_page(self, container, authenticated_client):
+        mock_usecase = container.lister_mes_recrutements_usecase.return_value
         mock_usecase.execute.return_value = MagicMock()
         mock_usecase.execute.return_value.count.return_value = 3
         mock_usecase.execute.return_value.slice.return_value = [
             RecrutementFactory.create_archive_read_model() for _ in range(2)
         ]
-        mock_recruteur_container.return_value = mock_container
 
         response = authenticated_client.get(
             RECRUTEMENTS_ARCHIVES_URL + "?size=2&page=1"
@@ -205,10 +190,8 @@ class TestRecrutementsArchivesView:
         assert data["next"] is not None
         assert data["previous"] is None
 
-    @patch("presentation.recruteur.views.recrutements.recruteur_container")
-    def test_returns_archives(self, mock_recruteur_container, authenticated_client):
-        mock_container = MagicMock()
-        mock_usecase = mock_container.lister_mes_recrutements_usecase.return_value
+    def test_returns_archives(self, container, authenticated_client):
+        mock_usecase = container.lister_mes_recrutements_usecase.return_value
         mock_usecase.execute.return_value = MagicMock()
         mock_usecase.execute.return_value.count.return_value = 1
         mock_usecase.execute.return_value.slice.return_value = [
@@ -221,7 +204,6 @@ class TestRecrutementsArchivesView:
                 recrute="Sophie Leblanc",
             )
         ]
-        mock_recruteur_container.return_value = mock_container
 
         response = authenticated_client.get(RECRUTEMENTS_ARCHIVES_URL)
         assert response.status_code == status.HTTP_200_OK
@@ -237,16 +219,10 @@ class TestRecrutementsArchivesView:
         assert "finalise" in first
         assert "recrute" in first
 
-    @patch("presentation.recruteur.views.recrutements.recruteur_container")
-    def test_returns_404_for_unknown_organisme(
-        self, mock_recruteur_container, authenticated_client
-    ):
+    def test_returns_404_for_unknown_organisme(self, container, authenticated_client):
         mock_usecase = MagicMock()
         mock_usecase.execute.side_effect = OrganismeNexistePas("not found")
-
-        mock_container = MagicMock()
-        mock_container.lister_mes_recrutements_usecase.return_value = mock_usecase
-        mock_recruteur_container.return_value = mock_container
+        container.lister_mes_recrutements_usecase.return_value = mock_usecase
 
         response = authenticated_client.get(RECRUTEMENTS_ARCHIVES_URL)
         assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
💡 prerquis : #1002 + #1020

## 📝 Description
🎸 Refactoring pur des tests de présentation recruteur, sans changement de code applicatif. Trois fichiers concernés : test_views_notes.py, test_views_organismes.py, test_views_recrutements.py.

## 🏷️ Type de changement
- [x] ♻️ Refactorisation

## 🔧 Modifications

### Remplacement du @patch("...recruteur_container") 
- répété sur chaque méthode de test  par une fixture pytest container partagée

### Ajout d'un helper etapes_as_json() et d'une constante VALID_ETAPES_PAYLOAD
- éviter la duplication de la sérialisation attendue des étapes et du payload valide répété dans plusieurs tests PUT.

### corrections mineures
- UUID(existing_uuid) au lieu de UUID(str(existing_uuid)) (redondant)
- len(data) == len(payload) au lieu d'un magique == 3.

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
