### PR TITLE
✨(recrutement-application) Mise en place RBAC agent pour la liste des recrutements

### DIFF
--- a/src/web/application/recruteur/services/recrutement_query_service_interface.py
+++ b/src/web/application/recruteur/services/recrutement_query_service_interface.py
@@ -11,8 +11,8 @@ from application.recruteur.dtos.recrutement_read_models import (
 
 class IRecrutementQueryService(Protocol):
     def get_actifs_by_organisme(
-        self, organisme_id: UUID
+        self, organisme_id: UUID, agent_id: UUID | None = None
     ) -> IPage[RecrutementActifsReadModel]: ...
     def get_archives_by_organisme(
-        self, organisme_id: UUID
+        self, organisme_id: UUID, agent_id: UUID | None = None
     ) -> IPage[RecrutementArchivesReadModel]: ...

--- a/src/web/application/recruteur/usecases/lister_mes_recrutements.py
+++ b/src/web/application/recruteur/usecases/lister_mes_recrutements.py
@@ -17,6 +17,7 @@ from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from domain.recruteur.value_objects.statut_recrutement import StatutRecrutement
 
 
@@ -49,12 +50,11 @@ class ListerMesRecrutementsUsecase(
     def execute(
         self, query: ListerMesRecrutementsQuery
     ) -> IPage[RecrutementActifsReadModel] | IPage[RecrutementArchivesReadModel]:
-        # TODO : handle list of recruitments which agent has a role on
         self.logger.info(
             f"List mes recrutements pour l'organisme_id={query.organisme_id}",
         )
 
-        self.organisme_permission_service.est_autorise(
+        role = self.organisme_permission_service.est_autorise(
             action=OrganismeAction.LISTER_MES_RECRUTEMENTS,
             organisme_id=query.organisme_id,
             agent_id=query.utilisateur_id,
@@ -62,10 +62,14 @@ class ListerMesRecrutementsUsecase(
         )
         self.organisme_repository.get_by_id(query.organisme_id)
 
+        agent_id_filtre = (
+            None if role == AgentOrganismeRole.RESPONSABLE else query.utilisateur_id
+        )
+
         if query.statut == StatutRecrutement.ACTIF:
             return self.recrutement_query_service.get_actifs_by_organisme(
-                query.organisme_id
+                query.organisme_id, agent_id_filtre
             )
         return self.recrutement_query_service.get_archives_by_organisme(
-            query.organisme_id
+            query.organisme_id, agent_id_filtre
         )

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -7,11 +7,15 @@ from domain.recruteur.repositories.organisme_agent_repository_interface import (
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
 
-_ROLES_REQUIS: dict[OrganismeAction, AgentOrganismeRole] = {
-    OrganismeAction.GET_ORGANISME: AgentOrganismeRole.RESPONSABLE,
-    OrganismeAction.INITIALIZE_ORGANISME_STEPS: AgentOrganismeRole.RESPONSABLE,
-    OrganismeAction.UPDATE_ORGANISME_STEPS: AgentOrganismeRole.RESPONSABLE,
-    OrganismeAction.LISTER_MES_RECRUTEMENTS: AgentOrganismeRole.RESPONSABLE,
+_ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
+    OrganismeAction.GET_ORGANISME: frozenset({AgentOrganismeRole.RESPONSABLE}),
+    OrganismeAction.INITIALIZE_ORGANISME_STEPS: frozenset(
+        {AgentOrganismeRole.RESPONSABLE}
+    ),
+    OrganismeAction.UPDATE_ORGANISME_STEPS: frozenset({AgentOrganismeRole.RESPONSABLE}),
+    OrganismeAction.LISTER_MES_RECRUTEMENTS: frozenset(
+        {AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE}
+    ),
 }
 
 
@@ -26,12 +30,13 @@ class OrganismePermissionService:
         organisme_id: UUID,
         agent_id: UUID,
         est_staff: bool,
-    ) -> None:
+    ) -> AgentOrganismeRole | None:
         if est_staff:
-            return
-        role_requis = _ROLES_REQUIS[action]
+            return None
+        roles_requis = _ROLES_REQUIS[action]
         role = self._organisme_agent_repository.get_role(
             organisme_id=organisme_id, agent_id=agent_id
         )
-        if role != role_requis:
+        if role not in roles_requis:
             raise AccesOrganismeRefuse(organisme_id)
+        return role

--- a/src/web/infrastructure/factories/recruteur/recrutement_factory.py
+++ b/src/web/infrastructure/factories/recruteur/recrutement_factory.py
@@ -95,6 +95,7 @@ class RecrutementFactory:
     @staticmethod
     def create_model(
         offre_id: UUID | None = None,
+        offre_archivee: bool = False,
         organisme_id: UUID | None = None,
         etapes: tuple[EtapeRecrutement, ...] | None = None,
         ordre_etapes: list[str] | None = None,
@@ -102,7 +103,8 @@ class RecrutementFactory:
         agent_roles: dict[UUID, AgentRecrutementRole] | None = None,
     ) -> RecrutementModel:
         if offre_id is None:
-            offre_id = OfferFactory.create_model().id
+            archived_at = datetime(2024, 1, 1) if offre_archivee else None
+            offre_id = OfferFactory.create_model(archived_at=archived_at).id
         if organisme_id is None:
             organisme_id = OrganismeFactory.create_model().id
         if etapes is None:

--- a/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
+++ b/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
@@ -28,13 +28,17 @@ from infrastructure.mappers.queryset_page import QuerySetPage
 
 class PostgresRecrutementQueryService(IRecrutementQueryService):
     def get_actifs_by_organisme(
-        self, organisme_id: UUID
+        self, organisme_id: UUID, agent_id: UUID | None = None
     ) -> QuerySetPage[RecrutementActifsReadModel]:
+        filters: dict = {
+            "organisme_id": organisme_id,
+            "offre__archived_at__isnull": True,
+        }
+        if agent_id is not None:
+            filters["agents_liaisons__agent_id"] = str(agent_id)
+
         qs = (
-            RecrutementModel.objects.filter(
-                organisme_id=organisme_id,
-                offre__archived_at__isnull=True,
-            )
+            RecrutementModel.objects.filter(**filters)
             .select_related("offre")
             .prefetch_related(
                 Prefetch(
@@ -91,13 +95,17 @@ class PostgresRecrutementQueryService(IRecrutementQueryService):
         return QuerySetPage(qs, mapper=_mapper)
 
     def get_archives_by_organisme(
-        self, organisme_id: UUID
+        self, organisme_id: UUID, agent_id: UUID | None = None
     ) -> QuerySetPage[RecrutementArchivesReadModel]:
+        filters: dict = {
+            "organisme_id": organisme_id,
+            "offre__archived_at__isnull": False,
+        }
+        if agent_id is not None:
+            filters["agents_liaisons__agent_id"] = str(agent_id)
+
         qs = (
-            RecrutementModel.objects.filter(
-                organisme_id=organisme_id,
-                offre__archived_at__isnull=False,
-            )
+            RecrutementModel.objects.filter(**filters)
             .select_related("offre")
             .prefetch_related(
                 Prefetch(

--- a/src/web/tests/application/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/application/recruteur/test_lister_mes_recrutements.py
@@ -72,7 +72,7 @@ class TestListerMesRecrutements:
         )
 
         assert result == recrutements_actifs
-        service.get_actifs_by_organisme.assert_called_once_with(organisme_id)
+        service.get_actifs_by_organisme.assert_called_once_with(organisme_id, None)
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_lister_mes_recrutements_archives(
@@ -93,7 +93,7 @@ class TestListerMesRecrutements:
         )
 
         assert result == recrutements_archives
-        service.get_archives_by_organisme.assert_called_once_with(organisme_id)
+        service.get_archives_by_organisme.assert_called_once_with(organisme_id, None)
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_raise_organisme_not_found(self, service, organisme_repository, usecase):

--- a/src/web/tests/application/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/application/recruteur/test_lister_mes_recrutements.py
@@ -17,6 +17,7 @@ from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRe
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from domain.recruteur.value_objects.statut_recrutement import StatutRecrutement
 from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
 from tests.utils.interface_aware_mock import create_interface_aware_mock
@@ -38,7 +39,9 @@ def organisme_repository_fixture():
 
 @pytest.fixture(name="organisme_permission_service")
 def organisme_permission_service_fixture():
-    return MagicMock(spec=OrganismePermissionService)
+    service = MagicMock(spec=OrganismePermissionService)
+    service.est_autorise.return_value = AgentOrganismeRole.RESPONSABLE
+    return service
 
 
 @pytest.fixture(name="usecase")
@@ -95,6 +98,56 @@ class TestListerMesRecrutements:
         assert result == recrutements_archives
         service.get_archives_by_organisme.assert_called_once_with(organisme_id, None)
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
+
+    def test_lister_mes_recrutements_actifs_filtre_par_agent_quand_membre(
+        self, service, organisme_repository, organisme_permission_service, usecase
+    ):
+        organisme_id = uuid4()
+        utilisateur_id = uuid4()
+        organisme_permission_service.est_autorise.return_value = (
+            AgentOrganismeRole.MEMBRE
+        )
+        recrutements_actifs = [RecrutementFactory.create_actif_read_model()]
+        service.get_actifs_by_organisme = MagicMock(return_value=recrutements_actifs)
+
+        result = usecase.execute(
+            ListerMesRecrutementsQuery(
+                organisme_id=organisme_id,
+                statut=StatutRecrutement.ACTIF,
+                utilisateur_id=utilisateur_id,
+            )
+        )
+
+        assert result == recrutements_actifs
+        service.get_actifs_by_organisme.assert_called_once_with(
+            organisme_id, utilisateur_id
+        )
+
+    def test_lister_mes_recrutements_archives_filtre_par_agent_quand_membre(
+        self, service, organisme_repository, organisme_permission_service, usecase
+    ):
+        organisme_id = uuid4()
+        utilisateur_id = uuid4()
+        organisme_permission_service.est_autorise.return_value = (
+            AgentOrganismeRole.MEMBRE
+        )
+        recrutements_archives = [RecrutementFactory.create_archive_read_model()]
+        service.get_archives_by_organisme = MagicMock(
+            return_value=recrutements_archives
+        )
+
+        result = usecase.execute(
+            ListerMesRecrutementsQuery(
+                organisme_id=organisme_id,
+                statut=StatutRecrutement.ARCHIVE,
+                utilisateur_id=utilisateur_id,
+            )
+        )
+
+        assert result == recrutements_archives
+        service.get_archives_by_organisme.assert_called_once_with(
+            organisme_id, utilisateur_id
+        )
 
     def test_raise_organisme_not_found(self, service, organisme_repository, usecase):
         organisme_id = uuid4()

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -21,13 +21,14 @@ def test_est_autorise_passes_when_agent_is_responsable() -> None:
     repository.get_role.return_value = AgentOrganismeRole.RESPONSABLE
     service = OrganismePermissionService(organisme_agent_repository=repository)
 
-    service.est_autorise(
+    result = service.est_autorise(
         action=OrganismeAction.GET_ORGANISME,
         organisme_id=organisme_id,
         agent_id=agent_id,
         est_staff=False,
     )
 
+    assert result == AgentOrganismeRole.RESPONSABLE
     repository.get_role.assert_called_once_with(
         organisme_id=organisme_id, agent_id=agent_id
     )
@@ -75,7 +76,10 @@ def test_verifier_responsable_passes_when_staff_even_if_not_responsable() -> Non
     repository.get_role.assert_not_called()
 
 
-@pytest.mark.parametrize("action", list(OrganismeAction))
+@pytest.mark.parametrize(
+    "action",
+    [a for a in OrganismeAction if a != OrganismeAction.LISTER_MES_RECRUTEMENTS],
+)
 def test_every_organisme_action_currently_requires_responsable(
     action: OrganismeAction,
 ) -> None:
@@ -86,6 +90,50 @@ def test_every_organisme_action_currently_requires_responsable(
     with pytest.raises(AccesOrganismeRefuse):
         service.est_autorise(
             action=action,
+            organisme_id=uuid4(),
+            agent_id=uuid4(),
+            est_staff=False,
+        )
+
+
+def test_lister_mes_recrutements_allows_responsable() -> None:
+    repository = Mock(spec=IOrganismeAgentRepository)
+    repository.get_role.return_value = AgentOrganismeRole.RESPONSABLE
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    result = service.est_autorise(
+        action=OrganismeAction.LISTER_MES_RECRUTEMENTS,
+        organisme_id=uuid4(),
+        agent_id=uuid4(),
+        est_staff=False,
+    )
+
+    assert result == AgentOrganismeRole.RESPONSABLE
+
+
+def test_lister_mes_recrutements_allows_membre() -> None:
+    repository = Mock(spec=IOrganismeAgentRepository)
+    repository.get_role.return_value = AgentOrganismeRole.MEMBRE
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    result = service.est_autorise(
+        action=OrganismeAction.LISTER_MES_RECRUTEMENTS,
+        organisme_id=uuid4(),
+        agent_id=uuid4(),
+        est_staff=False,
+    )
+
+    assert result == AgentOrganismeRole.MEMBRE
+
+
+def test_lister_mes_recrutements_raises_when_no_role() -> None:
+    repository = Mock(spec=IOrganismeAgentRepository)
+    repository.get_role.return_value = None
+    service = OrganismePermissionService(organisme_agent_repository=repository)
+
+    with pytest.raises(AccesOrganismeRefuse):
+        service.est_autorise(
+            action=OrganismeAction.LISTER_MES_RECRUTEMENTS,
             organisme_id=uuid4(),
             agent_id=uuid4(),
             est_staff=False,

--- a/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
@@ -4,11 +4,13 @@ from application.recruteur.usecases.lister_mes_recrutements import (
     ListerMesRecrutementsQuery,
 )
 from config.app_config import AppConfig
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
 from domain.recruteur.value_objects.roles import (
     AgentOrganismeRole,
+    AgentRecrutementRole,
 )
 from domain.recruteur.value_objects.statut_recrutement import (
     StatutRecrutement,
@@ -122,3 +124,94 @@ class TestListerMesRecrutements:
         assert items[0].finalise is True
         assert items[0].recrute is not None
         assert items[0].recrute != ""
+
+
+@pytest.mark.parametrize("statut", [StatutRecrutement.ACTIF, StatutRecrutement.ARCHIVE])
+class TestListerMesRecrutementsRbac:
+    def _create_recrutements(self, agent, organisme, statut):
+        offre_archivee = statut == StatutRecrutement.ARCHIVE
+
+        recrutement_in_org = RecrutementFactory.create_model(
+            offre_archivee=offre_archivee, organisme_id=organisme.id
+        )
+        recrutement_in_org_with_role = RecrutementFactory.create_model(
+            offre_archivee=offre_archivee,
+            organisme_id=organisme.id,
+            agent_ids=(agent.utilisateur_id,),
+            agent_roles={agent.utilisateur_id: AgentRecrutementRole.CONTRIBUTEUR},
+        )
+        recrutement_in_other_org = RecrutementFactory.create_model(
+            offre_archivee=offre_archivee
+        )
+        recrutement_in_other_org_with_role = RecrutementFactory.create_model(
+            offre_archivee=offre_archivee,
+            agent_ids=(agent.utilisateur_id,),
+            agent_roles={agent.utilisateur_id: AgentRecrutementRole.CONTRIBUTEUR},
+        )
+        return (
+            recrutement_in_org,
+            recrutement_in_org_with_role,
+            recrutement_in_other_org,
+            recrutement_in_other_org_with_role,
+        )
+
+    def _lister_recrutements(self, usecase, organisme, agent, statut):
+        return usecase.execute(
+            ListerMesRecrutementsQuery(
+                organisme_id=organisme.id,
+                statut=statut,
+                utilisateur_id=agent.utilisateur_id,
+            )
+        )
+
+    def test_responsable_organisme(self, usecase, statut):
+        agent = AgentFactory.create_model()
+        organisme = OrganismeFactory.create_model(
+            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        )
+        (
+            recrutement_in_org,
+            recrutement_in_org_with_role,
+            recrutement_in_other_org,
+            recrutement_in_other_org_with_role,
+        ) = self._create_recrutements(agent, organisme, statut)
+
+        results = self._lister_recrutements(usecase, organisme, agent, statut)
+
+        for recrutement in [recrutement_in_org, recrutement_in_org_with_role]:
+            assert recrutement in results._qs
+        for recrutement in [
+            recrutement_in_other_org,
+            recrutement_in_other_org_with_role,
+        ]:
+            assert recrutement not in results._qs
+
+    def test_membre_organisme(self, usecase, statut):
+        agent = AgentFactory.create_model()
+        organisme = OrganismeFactory.create_model(
+            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.MEMBRE
+        )
+        (
+            recrutement_in_org,
+            recrutement_in_org_with_role,
+            recrutement_in_other_org,
+            recrutement_in_other_org_with_role,
+        ) = self._create_recrutements(agent, organisme, statut)
+
+        results = self._lister_recrutements(usecase, organisme, agent, statut)
+
+        assert recrutement_in_org_with_role in results._qs
+        for recrutement in [
+            recrutement_in_org,
+            recrutement_in_other_org,
+            recrutement_in_other_org_with_role,
+        ]:
+            assert recrutement not in results._qs
+
+    def test_non_membre_organisme(self, usecase, statut):
+        agent = AgentFactory.create_model()
+        organisme = OrganismeFactory.create_model()
+        self._create_recrutements(agent, organisme, statut)
+
+        with pytest.raises(AccesOrganismeRefuse):
+            self._lister_recrutements(usecase, organisme, agent, statut)

--- a/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
@@ -1,18 +1,14 @@
-from datetime import datetime
-from unittest.mock import MagicMock
-from uuid import UUID, uuid4
-
 import pytest
 
 from application.recruteur.usecases.lister_mes_recrutements import (
     ListerMesRecrutementsQuery,
 )
 from config.app_config import AppConfig
-from domain.recruteur.services.organisme_permission_service import (
-    OrganismePermissionService,
-)
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
+)
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
 )
 from domain.recruteur.value_objects.statut_recrutement import (
     StatutRecrutement,
@@ -26,7 +22,6 @@ from infrastructure.factories.recruteur.etapes_recrutement_factory import (
     EtapeRecrutementFactory,
 )
 from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
-from infrastructure.factories.referentiel.offer_factory import OfferFactory
 from infrastructure.gateways.shared.logger import LoggerService
 
 
@@ -35,28 +30,40 @@ def recruteur_integration_container_fixture(db) -> RecruteurContainer:
     container = RecruteurContainer()
     container.app_config.override(AppConfig.from_django_settings())
     container.logger_service.override(LoggerService())
-    container.organisme_permission_service.override(
-        MagicMock(spec=OrganismePermissionService)
-    )
     return container
 
 
+@pytest.fixture(name="usecase")
+def usecase_fixture(recruteur_integration_container):
+    return recruteur_integration_container.lister_mes_recrutements_usecase()
+
+
 class TestListerMesRecrutements:
-    def test_lister_actifs(self, recruteur_integration_container):
-        usecase = recruteur_integration_container.lister_mes_recrutements_usecase()
-        organisme = OrganismeFactory.create_model()
-        offre_active = OfferFactory.create_model(archived_at=None)
-        offre_archivee = OfferFactory.create_model(archived_at=datetime(2024, 1, 1))
+    def _create_agent_responsable(self):
         agent = AgentFactory.create_model()
-        agent_id = UUID(agent.utilisateur_id)
+        organisme = OrganismeFactory.create_model(
+            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        )
+        return agent.utilisateur_id, organisme
+
+    def _lister_recrutements(self, usecase, organisme, agent_id, statut):
+        return usecase.execute(
+            ListerMesRecrutementsQuery(
+                organisme_id=organisme.id,
+                statut=statut,
+                utilisateur_id=agent_id,
+            )
+        )
+
+    def test_lister_actifs(self, usecase):
+        agent_id, organisme = self._create_agent_responsable()
         recrutement_actif = RecrutementFactory.create_model(
-            offre_id=offre_active.id,
             organisme_id=organisme.id,
             agent_ids=(agent_id,),
             etapes=EtapeRecrutementFactory.create_entities(),
         )
         RecrutementFactory.create_model(
-            offre_id=offre_archivee.id,
+            offre_archivee=True,
             organisme_id=organisme.id,
             agent_ids=(agent_id,),
         )
@@ -69,37 +76,31 @@ class TestListerMesRecrutements:
             categorie=CategorieEtapeRecrutement.EN_COURS.value,
         ).first()
 
-        CandidatureFactory.create_model(offre_id=offre_active.id, etape=etape_entree)
-        CandidatureFactory.create_model(offre_id=offre_active.id, etape=etape_en_cours)
+        CandidatureFactory.create_model(
+            offre_id=recrutement_actif.offre_id, etape=etape_entree
+        )
+        CandidatureFactory.create_model(
+            offre_id=recrutement_actif.offre_id, etape=etape_en_cours
+        )
 
-        result = usecase.execute(
-            ListerMesRecrutementsQuery(
-                organisme_id=organisme.id,
-                statut=StatutRecrutement.ACTIF,
-                utilisateur_id=uuid4(),
-            )
+        result = self._lister_recrutements(
+            usecase, organisme, agent_id, StatutRecrutement.ACTIF
         )
 
         items = list(result.slice(0, 10))
         assert len(items) == 1
-        assert items[0].offer_id == offre_active.id
+        assert items[0].offer_id == recrutement_actif.offre_id
         assert len(items[0].agents) == 1
         assert items[0].agents[0].nom != ""
         assert items[0].candidatures.total == 2  # noqa
         assert items[0].candidatures.a_traiter == 1
         assert items[0].candidatures.en_cours == 1
 
-    def test_lister_archives(self, recruteur_integration_container):
-        usecase = recruteur_integration_container.lister_mes_recrutements_usecase()
-        organisme = OrganismeFactory.create_model()
-        offre_active = OfferFactory.create_model(archived_at=None)
-        offre_archivee = OfferFactory.create_model(archived_at=datetime(2024, 1, 1))
-        RecrutementFactory.create_model(
-            offre_id=offre_active.id,
-            organisme_id=organisme.id,
-        )
+    def test_lister_archives(self, usecase):
+        agent_id, organisme = self._create_agent_responsable()
+        RecrutementFactory.create_model(organisme_id=organisme.id)
         recrutement_archive = RecrutementFactory.create_model(
-            offre_id=offre_archivee.id,
+            offre_archivee=True,
             organisme_id=organisme.id,
         )
         etape_accepte = EtapeModel.objects.filter(
@@ -107,19 +108,17 @@ class TestListerMesRecrutements:
             categorie=CategorieEtapeRecrutement.ACCEPTE.value,
         ).first()
 
-        CandidatureFactory.create_model(offre_id=offre_archivee.id, etape=etape_accepte)
+        CandidatureFactory.create_model(
+            offre_id=recrutement_archive.offre_id, etape=etape_accepte
+        )
 
-        result = usecase.execute(
-            ListerMesRecrutementsQuery(
-                organisme_id=organisme.id,
-                statut=StatutRecrutement.ARCHIVE,
-                utilisateur_id=uuid4(),
-            )
+        result = self._lister_recrutements(
+            usecase, organisme, agent_id, StatutRecrutement.ARCHIVE
         )
 
         items = list(result.slice(0, 10))
         assert len(items) == 1
-        assert items[0].offer_id == offre_archivee.id
+        assert items[0].offer_id == recrutement_archive.offre_id
         assert items[0].finalise is True
         assert items[0].recrute is not None
         assert items[0].recrute != ""


### PR DESCRIPTION
## 📝 Description
🎸 Permettre à un Agent membre d'un organisme, de consulter les recrutements pour lesquels il a un rôle dans cet organisme.
🎻 Les Agents Responsable de l'organisme continuent de pouvoir consulter tous les recrutements de l'organisme
🗡️ Les utitisateurs staff ne possèdent pas de droit particulier étendu

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
### Domaine (domain/recruteur)
- services/organisme_permission_service.py : _ROLES_REQUIS passe d'un rôle unique par action à un frozenset de rôles autorisés

### Application (application/recruteur)
- usecases/lister_mes_recrutements.py : le TODO historique est résolu. 

### Infrastructure (infrastructure/recruteur)
- postgres_recrutement_query_service.py : les deux méthodes construisent un filtre dynamique quand agent_id est fourni
- factories/recruteur/recrutement_factory.py : paramètre offre_archivee qui génère lui-même l'Offer associée
- 
## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
