### PR TITLE
🐛(ingestion) empêcher le mark_as_upserted quand la publication échoue

### DIFF
--- a/src/ingestion/infrastructure/external_gateways/web_publish_offer_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/web_publish_offer_gateway.py
@@ -1,21 +1,38 @@
+import logging
+
 from domain.entities.offer import Offer
 from domain.gateways.publish_offer_gateway import IPublishOfferGateway
 from domain.gateways.publish_offer_input import PublishOfferInput
+from infrastructure.exceptions.exceptions import ExternalApiError
 from infrastructure.external_gateways.base_web_gateway import BaseWebGateway
 from infrastructure.external_gateways.dtos.offer_upsert_payload import (
     OfferUpsertPayload,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class WebPublishOfferGateway(BaseWebGateway, IPublishOfferGateway):
     async def publish(self, input: PublishOfferInput) -> None:
-        await self._post(
+        response = await self._post(
             "/offres/creer_modifier",
             json={
                 "source_id": str(input.source_id),
                 "offres": [self._serialize(input.offer)],
             },
         )
+        errors = response.json().get("errors") if response.content else None
+        if errors:
+            logger.error(
+                "WebPublishOfferGateway: publish failed for offer %s: %s",
+                input.offer.reference,
+                errors,
+            )
+            raise ExternalApiError(
+                f"Failed to publish offer {input.offer.reference}",
+                api_name="web",
+                details={"errors": errors},
+            )
 
     def _serialize(self, offer: Offer) -> dict:
         return OfferUpsertPayload.from_offer(offer).model_dump(mode="json")

--- a/src/ingestion/migrations/env.py
+++ b/src/ingestion/migrations/env.py
@@ -21,7 +21,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # SQLModel exposes the shared SQLAlchemy metadata that all table=True models
 # register themselves into.

--- a/src/ingestion/tests/unit/test_ingest_offer_pipeline.py
+++ b/src/ingestion/tests/unit/test_ingest_offer_pipeline.py
@@ -218,13 +218,35 @@ async def test_execute_skips_publish_when_clean_fails(
 @pytest.mark.asyncio
 @patch("application.pipelines.ingest_offer_pipeline.logger")
 async def test_execute_does_not_raise_when_publish_fails(
-    mock_logger, pipeline_with_post, mock_publish_offer_use_case
+    mock_logger,
+    pipeline_with_post,
+    mock_publish_offer_use_case,
+    mock_raw_offer_repository,
 ):
     mock_publish_offer_use_case.execute.side_effect = RuntimeError("Web API down")
 
     await pipeline_with_post.execute(reference=REFERENCE, source_id=SOURCE_ID)
 
     mock_logger.exception.assert_called_once()
+    mock_raw_offer_repository.mark_as_upserted.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("application.pipelines.ingest_offer_pipeline.logger")
+async def test_execute_does_not_mark_as_upserted_when_publish_raises_external_api_error(
+    mock_logger,
+    pipeline_with_post,
+    mock_publish_offer_use_case,
+    mock_raw_offer_repository,
+):
+    mock_publish_offer_use_case.execute.side_effect = ExternalApiError(
+        "Failed to publish offer", api_name="web"
+    )
+
+    await pipeline_with_post.execute(reference=REFERENCE, source_id=SOURCE_ID)
+
+    mock_logger.exception.assert_called_once()
+    mock_raw_offer_repository.mark_as_upserted.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
+++ b/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
@@ -21,6 +21,7 @@ from referentiel.value_objects.verse import Verse
 
 from domain.entities.offer import Offer
 from domain.gateways.publish_offer_input import PublishOfferInput
+from infrastructure.exceptions.exceptions import ExternalApiError
 from infrastructure.external_gateways.web_publish_offer_gateway import (
     WebPublishOfferGateway,
 )
@@ -339,3 +340,45 @@ async def test_publish_raises_on_http_error(gateway, httpx_mock: HTTPXMock):
         await gateway.publish(
             PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER)
         )
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_and_logs_error_when_response_contains_errors(
+    gateway, httpx_mock: HTTPXMock, caplog
+):
+    httpx_mock.add_response(
+        method="POST",
+        url=PUBLISH_URL,
+        status_code=201,
+        json={
+            "created": 0,
+            "updated": 0,
+            "errors": [{"offer": {"reference": "2024-OFFER-001"}, "error": "invalid"}],
+        },
+    )
+
+    with caplog.at_level("ERROR"), pytest.raises(ExternalApiError):
+        await gateway.publish(
+            PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER)
+        )
+
+    assert any("2024-OFFER-001" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_publish_does_not_log_when_response_has_no_errors(
+    gateway, httpx_mock: HTTPXMock, caplog
+):
+    httpx_mock.add_response(
+        method="POST",
+        url=PUBLISH_URL,
+        status_code=201,
+        json={"created": 1, "updated": 0, "errors": []},
+    )
+
+    with caplog.at_level("ERROR"):
+        await gateway.publish(
+            PublishOfferInput(source_id=SOURCE_ID, offer=MINIMAL_OFFER)
+        )
+
+    assert caplog.records == []


### PR DESCRIPTION
## 📝 Description

Quand on cherche à publier une offre depuis ingestion et que ceci échoue :
- loggue un message d'erreur avec le détail des erreurs de validation
- ne marque pas l'offre comme upsertée en base de donnée

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
