### PR TITLE
🔒️(recrutement-test) renforcement des tests RBAC pour la gestion des organismes

### DIFF
--- a/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
@@ -14,6 +14,7 @@ from application.recruteur.usecases.update_organisme_steps import (
 )
 from config.app_config import AppConfig
 from domain.commons.services.audit_log_writer import AuditLogWriter
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
 from infrastructure.factories.identite.agent_factory import AgentFactory
@@ -100,3 +101,109 @@ def test_update_organisme_steps(recruteur_integration_container):
     usecase.audit_log_writer.drain_events.assert_called_once_with(
         utilisateur_id=agent.utilisateur_id, aggregate=organisme
     )
+
+
+class TestGetOrganismeRecruteurRbac:
+    @pytest.mark.parametrize(
+        ("role", "est_staff"),
+        [(AgentOrganismeRole.RESPONSABLE, False), (None, True)],
+        ids=["responsable", "staff"],
+    )
+    def test_role_grants_access(self, recruteur_integration_container, role, est_staff):
+        agent, organisme = _create_agent(role)
+        usecase = recruteur_integration_container.get_organisme_recruteur_usecase()
+
+        result = usecase.execute(
+            GetOrganismeRecruteurQuery(
+                organisme_id=organisme.id,
+                utilisateur_id=agent.utilisateur_id,
+                est_staff=est_staff,
+            )
+        )
+
+        assert result.entity_id == organisme.id
+
+    @pytest.mark.parametrize(
+        "role", [AgentOrganismeRole.MEMBRE, None], ids=["membre", "non_membre"]
+    )
+    def test_role_refuse_access(self, recruteur_integration_container, role):
+        agent, organisme = _create_agent(role)
+        usecase = recruteur_integration_container.get_organisme_recruteur_usecase()
+
+        with pytest.raises(AccesOrganismeRefuse):
+            usecase.execute(
+                GetOrganismeRecruteurQuery(
+                    organisme_id=organisme.id, utilisateur_id=agent.utilisateur_id
+                )
+            )
+
+
+class TestInitializeOrganismeStepsRbac:
+    @pytest.mark.parametrize(
+        ("role", "est_staff"),
+        [(AgentOrganismeRole.RESPONSABLE, False), (None, True)],
+        ids=["responsable", "staff"],
+    )
+    def test_role_grants_access(self, recruteur_integration_container, role, est_staff):
+        agent, organisme = _create_agent(role)
+        usecase = recruteur_integration_container.initialize_organisme_steps_usecase()
+
+        result = usecase.execute(
+            InitializeOrganismeStepsCommand(
+                organisme_id=organisme.id,
+                utilisateur_id=agent.utilisateur_id,
+                est_staff=est_staff,
+            )
+        )
+
+        assert result.etapes is not None
+        assert len(result.etapes) == NB_ETAPES_PAR_DEFAUT
+
+    @pytest.mark.parametrize(
+        "role", [AgentOrganismeRole.MEMBRE, None], ids=["membre", "non_membre"]
+    )
+    def test_role_refuse_access(self, recruteur_integration_container, role):
+        agent, organisme = _create_agent(role)
+        usecase = recruteur_integration_container.initialize_organisme_steps_usecase()
+
+        with pytest.raises(AccesOrganismeRefuse):
+            usecase.execute(
+                InitializeOrganismeStepsCommand(
+                    organisme_id=organisme.id, utilisateur_id=agent.utilisateur_id
+                )
+            )
+
+
+class TestUpdateOrganismeStepsRbac:
+    def _command(self, organisme, agent, *, est_staff=False):
+        etapes = EtapeRecrutementFactory.create_entities()
+        nouvelles_etapes = EtapeRecrutementFactory.to_etape_data_list(etapes)
+        return UpdateOrganismeStepsCommand(
+            utilisateur_id=agent.utilisateur_id,
+            organisme_id=organisme.id,
+            etapes=nouvelles_etapes,
+            est_staff=est_staff,
+        )
+
+    @pytest.mark.parametrize(
+        ("role", "est_staff"),
+        [(AgentOrganismeRole.RESPONSABLE, False), (None, True)],
+        ids=["responsable", "staff"],
+    )
+    def test_role_grants_access(self, recruteur_integration_container, role, est_staff):
+        agent, organisme = _create_agent(role)
+        usecase = recruteur_integration_container.update_organisme_steps_usecase()
+
+        result = usecase.execute(self._command(organisme, agent, est_staff=est_staff))
+
+        assert result.etapes is not None
+
+    @pytest.mark.parametrize(
+        "role", [AgentOrganismeRole.MEMBRE, None], ids=["membre", "non_membre"]
+    )
+    def test_role_refuse_access(self, recruteur_integration_container, role):
+        agent, organisme = _create_agent(role)
+        usecase = recruteur_integration_container.update_organisme_steps_usecase()
+
+        with pytest.raises(AccesOrganismeRefuse):
+            usecase.execute(self._command(organisme, agent))

--- a/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID
 
 import pytest
 
@@ -14,10 +14,9 @@ from application.recruteur.usecases.update_organisme_steps import (
 )
 from config.app_config import AppConfig
 from domain.commons.services.audit_log_writer import AuditLogWriter
