### PR TITLE
✨(identite-domain) Mise en place du RBAC sur la creation d'un organisme

### DIFF
--- a/src/web/application/identite/usecases/create_organisme.py
+++ b/src/web/application/identite/usecases/create_organisme.py
@@ -35,7 +35,7 @@ class CreateOrganismeUsecase(IUseCase[CreateOrganismeCommand, Organisme]):
         self.permission_service = permission_service
 
     def execute(self, input_data: CreateOrganismeCommand) -> Organisme:
-        self.permission_service.est_autorise(est_staff=input_data.est_staff)
+        self.permission_service.verifier_autorisation(est_staff=input_data.est_staff)
         organisme = Organisme.create(
             nom=input_data.nom,
             versant=input_data.versant,

--- a/src/web/application/identite/usecases/create_organisme.py
+++ b/src/web/application/identite/usecases/create_organisme.py
@@ -9,6 +9,9 @@ from domain.identite.entities.organisme import Organisme
 from domain.identite.repositories.organisme_repository_interface import (
     IOrganismeRepository,
 )
+from domain.identite.services.identite_permission_service import (
+    OrganismeCreationPermissionService,
+)
 from domain.identite.value_objects.siret import SIRET
 
 
@@ -19,13 +22,20 @@ class CreateOrganismeCommand:
     localisation: Localisation | None
     siret: SIRET | None
     parent_id: UUID | None
+    est_staff: bool = False
 
 
 class CreateOrganismeUsecase(IUseCase[CreateOrganismeCommand, Organisme]):
-    def __init__(self, organisme_repository: IOrganismeRepository):
+    def __init__(
+        self,
+        organisme_repository: IOrganismeRepository,
+        permission_service: OrganismeCreationPermissionService,
+    ):
         self.organisme_repository = organisme_repository
+        self.permission_service = permission_service
 
     def execute(self, input_data: CreateOrganismeCommand) -> Organisme:
+        self.permission_service.est_autorise(est_staff=input_data.est_staff)
         organisme = Organisme.create(
             nom=input_data.nom,
             versant=input_data.versant,

--- a/src/web/domain/identite/errors/organisme_permission_errors.py
+++ b/src/web/domain/identite/errors/organisme_permission_errors.py
@@ -1,0 +1,10 @@
+from ddd.domain_errors import DomainError
+
+
+class OrganismePermissionError(DomainError):
+    pass
+
+
+class CreationOrganismeRefusee(OrganismePermissionError):
+    def __init__(self):
+        super().__init__("Seul un membre du staff peut créer un organisme")

--- a/src/web/domain/identite/services/identite_permission_service.py
+++ b/src/web/domain/identite/services/identite_permission_service.py
@@ -1,0 +1,9 @@
+from domain.identite.errors.organisme_permission_errors import CreationOrganismeRefusee
+
+
+# TODO : refactor into a generic IdentitePermissionService fed with
+# an IdentiteAction enum (mirroring OrganismeAction/_ROLES_REQUIS in recruteur)
+class OrganismeCreationPermissionService:
+    def est_autorise(self, *, est_staff: bool) -> None:
+        if not est_staff:
+            raise CreationOrganismeRefusee()

--- a/src/web/domain/identite/services/identite_permission_service.py
+++ b/src/web/domain/identite/services/identite_permission_service.py
@@ -4,6 +4,6 @@ from domain.identite.errors.organisme_permission_errors import CreationOrganisme
 # TODO : refactor into a generic IdentitePermissionService fed with
 # an IdentiteAction enum (mirroring OrganismeAction/_ROLES_REQUIS in recruteur)
 class OrganismeCreationPermissionService:
-    def est_autorise(self, *, est_staff: bool) -> None:
+    def verifier_autorisation(self, *, est_staff: bool) -> None:
         if not est_staff:
             raise CreationOrganismeRefusee()

--- a/src/web/infrastructure/di/identite/identite_container.py
+++ b/src/web/infrastructure/di/identite/identite_container.py
@@ -10,6 +10,9 @@ from application.identite.usecases.log_utilisateur_connexion import (
     LogUtilisateurConnexionUsecase,
 )
 from domain.commons.services.audit_log_writer import AuditLogWriter
+from domain.identite.services.identite_permission_service import (
+    OrganismeCreationPermissionService,
+)
 from infrastructure.repositories.commons.postgres_audit_log_repository import (
     PostgresAuditLogRepository,
 )
@@ -63,7 +66,12 @@ class IdentiteContainer(containers.DeclarativeContainer):
         LogUtilisateurConnexionUsecase, audit_log_writer=audit_log_writer
     )
 
+    organisme_creation_permission_service = providers.Factory(
+        OrganismeCreationPermissionService
+    )
+
     create_organisme_usecase = providers.Factory(
         CreateOrganismeUsecase,
         organisme_repository=postgres_organisme_repository,
+        permission_service=organisme_creation_permission_service,
     )

--- a/src/web/infrastructure/django_apps/recruteur/admin.py
+++ b/src/web/infrastructure/django_apps/recruteur/admin.py
@@ -101,6 +101,7 @@ class OrganismeAdmin(admin.ModelAdmin):
                 localisation=localisation,
                 siret=SIRET(siret_raw),
                 parent_id=form.cleaned_data.get("parent_id"),
+                est_staff=request.user.is_staff,
             )
             container = create_identite_container()
             organisme = container.create_organisme_usecase().execute(command)

