### PR TITLE
✨(ats-presentation) make the vite dev server origin configurable

### DIFF
--- a/docs/frontend_vue.md
+++ b/docs/frontend_vue.md
@@ -62,7 +62,21 @@ Open http://localhost:8000/ats/
 
 ### Hot Module Replacement (HMR)
 
-In dev mode, the Django template loads assets from the Vite server (`localhost:5173`). Changes in `src/` are reflected instantly without a full page refresh.
+In dev mode, the Django template loads assets from the Vite server. Changes in `src/` are reflected instantly without a full page refresh.
+
+### Changing the dev server origin
+
+The Vite dev origin is a single environment variable, `WEB_VITE_DEV_ORIGIN`
+(default `http://localhost:5173`), read by both Vite (port, HMR) and Django
+(template, CSP). Set it in `env.d/web` to use another port:
+
+```
+WEB_VITE_DEV_ORIGIN=http://localhost:5200
+```
+
+An `https://` origin switches Vite to reverse-proxy mode (HMR over `wss`), for
+setups that serve the dev server behind a named host. The origin's host and
+port then drive the HMR client; Django's CSP follows the same variable.
 
 ## Production Build
 
@@ -120,8 +134,8 @@ The `ats/base.html` template uses custom Django tags to load Vite assets:
 {% load vite_tags %}
 
 {% if debug %}
-  <!-- Dev: load from Vite HMR -->
-  <script type="module" src="http://localhost:5173/src/app/main.ts"></script>
+  <!-- Dev: load from the Vite dev server (WEB_VITE_DEV_ORIGIN) -->
+  <script type="module" src="{% vite_dev_asset 'src/app/main.ts' %}"></script>
 {% else %}
   <!-- Prod: load from static with hash -->
   {% vite_css 'src/app/main.ts' %}
@@ -133,7 +147,7 @@ The `{% vite_asset %}` and `{% vite_css %}` tags read Vite's `manifest.json` to 
 
 ## CSP (Content Security Policy)
 
-In dev mode, CSP allows `localhost:5173` for HMR. Configured in `config/settings/dev.py`.
+In dev mode, CSP allows the Vite dev origin (`WEB_VITE_DEV_ORIGIN`, including its `ws`/`wss` variant for HMR). Derived in `config/settings/dev.py`.
 
 ## Feature Structure
 

--- a/env.d/web-example
+++ b/env.d/web-example
@@ -9,6 +9,10 @@ WEB_ROBOTS_INDEXING=1
 
 WEB_DEBUG_TOOLBAR=1
 
+# Vite dev server origin (port, HMR, CSP). Default http://localhost:5173.
+# Use an https:// origin to serve Vite behind a named host (HMR over wss).
+WEB_VITE_DEV_ORIGIN=http://localhost:5173
+
 # database
 WEB_DATABASE_URL=psql://web:pass@localhost:5432/web
 

--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -195,6 +195,8 @@ DSFR_USE_INTEGRITY_CHECKSUMS = False
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "static_collected"
 
