### PR TITLE
✨(recrutement-infrastructure) get_recrutement_liste exrait les données de la DB

### DIFF
--- a/src/web/application/recruteur/dtos/recrutement_read_models.py
+++ b/src/web/application/recruteur/dtos/recrutement_read_models.py
@@ -37,3 +37,26 @@ class RecrutementArchivesReadModel:
     agents: list[AgentDto]
     finalise: bool
     recrute: str | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class CandidatDto:
+    uuid: UUID
+    nom: str
+    prenom: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class EtapeDto:
+    etape_uuid: UUID
+    nom: str
+    categorie: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class CandidatureListeReadModel:
+    uuid: UUID
+    date_soumission: datetime
+    date_derniere_activite: datetime
+    candidat: CandidatDto
+    etape: EtapeDto

--- a/src/web/application/recruteur/services/recrutement_query_service_interface.py
+++ b/src/web/application/recruteur/services/recrutement_query_service_interface.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from ddd.page_interface import IPage
 
 from application.recruteur.dtos.recrutement_read_models import (
+    CandidatureListeReadModel,
     RecrutementActifsReadModel,
     RecrutementArchivesReadModel,
 )
@@ -16,3 +17,6 @@ class IRecrutementQueryService(Protocol):
     def get_archives_by_organisme(
         self, organisme_id: UUID, agent_id: UUID | None = None
     ) -> IPage[RecrutementArchivesReadModel]: ...
+    def get_candidatures_by_recrutement(
+        self, organisme_id: UUID, recrutement_id: UUID
+    ) -> list[CandidatureListeReadModel] | None: ...

--- a/src/web/application/recruteur/usecases/get_recrutement_liste.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_liste.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
-from typing import Any
 from uuid import UUID
 
 from ddd.usecase_interface import IUseCase
 
