### PR TITLE
🚧(recrutement-presentation) changer etape recrutement endpoint - INTERFACE

### DIFF
--- a/src/web/application/recruteur/usecases/changer_etape_candidatures.py
+++ b/src/web/application/recruteur/usecases/changer_etape_candidatures.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from ddd.usecase_interface import IUseCase
+
+from domain.identite.repositories.organisme_repository_interface import (
+    IOrganismeRepository,
+)
+
+
+@dataclass
+class CandidatureAChanger:
+    candidature_id: UUID
+    etape_actuelle_id: UUID
+
+
+@dataclass
+class ChangerEtapeCandidaturesCommand:
+    organisme_id: UUID
+    recrutement_id: UUID
+    etape_cible_id: UUID
+    candidatures: list[CandidatureAChanger]
+
+
+@dataclass
+class ChangerEtapeResultat:
+    reussites: list[UUID]
+    echecs: list[tuple[UUID, str]]  # (candidature_id, reason code)
+
+
+# TODO: ajouter
+# - validation coherence organisme x recrutement x etape cible
+# - RBAC organisme, RBAC recrutement
+# - par candidature validation coherence etape source x etape cible
+# - emission evenement + drain par auditlog
+# - sauvegarde
+class ChangerEtapeCandidaturesUsecase(
+    IUseCase[ChangerEtapeCandidaturesCommand, ChangerEtapeResultat]
+):
+    def __init__(self, organisme_repository: IOrganismeRepository):
+        self.organisme_repository = organisme_repository
+
+    def execute(self, command: ChangerEtapeCandidaturesCommand) -> ChangerEtapeResultat:
+        self.organisme_repository.get_by_id(command.organisme_id)
+        return ChangerEtapeResultat(
+            reussites=[c.candidature_id for c in command.candidatures],
+            echecs=[],
+        )

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -1,5 +1,8 @@
 from dependency_injector import containers, providers
 
