### PR TITLE
🐛(recrutement-infrastructure) correction des annotations dans PostgresRecrutementQueryService

### DIFF
--- a/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
+++ b/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
@@ -2,8 +2,7 @@ from datetime import datetime
 from typing import cast
 from uuid import UUID
 
-from django.db.models import Count, F, Max, Prefetch, Q
-from django.db.models.functions import Coalesce
+from django.db.models import Count, Max, Prefetch, Q
 
 from application.recruteur.dtos.recrutement_read_models import (
     AgentDto,
@@ -57,9 +56,8 @@ class PostgresRecrutementQueryService(IRecrutementQueryService):
                 )
             )
             .annotate(
-                derniere_activite=Coalesce(  # todo extract business rules
-                    Max("etapes__candidatures__updated_at"),
-                    F("offre__publication_date"),
+                derniere_activite=Max(  # todo extract business rules
+                    "etapes__candidatures__updated_at"
                 ),
                 candidatures_total=Count("etapes__candidatures"),
                 candidatures_a_traiter=Count(
@@ -92,7 +90,8 @@ class PostgresRecrutementQueryService(IRecrutementQueryService):
                 type_contrat=model.offre.contract_type or "",
                 date_publication=model.offre.publication_date,
                 agents=agents,
-                derniere_activite=cast(datetime, model.derniere_activite),  # type: ignore[attr-defined]
+                derniere_activite=model.derniere_activite  # type: ignore[attr-defined]
+                or model.offre.publication_date,
                 candidatures=CandidaturesCompteurDto(
                     total=cast(int, model.candidatures_total) or 0,  # type: ignore[attr-defined]
                     a_traiter=cast(int, model.candidatures_a_traiter) or 0,  # type: ignore[attr-defined]

--- a/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 
 from application.recruteur.usecases.lister_mes_recrutements import (
@@ -24,6 +26,7 @@ from infrastructure.factories.recruteur.etapes_recrutement_factory import (
     EtapeRecrutementFactory,
 )
 from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
+from infrastructure.factories.referentiel.offer_factory import OfferFactory
 from infrastructure.gateways.shared.logger import LoggerService
 
 
@@ -124,6 +127,48 @@ class TestListerMesRecrutements:
         assert items[0].finalise is True
         assert items[0].recrute is not None
         assert items[0].recrute != ""
+
+    def test_lister_actifs_sans_candidature_derniere_activite_repli_sur_publication(
+        self, usecase
+    ):
+        agent_id, organisme = self._create_agent_responsable()
+        offre = OfferFactory.create_model(
+            publication_date=datetime(2024, 3, 1, tzinfo=UTC)
+        )
+        recrutement_actif = RecrutementFactory.create_model(
+            offre_id=offre.id,
+            organisme_id=organisme.id,
+            agent_ids=(agent_id,),
+            etapes=EtapeRecrutementFactory.create_entities(),
+        )
+
+        result = self._lister_recrutements(
+            usecase, organisme, agent_id, StatutRecrutement.ACTIF
+        )
+
+        items = list(result.slice(0, 10))
+        assert len(items) == 1
+        assert items[0].offer_id == recrutement_actif.offre_id
+        assert items[0].candidatures.total == 0
+        assert items[0].derniere_activite == offre.publication_date
+
+    def test_lister_archives_sans_candidature_acceptee(self, usecase):
+        agent_id, organisme = self._create_agent_responsable()
+        recrutement_archive = RecrutementFactory.create_model(
+            offre_archivee=True,
+            organisme_id=organisme.id,
+            agent_ids=(agent_id,),
+        )
+
+        result = self._lister_recrutements(
+            usecase, organisme, agent_id, StatutRecrutement.ARCHIVE
+        )
+
+        items = list(result.slice(0, 10))
+        assert len(items) == 1
+        assert items[0].offer_id == recrutement_archive.offre_id
+        assert items[0].finalise is False
+        assert items[0].recrute is None
 
 
 @pytest.mark.parametrize("statut", [StatutRecrutement.ACTIF, StatutRecrutement.ARCHIVE])


### PR DESCRIPTION
## 📝 Description
🎸 Correction d'une erreur 500 sur `GET /recruteur/organisme/{id}/recrutements-actifs` : l'annotation `derniere_activite` combinait un `Coalesce(Max(...), F("offre__publication_date"))` avec un `select_related`

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
- Infrastructure (`recruteur`) : dans `PostgresRecrutementQueryService.get_actifs_by_organisme`, simplification de l'annotation `derniere_activite` en `Max("etapes__candidatures__updated_at")` seul, et report du repli sur `offre.publication_date` dans le mapper Python ; retrait des imports `F` et `Coalesce` devenus inutiles (+ tests)

- Ajout d'un test d'intégration 

🛸 Dépendances requises pour ce changement (si applicable)
_Aucune_

## 🏝️ Comment tester (si applicable)
- En local, appeler `GET /recruteur/organisme/{id}/recrutements-actifs` pour un organisme ayant un recrutement actif sans aucune candidature et confirmer que la réponse est 200 avec `derniere_activite` égale à la date de publication de l'offre

## 📸 Captures d'écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J'ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J'ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J'ai pris en compte l'impact sur les performances, la sécurité et l'expérience utilisateur.
- [ ] 👀 J'ai demandé une revue à une personne de l'équipe.