### PR TITLE
🐛(ingestion) gérer les codes NIV_DIPL dans le mapping du niveau d'études

### DIFF
--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 from typing import List, Optional, cast
 from uuid import UUID
@@ -9,6 +10,7 @@ from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractKind, ContractType
 from referentiel.value_objects.country import Country
 from referentiel.value_objects.department import Department
+from referentiel.value_objects.diploma import Diploma
 from referentiel.value_objects.experience_level import ExperienceLevel
 from referentiel.value_objects.language import Language
 from referentiel.value_objects.language_level import LanguageLevel
@@ -310,18 +312,29 @@ class OffersCleaner:
         }
         return mapping[client_code]
 
+    _EDUCATION_LEVEL_MAPPING: dict[str, int] = {
+        "A": 1,
+        "B": 2,
+        "C": 3,
+        "D": 4,
+        "E": 5,
+        "F": 6,
+        "G": 7,
+        "H": 8,
+    }
+    _NIV_DIPL_PATTERN = re.compile(r"NIV_DIPL(\d)")
+
     def _map_education_level(self, client_code: str) -> Optional[int]:
-        mapping = {
-            "A": 1,
-            "B": 2,
-            "C": 3,
-            "D": 4,
-            "E": 5,
-            "F": 6,
-            "G": 7,
-            "H": 8,
-        }
-        return mapping[client_code]
+        if client_code in self._EDUCATION_LEVEL_MAPPING:
+            return self._EDUCATION_LEVEL_MAPPING[client_code]
+
+        match = self._NIV_DIPL_PATTERN.fullmatch(client_code)
+        if match:
+            level = int(match.group(1))
+            if Diploma.MIN_DIPLOMA_LEVEL <= level <= Diploma.MAX_DIPLOMA_LEVEL:
+                return level
+
+        return None
 
     def _parse_category(self, category_code: Optional[str]) -> Optional[Category]:
         if category_code in ["CAT-AEF", "CAT-ESD", "CAT-ES"]:

--- a/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
+++ b/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
@@ -387,6 +387,9 @@ def test_clean_returns_none_end_publication_date_when_absent(cleaner):
         ("F", 6),
         ("G", 7),
         ("H", 8),
+        ("NIV_DIPL1", 1),
+        ("NIV_DIPL7", 7),
+        ("NIV_DIPL8", 8),
     ],
 )
 def test_clean_maps_education_level(cleaner, client_code, expected):
@@ -396,6 +399,16 @@ def test_clean_maps_education_level(cleaner, client_code, expected):
     offer = cleaner.clean(raw_offer)
 
     assert offer.education_level == expected
+
+
+@pytest.mark.parametrize("client_code", ["UNKNOWN_CODE", "NIV_DIPL9", "NIV_DIPL0"])
+def test_clean_maps_unknown_education_level_to_none(cleaner, client_code):
+    education = TalentsoftCodedObjectFactory.build(clientCode=client_code)
+    raw_offer = _make_raw_offer(educationLevel=education)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.education_level is None
 
 
 def test_clean_returns_none_education_level_when_absent(cleaner):


### PR DESCRIPTION
## 📝 Description

Les offres venant de Talensoft de l'ARS utilisent `NIV_DIPL(\d)` pour les niveaux de diplôme plutôt que des lettres.

[Voir exception](https://sentry.incubateur.net/organizations/betagouv/issues/299048/events/)

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [ ] 👀 J’ai demandé une revue à une personne de l’équipe.