+from application.recruteur.usecases.changer_etape_candidatures import (
+    ChangerEtapeCandidaturesUsecase,
+)
 from application.recruteur.usecases.creer_note import CreerNoteUsecase
 from application.recruteur.usecases.editer_note import EditerNoteUsecase
 from application.recruteur.usecases.get_organisme_recruteur import (
@@ -156,4 +159,9 @@ class RecruteurContainer(containers.DeclarativeContainer):
         organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
         recrutement_query_service=postgres_recrutement_query_service,
+    )
+
+    changer_etape_candidatures_usecase = providers.Factory(
+        ChangerEtapeCandidaturesUsecase,
+        organisme_repository=postgres_organisme_repository,
     )

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -132,6 +132,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/candidatures/etape": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Changer l'étape d'une ou plusieurs candidatures (batch, statique) */
+        patch: operations["recruteur_organisme_recrutements_candidatures_etape_partial_update"];
+        trace?: never;
+    };
     "/recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/kanban": {
         parameters: {
             query?: never;
@@ -204,6 +221,17 @@ export interface components {
             date_derniere_activite: string;
             candidat: components["schemas"]["Candidat"];
         };
+        CandidatureAChanger: {
+            /** Format: uuid */
+            candidature_uuid: string;
+            /** Format: uuid */
+            etape_actuelle_uuid: string;
+        };
+        CandidatureEchec: {
+            /** Format: uuid */
+            candidature_uuid: string;
+            raison: string;
+        };
         CandidatureListe: {
             /** Format: uuid */
             uuid: string;
@@ -236,6 +264,10 @@ export interface components {
          * @enum {string}
          */
         CategorieOffreEnum: "APLUS" | "A" | "B" | "C" | "HORS_CATEGORIE";
+        ChangerEtapeResultat: {
+            reussites: string[];
+            echecs: components["schemas"]["CandidatureEchec"][];
+        };
         CreerNote: {
             message: string;
         };
@@ -449,6 +481,11 @@ export interface components {
              */
             previous?: string | null;
             results: components["schemas"]["RecrutementsArchives"][];
+        };
+        PatchedChangerEtapeCandidatures: {
+            /** Format: uuid */
+            etape_cible_uuid?: string;
+            candidatures?: components["schemas"]["CandidatureAChanger"][];
         };
         PatchedEditerNote: {
             message?: string;
@@ -1095,6 +1132,66 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+        };
+    };
+    recruteur_organisme_recrutements_candidatures_etape_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organisme_uuid: string;
+                recrutement_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedChangerEtapeCandidatures"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedChangerEtapeCandidatures"];
+                "multipart/form-data": components["schemas"]["PatchedChangerEtapeCandidatures"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChangerEtapeResultat"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenError"];
                 };
             };
             404: {

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -123,3 +123,28 @@ class CreerNoteSerializer(serializers.Serializer):
 
 class EditerNoteSerializer(serializers.Serializer):
     message = serializers.CharField()
+
+
+# ---------------------------------------------------------------------------
+# Serializers pour le changement d'étape (batch) de candidatures
+# ---------------------------------------------------------------------------
+
+
+class CandidatureAChangerSerializer(serializers.Serializer):
+    candidature_uuid = serializers.UUIDField()
+    etape_actuelle_uuid = serializers.UUIDField()
+
+
+class ChangerEtapeCandidaturesSerializer(serializers.Serializer):
+    etape_cible_uuid = serializers.UUIDField()
+    candidatures = CandidatureAChangerSerializer(many=True)
+
+
+class CandidatureEchecSerializer(serializers.Serializer):
+    candidature_uuid = serializers.UUIDField()
+    raison = serializers.CharField()
+
+
+class ChangerEtapeResultatSerializer(serializers.Serializer):
+    reussites = serializers.ListField(child=serializers.UUIDField())
+    echecs = CandidatureEchecSerializer(many=True)

--- a/src/web/presentation/recruteur/urls.py
+++ b/src/web/presentation/recruteur/urls.py
@@ -10,6 +10,7 @@ from presentation.recruteur.views.organismes import (
     OrganismeView,
 )
 from presentation.recruteur.views.recrutements import (
+    RecrutementCandidaturesEtapeView,
     RecrutementKanbanView,
     RecrutementListeView,
     RecrutementsActifsView,
@@ -53,6 +54,11 @@ urlpatterns = [
         "organisme/<uuid:organisme_uuid>/recrutements/<uuid:recrutement_uuid>/liste",
         RecrutementListeView.as_view(),
         name="organisme-recrutement-liste",
+    ),
+    path(
+        "organisme/<uuid:organisme_uuid>/recrutements/<uuid:recrutement_uuid>/candidatures/etape",
+        RecrutementCandidaturesEtapeView.as_view(),
+        name="organisme-recrutement-candidatures-etape",
     ),
     path(
         "candidature/<uuid:candidature_uuid>/notes",

--- a/src/web/presentation/recruteur/views/recrutements.py
+++ b/src/web/presentation/recruteur/views/recrutements.py
@@ -7,6 +7,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from application.recruteur.usecases.changer_etape_candidatures import (
+    CandidatureAChanger,
+    ChangerEtapeCandidaturesCommand,
+)
 from application.recruteur.usecases.get_recrutement_kanban import (
     GetRecrutementKanbanQuery,
 )
@@ -24,6 +28,8 @@ from presentation.api.serializers import GenericErrorSerializer, TokenErrorSeria
 from presentation.commons.pagination import WebPagination
 from presentation.recruteur.serializers import (
     CandidatureListeSerializer,
+    ChangerEtapeCandidaturesSerializer,
+    ChangerEtapeResultatSerializer,
     RecrutementDetailKanbanSerializer,
     RecrutementsActifsSerializer,
     RecrutementsArchivesSerializer,
@@ -181,6 +187,70 @@ class RecrutementKanbanView(APIView):
             serializer = GenericErrorSerializer({"error": "Unexpected error"})
             return Response(
                 serializer.data, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+
+# TODO: stub sans persistance, voir ChangerEtapeCandidaturesUsecase.
+@extend_schema(
+    summary="Changer l'étape d'une ou plusieurs candidatures (batch, statique)",
+    tags=["recruteur"],
+    request=ChangerEtapeCandidaturesSerializer,
+    responses={
+        200: ChangerEtapeResultatSerializer,
+        400: GenericErrorSerializer,
+        401: TokenErrorSerializer,
+        404: GenericErrorSerializer,
+        500: GenericErrorSerializer,
+    },
+)
+class RecrutementCandidaturesEtapeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.container = recruteur_container()
+
+    def patch(
+        self, request: Request, organisme_uuid: UUID, recrutement_uuid: UUID
+    ) -> Response:
+        serializer = ChangerEtapeCandidaturesSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+        try:
+            usecase = self.container.changer_etape_candidatures_usecase()
+            resultat = usecase.execute(
+                ChangerEtapeCandidaturesCommand(
+                    organisme_id=organisme_uuid,
+                    recrutement_id=recrutement_uuid,
+                    etape_cible_id=data["etape_cible_uuid"],
+                    candidatures=[
+                        CandidatureAChanger(
+                            candidature_id=c["candidature_uuid"],
+                            etape_actuelle_id=c["etape_actuelle_uuid"],
+                        )
+                        for c in data["candidatures"]
+                    ],
+                )
+            )
+            return Response(
+                ChangerEtapeResultatSerializer(
+                    {
+                        "reussites": resultat.reussites,
+                        "echecs": [
+                            {"candidature_uuid": cid, "raison": reason}
+                            for cid, reason in resultat.echecs
+                        ],
+                    }
+                ).data
+            )
+        except OrganismeNexistePas:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        except Exception:
+            error_serializer = GenericErrorSerializer({"error": "Unexpected error"})
+            return Response(
+                error_serializer.data, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
 

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -547,6 +547,70 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+  /recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/candidatures/etape:
+    patch:
+      operationId: recruteur_organisme_recrutements_candidatures_etape_partial_update
+      summary: Changer l'étape d'une ou plusieurs candidatures (batch, statique)
+      parameters:
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: recrutement_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - recruteur
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedChangerEtapeCandidatures'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedChangerEtapeCandidatures'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedChangerEtapeCandidatures'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangerEtapeResultat'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/kanban:
     get:
       operationId: recruteur_organisme_recrutements_kanban_retrieve
@@ -743,6 +807,29 @@ components:
       - date_derniere_activite
       - date_soumission
       - uuid
+    CandidatureAChanger:
+      type: object
+      properties:
+        candidature_uuid:
+          type: string
+          format: uuid
+        etape_actuelle_uuid:
+          type: string
+          format: uuid
+      required:
+      - candidature_uuid
+      - etape_actuelle_uuid
+    CandidatureEchec:
+      type: object
+      properties:
+        candidature_uuid:
+          type: string
+          format: uuid
+        raison:
+          type: string
+      required:
+      - candidature_uuid
+      - raison
     CandidatureListe:
       type: object
       properties:
@@ -807,6 +894,21 @@ components:
         * `B` - B
         * `C` - C
         * `HORS_CATEGORIE` - HORS_CATEGORIE
+    ChangerEtapeResultat:
+      type: object
+      properties:
+        reussites:
+          type: array
+          items:
+            type: string
+            format: uuid
+        echecs:
+          type: array
+          items:
+            $ref: '#/components/schemas/CandidatureEchec'
+      required:
+      - echecs
+      - reussites
     CreerNote:
       type: object
       properties:
@@ -1239,6 +1341,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RecrutementsArchives'
+    PatchedChangerEtapeCandidatures:
+      type: object
+      properties:
+        etape_cible_uuid:
+          type: string
+          format: uuid
+        candidatures:
+          type: array
+          items:
+            $ref: '#/components/schemas/CandidatureAChanger'
     PatchedEditerNote:
       type: object
       properties:

--- a/src/web/tests/application/recruteur/test_changer_etape_candidatures.py
+++ b/src/web/tests/application/recruteur/test_changer_etape_candidatures.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from application.recruteur.usecases.changer_etape_candidatures import (
+    CandidatureAChanger,
+    ChangerEtapeCandidaturesCommand,
+    ChangerEtapeCandidaturesUsecase,
+)
+from domain.identite.errors.organisme_errors import OrganismeNexistePas
+
+
+@pytest.fixture(name="organisme_repository")
+def organisme_repository_fixture():
+    repo = MagicMock()
+    repo.get_by_id.return_value = MagicMock()
+    return repo
+
+
+@pytest.fixture(name="usecase")
+def usecase_fixture(organisme_repository):
+    return ChangerEtapeCandidaturesUsecase(organisme_repository=organisme_repository)
+
+
+class TestChangerEtapeCandidaturesUsecase:
+    # TODO : failed updates are not yet tested, waiting for their implementation
+    def test_echoes_all_candidatures_as_reussites(self, organisme_repository, usecase):
+        organisme_id = uuid4()
+        candidature_ids = [uuid4(), uuid4()]
+        command = ChangerEtapeCandidaturesCommand(
+            organisme_id=organisme_id,
+            recrutement_id=uuid4(),
+            etape_cible_id=uuid4(),
+            candidatures=[
+                CandidatureAChanger(candidature_id=cid, etape_actuelle_id=uuid4())
+                for cid in candidature_ids
+            ],
+        )
+
+        resultat = usecase.execute(command)
+
+        assert resultat.reussites == candidature_ids
+        assert resultat.echecs == []
+        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
+
+    def test_empty_batch_returns_empty_result(self, usecase):
+        command = ChangerEtapeCandidaturesCommand(
+            organisme_id=uuid4(),
+            recrutement_id=uuid4(),
+            etape_cible_id=uuid4(),
+            candidatures=[],
+        )
+
+        resultat = usecase.execute(command)
+
+        assert resultat.reussites == []
+        assert resultat.echecs == []
+
+    def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
+        organisme_id = uuid4()
+        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
+            str(organisme_id)
+        )
+
+        with pytest.raises(OrganismeNexistePas):
+            usecase.execute(
+                ChangerEtapeCandidaturesCommand(
+                    organisme_id=organisme_id,
+                    recrutement_id=uuid4(),
+                    etape_cible_id=uuid4(),
+                    candidatures=[
+                        CandidatureAChanger(
+                            candidature_id=uuid4(), etape_actuelle_id=uuid4()
+                        )
+                    ],
+                )
+            )

--- a/src/web/tests/infrastructure/recruteur/test_changer_etape_candidatures.py
+++ b/src/web/tests/infrastructure/recruteur/test_changer_etape_candidatures.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from faker import Faker
+
+from application.recruteur.usecases.changer_etape_candidatures import (
+    CandidatureAChanger,
+    ChangerEtapeCandidaturesCommand,
+)
+from config.app_config import AppConfig
+from domain.commons.services.audit_log_writer import AuditLogWriter
+from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
+from infrastructure.factories.candidate.candidature_factory import CandidatureFactory
+from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.gateways.shared.logger import LoggerService
+
+fake = Faker("fr_FR")
+
+
+@pytest.fixture(name="recruteur_integration_container")
+def recruteur_integration_container_fixture(db):
+    container = RecruteurContainer()
+    app_config = AppConfig.from_django_settings()
+    logger_service = LoggerService()
+    container.app_config.override(app_config)
+    container.logger_service.override(logger_service)
+    container.audit_log_writer.override(MagicMock(spec=AuditLogWriter))
+    return container
+
+
+class TestChangerEtapeCandidatures:
+    # TODO : update this class after persistence is implemented
+    def test_changer_etape_candidatures(self, db, recruteur_integration_container):
+        organisme_model = OrganismeFactory.create_model()
+        candidature_model = CandidatureFactory.create_model()
+        etape_cible_id = uuid4()
+        usecase = recruteur_integration_container.changer_etape_candidatures_usecase()
+
+        resultat = usecase.execute(
+            command=ChangerEtapeCandidaturesCommand(
+                organisme_id=organisme_model.id,
+                recrutement_id=candidature_model.etape.recrutement_id,
+                etape_cible_id=etape_cible_id,
+                candidatures=[
+                    CandidatureAChanger(
+                        candidature_id=candidature_model.id,
+                        etape_actuelle_id=candidature_model.etape_id,
+                    )
+                ],
+            )
+        )
+
+        assert resultat.reussites == [candidature_model.id]
+        assert resultat.echecs == []
+
+    def test_changer_etape_candidatures_raises_when_organisme_introuvable(
+        self, db, recruteur_integration_container
+    ):
+        candidature_model = CandidatureFactory.create_model()
+        usecase = recruteur_integration_container.changer_etape_candidatures_usecase()
+
+        with pytest.raises(OrganismeNexistePas):
+            usecase.execute(
+                command=ChangerEtapeCandidaturesCommand(
+                    organisme_id=uuid4(),
+                    recrutement_id=candidature_model.etape.recrutement_id,
+                    etape_cible_id=uuid4(),
+                    candidatures=[
+                        CandidatureAChanger(
+                            candidature_id=candidature_model.id,
+                            etape_actuelle_id=candidature_model.etape_id,
+                        )
+                    ],
+                )
+            )

--- a/src/web/tests/presentation/recruteur/test_views_recrutements.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutements.py
@@ -123,6 +123,10 @@ UNKNOWN_RECRUTEMENT_LISTE_URL = reverse(
         "recrutement_uuid": UNKNOWN_RECRUTEMENT_UUID,
     },
 )
+RECRUTEMENT_CANDIDATURES_ETAPE_URL = reverse(
+    "recruteur:organisme-recrutement-candidatures-etape",
+    kwargs={"organisme_uuid": ORGANISME_UUID, "recrutement_uuid": RECRUTEMENT_UUID},
+)
 
 
 @pytest.fixture
@@ -539,5 +543,75 @@ class TestRecrutementListeView:
         )
 
         response = authenticated_client.get(RECRUTEMENT_LISTE_URL)
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"error": "Unexpected error"}
+
+
+class TestRecrutementCandidaturesEtapeView:
+    def test_anonymous_access_is_unauthorized(self, api_client):
+        response = api_client.patch(
+            RECRUTEMENT_CANDIDATURES_ETAPE_URL,
+            data={"etape_cible_uuid": fake.uuid4(), "candidatures": []},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_echoes_candidatures_as_reussites(self, container, authenticated_client):
+        candidature_uuid = str(uuid4())
+        mock_usecase = container.changer_etape_candidatures_usecase.return_value
+        mock_usecase.execute.return_value = MagicMock(
+            reussites=[UUID(candidature_uuid)], echecs=[]
+        )
+
+        response = authenticated_client.patch(
+            RECRUTEMENT_CANDIDATURES_ETAPE_URL,
+            data={
+                "etape_cible_uuid": fake.uuid4(),
+                "candidatures": [
+                    {
+                        "candidature_uuid": candidature_uuid,
+                        "etape_actuelle_uuid": fake.uuid4(),
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["reussites"] == [candidature_uuid]
+        assert data["echecs"] == []
+
+    def test_requires_etape_cible_uuid(self, authenticated_client):
+        response = authenticated_client.patch(
+            RECRUTEMENT_CANDIDATURES_ETAPE_URL,
+            data={"candidatures": []},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_returns_404_for_unknown_organisme(self, container, authenticated_client):
+        mock_usecase = container.changer_etape_candidatures_usecase.return_value
+        mock_usecase.execute.side_effect = OrganismeNexistePas("not found")
+
+        response = authenticated_client.patch(
+            RECRUTEMENT_CANDIDATURES_ETAPE_URL,
+            data={"etape_cible_uuid": fake.uuid4(), "candidatures": []},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {"detail": "Not found."}
+
+    def test_returns_500_on_unexpected_error(self, container, authenticated_client):
+        mock_usecase = container.changer_etape_candidatures_usecase.return_value
+        mock_usecase.execute.side_effect = Exception("unexpected")
+
+        response = authenticated_client.patch(
+            RECRUTEMENT_CANDIDATURES_ETAPE_URL,
+            data={"etape_cible_uuid": fake.uuid4(), "candidatures": []},
+            format="json",
+        )
+
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json() == {"error": "Unexpected error"}


### PR DESCRIPTION
## 📝 Description
🎸 Mise en place de l'interface (endpoint + use case + wiring) pour changer l'étape d'un lot de candidatures, en préparation de l'interface kanban. Le use case est volontairement un stub statique sans persistance, RBAC ni émission d'événements — cela viendra dans une itération suivante.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
- **Application (recruteur)** : ajout du use case `ChangerEtapeCandidaturesUsecase` : stub statique sans persistance,
- **Infrastructure (recruteur)** : wiring de `changer_etape_candidatures_usecase` dans `RecruteurContainer`,
- **Presentation (recruteur)** : nouvelle vue `RecrutementCandidaturesEtapeView`,
- schéma OpenAPI interne + types API mis à jour

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