-from domain.recruteur.services.organisme_permission_service import (
-    OrganismePermissionService,
-)
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
+from infrastructure.factories.identite.agent_factory import AgentFactory
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory
 from infrastructure.factories.recruteur.etapes_recrutement_factory import (
     EtapeRecrutementFactory,
@@ -25,6 +24,17 @@ from infrastructure.factories.recruteur.etapes_recrutement_factory import (
 from infrastructure.gateways.shared.logger import LoggerService
 
 NB_ETAPES_PAR_DEFAUT = 6
+
+
+def _create_agent(role: AgentOrganismeRole | None = None, **organisme_kwargs):
+    agent = AgentFactory.create_model()
+    if role is not None:
+        organisme = OrganismeFactory.create_model(
+            agent_id=UUID(agent.utilisateur_id), role=role, **organisme_kwargs
+        )
+    else:
+        organisme = OrganismeFactory.create_model(**organisme_kwargs)
+    return agent, organisme
 
 
 @pytest.fixture(name="recruteur_integration_container")
@@ -35,20 +45,16 @@ def recruteur_integration_container_fixture(db):
     container.app_config.override(app_config)
     container.logger_service.override(logger_service)
     container.audit_log_writer.override(MagicMock(spec=AuditLogWriter))
-    container.organisme_permission_service.override(
-        MagicMock(spec=OrganismePermissionService)
-    )
     return container
 
 
 def test_get_organisme_steps(recruteur_integration_container):
-    organisme_model = OrganismeFactory.create_model()
-    organisme_model.save()
+    agent, organisme_model = _create_agent(AgentOrganismeRole.RESPONSABLE)
     usecase = recruteur_integration_container.get_organisme_recruteur_usecase()
 
     organisme = usecase.execute(
         command=GetOrganismeRecruteurQuery(
-            organisme_id=organisme_model.id, utilisateur_id=uuid4()
+            organisme_id=organisme_model.id, utilisateur_id=agent.utilisateur_id
         )
     )
     events = organisme.collect_events()
@@ -57,12 +63,12 @@ def test_get_organisme_steps(recruteur_integration_container):
 
 
 def test_initialize_organisme_steps(recruteur_integration_container):
-    organisme_model = OrganismeFactory.create_model()
+    agent, organisme_model = _create_agent(AgentOrganismeRole.RESPONSABLE)
     usecase = recruteur_integration_container.initialize_organisme_steps_usecase()
 
     organisme = usecase.execute(
         command=InitializeOrganismeStepsCommand(
-            organisme_id=organisme_model.id, utilisateur_id=uuid4()
+            organisme_id=organisme_model.id, utilisateur_id=agent.utilisateur_id
         )
     )
 
@@ -75,15 +81,16 @@ def test_initialize_organisme_steps(recruteur_integration_container):
 def test_update_organisme_steps(recruteur_integration_container):
     etapes = EtapeRecrutementFactory.create_entities()
 
-    organisme_model = OrganismeFactory.create_model(etapes=etapes)
+    agent, organisme_model = _create_agent(
+        AgentOrganismeRole.RESPONSABLE, etapes=etapes
+    )
 
     nouvelles_etapes = EtapeRecrutementFactory.to_etape_data_list(etapes)
 
-    utilisateur_id = uuid4()
     usecase = recruteur_integration_container.update_organisme_steps_usecase()
     organisme = usecase.execute(
         command=UpdateOrganismeStepsCommand(
-            utilisateur_id=utilisateur_id,
+            utilisateur_id=agent.utilisateur_id,
             organisme_id=organisme_model.id,
             etapes=nouvelles_etapes,
         )
@@ -91,5 +98,5 @@ def test_update_organisme_steps(recruteur_integration_container):
     assert organisme.etapes is not None
     assert len(organisme.etapes) == len(nouvelles_etapes)
     usecase.audit_log_writer.drain_events.assert_called_once_with(
-        utilisateur_id=utilisateur_id, aggregate=organisme
+        utilisateur_id=agent.utilisateur_id, aggregate=organisme
     )


### PR DESCRIPTION
## 📝 Description
🎸 Mocker la reponse du service de permission creer un faux sentiment de sécurité.
🎸 Ajout de tests intégrant la DB

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## ⚒️ Changements

Les use cases GetOrganismeRecruteurUsecase, InitializeOrganismeStepsUsecase et UpdateOrganismeStepsUsecase appellent déjà OrganismePermissionService.est_autorise(...) (rôle RESPONSABLE requis), mais leurs tests d'intégration mockaient entièrement ce service (organisme_permission_service.override(MagicMock(...))). Le RBAC réel (recherche du rôle en base, levée de AccesOrganismeRefuse, bypass staff) n'était donc jamais exercé — un mock de permission est un piège qui masque les régressions RBAC.

- Suppression du mock de organisme_permission_service dans la fixture recruteur_integration_container : le service tourne désormais réellement, adossé à Postgres.
- Les 3 tests existants (test_get_organisme_steps, test_initialize_organisme_steps, test_update_organisme_steps) créent maintenant un agent RESPONSABLE réel (via un helper _create_agent) au lieu d'un uuid4() placeholder, sinon le retrait du mock les ferait échouer.
- Ajout de 3 classes de tests RBAC (TestGetOrganismeRecruteurRbac, TestInitializeOrganismeStepsRbac, TestUpdateOrganismeStepsRbac), chacune avec :
  - test_role_grants_access — paramétré responsable / staff : accès accordé quel que soit le cas.
  - test_role_refuse_access — paramétré membre / non_membre : lève AccesOrganismeRefuse dans les deux cas.


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