-from application.recruteur.usecases.recrutement_detail_static_data import (
-    STATIC_RECRUTEMENTS_DETAIL_BY_ID,
+from application.recruteur.dtos.recrutement_read_models import (
+    CandidatureListeReadModel,
+)
+from application.recruteur.services.recrutement_query_service_interface import (
+    IRecrutementQueryService,
 )
 from domain.identite.repositories.organisme_repository_interface import (
     IOrganismeRepository,
@@ -25,17 +27,21 @@ class GetRecrutementListeQuery:
 
 
 class GetRecrutementListeUsecase(
-    IUseCase[GetRecrutementListeQuery, dict[str, Any] | None]
+    IUseCase[GetRecrutementListeQuery, list[CandidatureListeReadModel] | None]
 ):
     def __init__(
         self,
         organisme_repository: IOrganismeRepository,
         organisme_permission_service: OrganismePermissionService,
+        recrutement_query_service: IRecrutementQueryService,
     ):
         self.organisme_repository = organisme_repository
         self.organisme_permission_service = organisme_permission_service
+        self.recrutement_query_service = recrutement_query_service
 
-    def execute(self, query: GetRecrutementListeQuery) -> dict[str, Any] | None:
+    def execute(
+        self, query: GetRecrutementListeQuery
+    ) -> list[CandidatureListeReadModel] | None:
         # TODO RBAC : handle MEMBRE role on recrutement
         self.organisme_permission_service.est_autorise(
             action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
@@ -45,4 +51,6 @@ class GetRecrutementListeUsecase(
         )
         self.organisme_repository.get_by_id(query.organisme_id)
 
-        return STATIC_RECRUTEMENTS_DETAIL_BY_ID.get(str(query.recrutement_id))
+        return self.recrutement_query_service.get_candidatures_by_recrutement(
+            organisme_id=query.organisme_id, recrutement_id=query.recrutement_id
+        )

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -154,4 +154,5 @@ class RecruteurContainer(containers.DeclarativeContainer):
         GetRecrutementListeUsecase,
         organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
+        recrutement_query_service=postgres_recrutement_query_service,
     )

--- a/src/web/infrastructure/django_apps/recruteur/models/recrutement.py
+++ b/src/web/infrastructure/django_apps/recruteur/models/recrutement.py
@@ -13,6 +13,7 @@ class RecrutementModel(models.Model):
     offre = models.OneToOneField(
         OfferModel,
         on_delete=models.PROTECT,
+        # to be noticed : offre is the PK
         primary_key=True,
         db_column="id",
         related_name="recrutement",

--- a/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
+++ b/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
@@ -7,7 +7,10 @@ from django.db.models.functions import Coalesce
 
 from application.recruteur.dtos.recrutement_read_models import (
     AgentDto,
+    CandidatDto,
+    CandidatureListeReadModel,
     CandidaturesCompteurDto,
+    EtapeDto,
     RecrutementActifsReadModel,
     RecrutementArchivesReadModel,
 )
@@ -171,3 +174,44 @@ class PostgresRecrutementQueryService(IRecrutementQueryService):
             )
 
         return QuerySetPage(qs, mapper=_mapper)
+
+    def get_candidatures_by_recrutement(
+        self, organisme_id: UUID, recrutement_id: UUID
+    ) -> list[CandidatureListeReadModel] | None:
+        if not RecrutementModel.objects.filter(
+            pk=recrutement_id, organisme_id=organisme_id
+        ).exists():
+            return None
+
+        etapes = (
+            EtapeModel.objects.filter(recrutement_id=recrutement_id)
+            .prefetch_related(
+                Prefetch(
+                    "candidatures",
+                    queryset=CandidatureModel.objects.select_related(
+                        "candidat__utilisateur"
+                    ).order_by("created_at"),
+                )
+            )
+            .order_by("updated_at")
+        )
+
+        return [
+            CandidatureListeReadModel(
+                uuid=candidature.id,
+                date_soumission=candidature.created_at,
+                date_derniere_activite=candidature.updated_at,
+                candidat=CandidatDto(
+                    uuid=UUID(candidature.candidat_id),
+                    nom=candidature.candidat.utilisateur.last_name,
+                    prenom=candidature.candidat.utilisateur.first_name,
+                ),
+                etape=EtapeDto(
+                    etape_uuid=etape.id,
+                    nom=etape.nom,
+                    categorie=CategorieEtapeRecrutement(etape.categorie).name,
+                ),
+            )
+            for etape in etapes
+            for candidature in etape.candidatures.all()
+        ]

--- a/src/web/presentation/recruteur/mappers.py
+++ b/src/web/presentation/recruteur/mappers.py
@@ -26,19 +26,3 @@ class RecrutementKanbanMapper(IFromDomainMapper[dict, dict]):
         if domain_object is None:
             return None
         return domain_object
-
-
-class RecrutementListeMapper(IFromDomainMapper[dict, list[dict]]):
-    def from_domain(self, domain_object: Optional[dict]) -> Optional[list[dict]]:
-        if domain_object is None:
-            return None
-        result = []
-        for etape in domain_object["etapes"]:
-            etape_dto = {
-                "etape_uuid": etape["etape_uuid"],
-                "nom": etape["nom"],
-                "categorie": etape["categorie"],
-            }
-            for candidature in etape["candidatures"]:
-                result.append({**candidature, "etape": etape_dto})
-        return result

--- a/src/web/presentation/recruteur/views/recrutements.py
+++ b/src/web/presentation/recruteur/views/recrutements.py
@@ -24,10 +24,7 @@ from domain.recruteur.value_objects.statut_recrutement import StatutRecrutement
 from infrastructure.di.recruteur.recruteur_factory import recruteur_container
 from presentation.api.serializers import GenericErrorSerializer, TokenErrorSerializer
 from presentation.commons.pagination import WebPagination
-from presentation.recruteur.mappers import (
-    RecrutementKanbanMapper,
-    RecrutementListeMapper,
-)
+from presentation.recruteur.mappers import RecrutementKanbanMapper
 from presentation.recruteur.serializers import (
     CandidatureListeSerializer,
     RecrutementDetailKanbanSerializer,
@@ -232,7 +229,7 @@ class RecrutementListeView(APIView):
     ) -> Response:
         try:
             usecase = self.container.get_recrutement_liste_usecase()
-            detail = usecase.execute(
+            candidatures = usecase.execute(
                 GetRecrutementListeQuery(
                     organisme_id=organisme_uuid,
                     recrutement_id=recrutement_uuid,
@@ -240,13 +237,12 @@ class RecrutementListeView(APIView):
                     est_staff=request.user.is_staff,
                 )
             )
-            if detail is None:
+            if candidatures is None:
                 return Response(
                     {"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND
                 )
 
-            all_candidatures = RecrutementListeMapper().from_domain(detail) or []
-            result = ListPage(all_candidatures)
+            result = ListPage(candidatures)
 
             paginator = WebPagination()
             items = paginator.paginate(result, request)

--- a/src/web/tests/application/recruteur/test_get_recrutement_liste.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_liste.py
@@ -1,14 +1,20 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 
+from application.recruteur.dtos.recrutement_read_models import (
+    CandidatDto,
+    CandidatureListeReadModel,
+    EtapeDto,
+)
+from application.recruteur.services.recrutement_query_service_interface import (
+    IRecrutementQueryService,
+)
 from application.recruteur.usecases.get_recrutement_liste import (
     GetRecrutementListeQuery,
     GetRecrutementListeUsecase,
-)
-from application.recruteur.usecases.recrutement_detail_static_data import (
-    STATIC_RECRUTEMENT_DETAIL,
 )
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
@@ -16,6 +22,16 @@ from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
+
+
+def _candidature_liste_read_model() -> CandidatureListeReadModel:
+    return CandidatureListeReadModel(
+        uuid=uuid4(),
+        date_soumission=datetime.now(tz=timezone.utc),
+        date_derniere_activite=datetime.now(tz=timezone.utc),
+        candidat=CandidatDto(uuid=uuid4(), nom="Dupont", prenom="Alice"),
+        etape=EtapeDto(etape_uuid=uuid4(), nom="Réception", categorie="ENTREE"),
+    )
 
 
 @pytest.fixture(name="organisme_repository")
@@ -30,11 +46,19 @@ def organisme_permission_service_fixture():
     return MagicMock(spec=OrganismePermissionService)
 
 
+@pytest.fixture(name="recrutement_query_service")
+def recrutement_query_service_fixture():
+    return MagicMock(spec=IRecrutementQueryService)
+
+
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository, organisme_permission_service):
+def usecase_fixture(
+    organisme_repository, organisme_permission_service, recrutement_query_service
+):
     return GetRecrutementListeUsecase(
         organisme_repository=organisme_repository,
         organisme_permission_service=organisme_permission_service,
+        recrutement_query_service=recrutement_query_service,
     )
 
 
@@ -47,11 +71,20 @@ class TestGetRecrutementListe:
         ],
     )
     def test_returns_detail_when_authorized(
-        self, organisme_repository, organisme_permission_service, usecase, role
+        self,
+        organisme_repository,
+        organisme_permission_service,
+        recrutement_query_service,
+        usecase,
+        role,
     ):
         organisme_permission_service.est_autorise.return_value = role
         organisme_id = uuid4()
-        recrutement_id = UUID(STATIC_RECRUTEMENT_DETAIL["offer_id"])
+        recrutement_id = uuid4()
+        candidatures = [_candidature_liste_read_model()]
+        recrutement_query_service.get_candidatures_by_recrutement.return_value = (
+            candidatures
+        )
 
         result = usecase.execute(
             GetRecrutementListeQuery(
@@ -61,16 +94,24 @@ class TestGetRecrutementListe:
             )
         )
 
-        assert result == STATIC_RECRUTEMENT_DETAIL
+        assert result == candidatures
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
+        recrutement_query_service.get_candidatures_by_recrutement.assert_called_once_with(
+            organisme_id=organisme_id, recrutement_id=recrutement_id
+        )
 
     def test_returns_none_for_unknown_recrutement(
-        self, organisme_repository, organisme_permission_service, usecase
+        self,
+        organisme_repository,
+        organisme_permission_service,
+        recrutement_query_service,
+        usecase,
     ):
         organisme_permission_service.est_autorise.return_value = (
             AgentOrganismeRole.RESPONSABLE
         )
         organisme_id = uuid4()
+        recrutement_query_service.get_candidatures_by_recrutement.return_value = None
 
         result = usecase.execute(
             GetRecrutementListeQuery(

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
@@ -1,17 +1,22 @@
+from uuid import UUID, uuid4
+
 import pytest
 
 from application.recruteur.usecases.get_recrutement_liste import (
     GetRecrutementListeQuery,
 )
-from application.recruteur.usecases.recrutement_detail_static_data import (
-    STATIC_RECRUTEMENT_DETAIL,
-)
 from config.app_config import AppConfig
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.value_objects.categorie_etapes_recrutement import (
+    CategorieEtapeRecrutement,
+)
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
+from infrastructure.django_apps.recruteur.models.etape import EtapeModel
+from infrastructure.factories.candidate.candidature_factory import CandidatureFactory
 from infrastructure.factories.identite.agent_factory import AgentFactory
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
 from infrastructure.gateways.shared.logger import LoggerService
 
 
@@ -37,16 +42,30 @@ class TestGetRecrutementListeRbac:
         organisme = OrganismeFactory.create_model(
             agent_id=agent.utilisateur_id, role=role
         )
+        recrutement = RecrutementFactory.create_model(organisme_id=organisme.id)
+        etape_entree = EtapeModel.objects.get(
+            recrutement_id=recrutement.offre_id,
+            categorie=CategorieEtapeRecrutement.ENTREE.value,
+        )
+        candidature = CandidatureFactory.create_model(
+            offre_id=recrutement.offre_id, etape=etape_entree
+        )
 
         result = usecase.execute(
             GetRecrutementListeQuery(
                 organisme_id=organisme.id,
-                recrutement_id=STATIC_RECRUTEMENT_DETAIL["offer_id"],
+                recrutement_id=recrutement.offre_id,
                 utilisateur_id=agent.utilisateur_id,
             )
         )
 
-        assert result == STATIC_RECRUTEMENT_DETAIL
+        assert result is not None
+        assert len(result) == 1
+        item = result[0]
+        assert item.uuid == UUID(candidature.id)
+        assert item.candidat.uuid == UUID(candidature.candidat_id)
+        assert item.etape.etape_uuid == etape_entree.id
+        assert item.etape.categorie == "ENTREE"
 
     @pytest.mark.parametrize("est_staff", [False, True])
     def test_forbidden_when_agent_has_no_organisme_role(self, usecase, est_staff):
@@ -57,8 +76,42 @@ class TestGetRecrutementListeRbac:
             usecase.execute(
                 GetRecrutementListeQuery(
                     organisme_id=organisme.id,
-                    recrutement_id=STATIC_RECRUTEMENT_DETAIL["offer_id"],
+                    recrutement_id=uuid4(),
                     utilisateur_id=agent.utilisateur_id,
                     est_staff=est_staff,
                 )
             )
+
+    def test_returns_none_for_unknown_recrutement(self, usecase):
+        agent = AgentFactory.create_model()
+        organisme = OrganismeFactory.create_model(
+            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        )
+
+        result = usecase.execute(
+            GetRecrutementListeQuery(
+                organisme_id=organisme.id,
+                recrutement_id=uuid4(),
+                utilisateur_id=agent.utilisateur_id,
+            )
+        )
+
+        assert result is None
+
+    def test_returns_none_when_recrutement_belongs_to_another_organisme(self, usecase):
+        agent = AgentFactory.create_model()
+        organisme = OrganismeFactory.create_model(
+            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        )
+        autre_organisme = OrganismeFactory.create_model()
+        recrutement = RecrutementFactory.create_model(organisme_id=autre_organisme.id)
+
+        result = usecase.execute(
+            GetRecrutementListeQuery(
+                organisme_id=organisme.id,
+                recrutement_id=recrutement.offre_id,
+                utilisateur_id=agent.utilisateur_id,
+            )
+        )
+
+        assert result is None

--- a/src/web/tests/presentation/recruteur/test_views_recrutements.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutements.py
@@ -1,5 +1,6 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from django.urls import reverse
@@ -8,7 +9,10 @@ from rest_framework import status
 
 from application.recruteur.dtos.recrutement_read_models import (
     AgentDto,
+    CandidatDto,
+    CandidatureListeReadModel,
     CandidaturesCompteurDto,
+    EtapeDto,
 )
 from application.recruteur.usecases.recrutement_detail_static_data import (
     STATIC_RECRUTEMENT_DETAIL,
@@ -18,6 +22,22 @@ from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRe
 from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
 
 fake = Faker()
+
+
+def _candidature_liste_read_models(
+    count: int = 11,
+) -> list[CandidatureListeReadModel]:
+    return [
+        CandidatureListeReadModel(
+            uuid=uuid4(),
+            date_soumission=datetime.now(tz=timezone.utc),
+            date_derniere_activite=datetime.now(tz=timezone.utc),
+            candidat=CandidatDto(uuid=uuid4(), nom="Dupont", prenom="Alice"),
+            etape=EtapeDto(etape_uuid=uuid4(), nom="Réception", categorie="ENTREE"),
+        )
+        for _ in range(count)
+    ]
+
 
 ORGANISME_UUID = fake.uuid4()
 UNKNOWN_ORGANISME_UUID = fake.uuid4()
@@ -372,7 +392,7 @@ class TestRecrutementListeView:
     @pytest.fixture(autouse=True)
     def _default_usecase(self, container):
         container.get_recrutement_liste_usecase.return_value.execute.return_value = (
-            STATIC_RECRUTEMENT_DETAIL
+            _candidature_liste_read_models()
         )
 
     def test_anonymous_access_is_unauthorized(self, api_client):
@@ -458,9 +478,10 @@ class TestRecrutementListeView:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found."}
 
-    @patch("presentation.recruteur.views.recrutements.RecrutementListeMapper")
-    def test_returns_500_on_unexpected_error(self, mock_mapper, authenticated_client):
-        mock_mapper.return_value.from_domain.side_effect = Exception("unexpected")
+    def test_returns_500_on_unexpected_error(self, container, authenticated_client):
+        container.get_recrutement_liste_usecase.return_value.execute.side_effect = (
+            Exception("unexpected")
+        )
 
         response = authenticated_client.get(RECRUTEMENT_LISTE_URL)
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
📢 requiert #1026 et #1030

## 📝 Description
🎸 Remplace les données statiques de GetRecrutementListeUsecase par une lecture réelle en base, scopée à l'organisme, et supprime le mapper de présentation devenu inutile.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
### Application
- GetRecrutementListeUsecase délègue désormais à IRecrutementQueryService.get_candidatures_by_recrutement
- Extension de l'interface IRecrutementQueryService avec get_candidatures_by_recrutement(organisme_id, recrutement_id).

### Infrastructure PostgresRecrutementQueryService
- vérifie que le recrutement appartient bien à l'organisme
- avec select_related/prefetch_related (évite le N+1) sur les étapes
- conversion de la catégorie d'étape (valeur DB en minuscule) vers le nom d'enum attendu par le serializer 

### Présentation
- RecrutementListeView simplifiée en conséquence (plus d'étape de mapping avant pagination).

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