+VITE_DEV_ORIGIN = env.str("VITE_DEV_ORIGIN", default="http://localhost:5173")
+
 STORAGES = {
     "staticfiles": {
         "BACKEND": "config.storages.ViteCompressedManifestStaticFilesStorage",

--- a/src/web/config/settings/dev.py
+++ b/src/web/config/settings/dev.py
@@ -55,16 +55,18 @@ AUTH_PASSWORD_VALIDATORS = []
 REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] = []  # noqa: F405
 
 # CSP overrides for Vite dev server
-SECURE_CSP["script-src"] = [*SECURE_CSP["script-src"], "http://localhost:5173"]  # noqa: F405
+_vite_origin = VITE_DEV_ORIGIN  # noqa: F405
+_vite_ws_origin = _vite_origin.replace("https://", "wss://").replace("http://", "ws://")
+SECURE_CSP["script-src"] = [*SECURE_CSP["script-src"], _vite_origin]  # noqa: F405
 SECURE_CSP["script-src-elem"] = [  # noqa: F405
     *SECURE_CSP["script-src-elem"],  # noqa: F405
-    "http://localhost:5173",
+    _vite_origin,
 ]
 SECURE_CSP["connect-src"] = [  # noqa: F405
     *SECURE_CSP["connect-src"],  # noqa: F405
-    "http://localhost:5173",
-    "ws://localhost:5173",
+    _vite_origin,
+    _vite_ws_origin,
 ]
 SECURE_CSP["style-src"] = ["'self'", "'unsafe-inline'"]  # noqa: F405
 SECURE_CSP["style-src-elem"] = ["'self'", "'unsafe-inline'"]  # noqa: F405
-SECURE_CSP["font-src"] = [*SECURE_CSP["font-src"], "http://localhost:5173"]  # noqa: F405
+SECURE_CSP["font-src"] = [*SECURE_CSP["font-src"], _vite_origin]  # noqa: F405

--- a/src/web/presentation/ats/templatetags/vite_tags.py
+++ b/src/web/presentation/ats/templatetags/vite_tags.py
@@ -27,6 +27,11 @@ def _load_manifest() -> dict:
 
 
 @register.simple_tag
+def vite_dev_asset(path: str) -> str:
+    return f"{settings.VITE_DEV_ORIGIN.rstrip('/')}/{path}"
+
+
+@register.simple_tag
 def vite_asset(entry: str) -> str:
     manifest = _load_manifest()
 

--- a/src/web/presentation/frontend/vite.config.ts
+++ b/src/web/presentation/frontend/vite.config.ts
@@ -1,11 +1,33 @@
 /// <reference types="vitest" />
 import { dirname, resolve } from 'node:path'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const devOrigin = process.env.WEB_VITE_DEV_ORIGIN ?? 'http://localhost:5173'
+const atsOrigin = process.env.WEB_ATS_ORIGIN ?? 'http://localhost:8000'
+const devUrl = new URL(devOrigin)
+
+const server = devUrl.protocol === 'https:'
+  ? {
+      origin: devOrigin,
+      cors: { origin: atsOrigin },
+      hmr: {
+        protocol: 'wss',
+        host: devUrl.hostname,
+        clientPort: Number(devUrl.port) || 443,
+      },
+    }
+  : {
+      port: Number(devUrl.port) || 5173,
+      strictPort: true,
+      origin: devOrigin,
+      cors: { origin: atsOrigin },
+    }
 
 export default defineConfig(({ command }) => ({
   base: command === 'build' ? '/static/frontend/' : '/',
@@ -23,13 +45,7 @@ export default defineConfig(({ command }) => ({
       input: resolve(__dirname, 'src/app/main.ts'),
     },
   },
-  server: {
-    port: 5173,
-    origin: 'http://localhost:5173',
-    cors: {
-      origin: 'http://localhost:8000',
-    },
-  },
+  server,
   test: {
     environment: 'jsdom',
     coverage: {

--- a/src/web/presentation/templates/ats/base.html
+++ b/src/web/presentation/templates/ats/base.html
@@ -6,8 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>ATS - CSPLab</title>
         {% if debug %}
-            <script type="module" src="http://localhost:5173/@vite/client"></script>
-            <script type="module" src="http://localhost:5173/src/app/main.ts"></script>
+            <script type="module" src="{% vite_dev_asset '@vite/client' %}"></script>
+            <script type="module" src="{% vite_dev_asset 'src/app/main.ts' %}"></script>
         {% else %}
             {% vite_css 'src/app/main.ts' %}
             <script type="module" src="{% vite_asset 'src/app/main.ts' %}"></script>

--- a/src/web/tests/presentation/ats/test_vite_tags.py
+++ b/src/web/tests/presentation/ats/test_vite_tags.py
@@ -1,0 +1,17 @@
+from django.template import Context, Template
+from django.test import override_settings
+
+
+def _render(path: str) -> str:
+    template = Template("{% load vite_tags %}{% vite_dev_asset path %}")
+    return template.render(Context({"path": path}))
+
+
+class TestViteDevAsset:
+    @override_settings(VITE_DEV_ORIGIN="http://localhost:5173")
+    def test_joins_origin_and_path(self):
+        assert _render("src/app/main.ts") == "http://localhost:5173/src/app/main.ts"
+
+    @override_settings(VITE_DEV_ORIGIN="https://vite.csplab.localhost/")
+    def test_normalizes_trailing_slash(self):
+        assert _render("@vite/client") == "https://vite.csplab.localhost/@vite/client"


### PR DESCRIPTION
## 📝 Description
🎸 Le point d'entrée du serveur Vite en dev était figé sur `http://localhost:5173`, hardcodé dans le template, la config Vite et la CSP. Cette PR le pilote via une seule variable, `WEB_VITE_DEV_ORIGIN`, lue côté Vite (port, HMR, CORS) et côté Django (template, CSP). Une origine `https://` bascule Vite en mode reverse-proxy (HMR en `wss`), ce qui permet de servir le dev derrière un hôte nommé.

## 🏷️ Type de changement
- [x] 🔧 Changement technique

## 🏝️ Comment tester
- Sans rien changer : `make dev` + `make frontend-dev`, l'app charge Vite sur :5173
- Autre port : `WEB_VITE_DEV_ORIGIN=http://localhost:5200` dans `env.d/web`, relancer
- Vérifier que la CSP en dev autorise bien l'origine choisie (pas d'erreur console)

## ✅ Liste de contrôle
- [x] 💅 Tests ajoutés (tag `vite_dev_asset`)
- [x] 📝 Documentation mise à jour
- [x] 🚀 Impact perf/sécu/UX pris en compte (dev-only, CSP dérivée de la variable)