### PR TITLE
🐛(tooling) skip whitenoise processing for already vite processed assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ COMPOSE_UP              = $(COMPOSE) up -d --remove-orphans
 WEB_PNPM = cd src/web && pnpm
 WEB_UV = cd src/web && direnv exec .
 WEB_INTERNAL_API_UV = cd src/web && DJANGO_SETTINGS_MODULE=config.settings.schema_internal direnv exec .
+WEB_PROD_UV = cd src/web && DJANGO_SETTINGS_MODULE=config.settings.base direnv exec .
 OCR_UV = cd src/ocr && direnv exec .
 INGESTION_UV = cd src/ingestion && direnv exec .
 NOTEBOOK_UV = cd src/notebook && direnv exec .
@@ -282,6 +283,14 @@ dev: ## run web with sass watch and browser auto-reload
 	bin/sass watch & \
 	bin/manage runserver
 .PHONY: dev
+
+emulate-prod: ## build front + collectstatic + run web with prod settings on :8001 (reproduce production-only bugs)
+	@echo "🏗️  Émulation prod : build front + collectstatic + runserver :8001 (settings.base, DEBUG=False)…"
+	@echo "   Ctrl+C pour arrêter"
+	$(WEB_PNPM) --filter $(FRONTEND_FILTER) exec vite build --mode production
+	$(WEB_PROD_UV) python manage.py collectstatic --noinput --clear
+	$(WEB_PROD_UV) env WEB_ALLOWED_HOSTS=localhost,127.0.0.1 python manage.py runserver 8001 --noreload
+.PHONY: emulate-prod
 
 run-mvp: ## run web + ocr + ingestion + huey with unified logs
 	@echo "🚀 Démarrage des services frontend web + ocr + ingestion…"

--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -197,8 +197,7 @@ STATIC_ROOT = BASE_DIR / "static_collected"
 
 STORAGES = {
     "staticfiles": {
-        # TODO - reactivate Manifest
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        "BACKEND": "config.storages.ViteCompressedManifestStaticFilesStorage",
     },
 }
 

--- a/src/web/config/storages.py
+++ b/src/web/config/storages.py
@@ -1,0 +1,8 @@
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+
+class ViteCompressedManifestStaticFilesStorage(CompressedManifestStaticFilesStorage):
+    def hashed_name(self, name, content=None, filename=None):
+        if name.startswith("frontend/"):
+            return name
+        return super().hashed_name(name, content, filename)

--- a/src/web/tests/utils/test_storages.py
+++ b/src/web/tests/utils/test_storages.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+from config.storages import ViteCompressedManifestStaticFilesStorage
+
+
+def test_frontend_assets_keep_their_vite_hash():
+    storage = ViteCompressedManifestStaticFilesStorage()
+    name = "frontend/assets/main-Cd5DptNt.js"
+
+    assert storage.hashed_name(name) == name
+
+
+def test_non_frontend_assets_are_django_hashed():
+    storage = ViteCompressedManifestStaticFilesStorage()
+    name = "dsfr/dist/dsfr.min.css"
+    hashed = "dsfr/dist/dsfr.min.abc123.css"
+
+    with patch.object(
+        CompressedManifestStaticFilesStorage,
+        "hashed_name",
+        return_value=hashed,
+    ) as super_hashed_name:
+        result = storage.hashed_name(name)
+
+    super_hashed_name.assert_called_once_with(name, None, None)
+    assert result == hashed


### PR DESCRIPTION
## 📝 Description
🎸 En prod, depuis #985, le premier clic de navigation depuis l'accueil de l'ats était avalé (l'URL changeait puis revenait, la vue restait figée), le second fonctionnait.

Ça révèle un flaw préexistant et assez dur à identifier : whitenoise re-hashe les assets Vite déjà hashés sans réécrire les imports internes des chunks js. Le chunk d'entrée existait donc sous deux URLs : le nom hashé 2x chargé par le template, et le nom Vite original importé par les chunks lazy. Au premier clic, le navigateur chargeait la seconde URL comme un nouveau module : main.ts s'exécutait une deuxième fois, une seconde app et un second router se montaient sur #ats-app, et la navigation initiale de ce second router écrasait celle du clic (replaceState vers /).

Fix proposé : on sort frontend/ du hash Django

Ajoute aussi un script makefile pour reproduire au plus près la config de prod localement, qui a aussi permi d'investiguer le bug résolu dans #1001 qui n'existait qu'en prod :

```makefile
make emulate-prod
```

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [x] 🔧 Changement technique

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [ ] 👀 J’ai demandé une revue à une personne de l’équipe.