--- a/src/web/tests/application/identite/test_create_organisme.py
+++ b/src/web/tests/application/identite/test_create_organisme.py
@@ -1,6 +1,10 @@
+import pytest
 from referentiel.value_objects.verse import Verse
 
 from application.identite.usecases.create_organisme import CreateOrganismeCommand
+from domain.identite.errors.organisme_permission_errors import (
+    CreationOrganismeRefusee,
+)
 from domain.identite.events.organisme_events import OrganismeCree
 
 
@@ -11,6 +15,7 @@ def test_create_organisme_success(create_organisme_usecase):
         localisation=None,
         siret=None,
         parent_id=None,
+        est_staff=True,
     )
 
     organisme = create_organisme_usecase.execute(input_data=command)
@@ -20,3 +25,17 @@ def test_create_organisme_success(create_organisme_usecase):
     assert isinstance(events[0], OrganismeCree)
     assert organisme.nom == "Commune de Paris"
     assert organisme.versant == Verse.FPT
+
+
+def test_create_organisme_refuse_non_staff(create_organisme_usecase):
+    command = CreateOrganismeCommand(
+        nom="Commune de Paris",
+        versant=Verse.FPT,
+        localisation=None,
+        siret=None,
+        parent_id=None,
+        est_staff=False,
+    )
+
+    with pytest.raises(CreationOrganismeRefusee):
+        create_organisme_usecase.execute(input_data=command)

--- a/src/web/tests/infrastructure/identite/test_create_organisme.py
+++ b/src/web/tests/infrastructure/identite/test_create_organisme.py
@@ -29,6 +29,7 @@ def test_create_organisme(identite_integration_container):
         localisation=None,
         siret=SIRET("19754687200015"),
         parent_id=None,
+        est_staff=True,
     )
 
     organisme = identite_integration_container.create_organisme_usecase().execute(
@@ -49,6 +50,7 @@ def test_create_organisme_avec_siret(identite_integration_container):
         localisation=None,
         siret=SIRET("19754687200015"),
         parent_id=None,
+        est_staff=True,
     )
 
     organisme = identite_integration_container.create_organisme_usecase().execute(

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -68,6 +68,9 @@ from domain.identite.repositories.organisme_repository_interface import (
 from domain.identite.repositories.utilisateur_repository_interface import (
     IUtilisateurRepository,
 )
+from domain.identite.services.identite_permission_service import (
+    OrganismeCreationPermissionService,
+)
 from domain.ingestion.entities.document import DocumentType
 from domain.ingestion.exceptions.document_error import UnsupportedDocumentTypeError
 from domain.ingestion.repositories.document_repository_interface import (
@@ -510,7 +513,10 @@ def create_organisme_usecase():
     organisme_repository = cast(
         IOrganismeRepository, create_interface_aware_mock(IOrganismeRepository)
     )
-    return CreateOrganismeUsecase(organisme_repository=organisme_repository)
+    return CreateOrganismeUsecase(
+        organisme_repository=organisme_repository,
+        permission_service=OrganismeCreationPermissionService(),
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## 📝 Description
🎸 Un résumé clair et concis des changements. Quel problème cette PR résout-elle ?

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
- Ajout d'un service de domain/identite/services/identite_permission_service.py, qui n'autorise la création d'un organisme qu'aux utilisateurs staff (est_staff=True), sans dépendance à un rôle ou à un organisme existant (aucun organisme n'existe encore à la création).
- CreateOrganismeCommand porte désormais un champ est_staff: bool = False, vérifié en première ligne de execute().
- L'admin Django (OrganismeAdmin.save_model) transmet est_staff=request.user.is_staff à la commande.

Ce service est volontairement simple (booléen unique) plutôt que basé sur une action générique comme OrganismePermissionService du contexte recruteur : un seul cas d'usage est concerné pour l'instant et la règle ne varie pas selon une action. Un TODO documente la piste de généralisation.


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
