### PR TITLE
🔧(tooling) add mise tasks as an ergonomic layer over make

### DIFF
--- a/docs/local_https_named_host.md
+++ b/docs/local_https_named_host.md
@@ -1,0 +1,43 @@
+# Servir l'ATS sur un hôte HTTPS local nommé
+
+Par défaut, l'ATS tourne sur `http://localhost:8000` et charge Vite depuis
+`http://localhost:5173`. On peut aussi le servir derrière un nom stable en HTTPS
+(ex. `https://csplab.localhost`, sans port). Le dépôt ne code aucun hôte en dur ;
+le reverse-proxy (Caddy, Traefik, valet + portless…) reste propre à chaque machine.
+
+## Contrat pour servir l'ATS sur un hôte HTTPS local nommé, quel que soit le reverse-proxy
+
+1. **Origines** : `WEB_VITE_DEV_ORIGIN` (lue par Vite et Django) pointe vers
+   l'hôte Vite public. Une origine `https://` bascule Vite en reverse-proxy
+   (HMR `wss`) et adapte la CSP dev. `WEB_ATS_ORIGIN` indique à Vite l'origine de
+   la page, sans quoi le CORS refuse le chargement des modules :
+
+   ```
+   WEB_VITE_DEV_ORIGIN=https://vite.csplab.localhost
+   WEB_ATS_ORIGIN=https://csplab.localhost
+   ```
+
+2. **Router les hôtes** via le proxy :
+- `csplab.localhost` : Django `:8000`,
+- `vite.csplab.localhost` : serveur Vite.
+
+3. **Autoriser hôte + CSRF** dans `env.d/web` :
+
+   ```
+   WEB_ALLOWED_HOSTS=.localhost,127.0.0.1,0.0.0.0
+   WEB_CSRF_TRUSTED_ORIGINS=https://csplab.localhost
+   ```
+
+## Exemple : portless
+
+En utilisant [portless](https://www.npmjs.com/package/portless), on peut :
+
+1. Configurer un alias via `portless alias csplab 8000`
+
+2. Référencer des tâches dans un fichier `mise.local.toml` (gitignoré) qui surchargeront le `mise.local` versionné :
+- `front:portless` : Vite via portless, `WEB_VITE_DEV_ORIGIN` + `WEB_ATS_ORIGIN` sur les hôtes nommés ;
+- `back:portless` : `make run-web` avec la même origine ;
+- `open:portless` : attend le back puis ouvre `https://csplab.localhost` ;
+- `dev` : override du `dev` versionné vers les trois ci-dessus.
+
+Résultat : `mise dev` prépare, sert et ouvre l'ATS sur `https://csplab.localhost`.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,74 @@
+# Tâches mise : surcouche d'ergonomie optionnelle pour le dev front par-dessus le Makefile
+
+[tools]
+node = "24"        # engines.node (src/web/package.json)
+pnpm = "11.1.3"    # packageManager (src/web/package.json)
+
+# ── Frontend (node seul, aucun service back requis) ──────────────────────────
+[tasks.sb]
+description = "Storybook front"
+run = "make storybook"
+
+[tasks."front:dev"]
+description = "Vite HMR front"
+run = "make frontend-dev"
+
+[tasks.check]
+description = "Front : lint + typecheck + tests"
+run = "make frontend-check"
+
+# ── Install & migrations ─────────────────────────────────────────────────────
+[tasks."install:py"]
+description = "Dépendances Python du back (uv : web + ddd + referentiel)"
+run = "make build-web"
+
+[tasks."install:js"]
+description = "Dépendances frontend (pnpm)"
+run = "make frontend-install"
+
+[tasks.install]
+description = "Installe les dépendances ATS (Python + frontend)"
+depends = ["install:py", "install:js"]
+
+# ── Services & app (Docker + Django) ─────────────────────────────────────────
+[tasks."docker:up"]
+description = "Vérifie que Docker est joignable (démarrez votre moteur au besoin)"
+run = "docker info >/dev/null 2>&1 || { echo 'Docker injoignable, démarrez votre moteur (Colima, Docker Desktop, OrbStack…)'; exit 1; }"
+
+[tasks."services:ats"]
+description = "Démarre postgres (suffit pour le dev ATS)"
+depends = ["docker:up"]
+run = "make run-postgres"
+
+[tasks."services:cv"]
+description = "Postgres + Redis + Qdrant (recherche vectorielle, analyse de CV, ingestion)"
+depends = ["docker:up"]
+run = ["make run-postgres", "make run-redis", "make run-qdrant"]
+
+[tasks."back:ats"]
+description = "Back Django"
+depends = ["services:ats"]
+run = "make run-web"
+
+[tasks."back:cv"]
+description = "Back Django + sass watch (dev candidat/CV : styles SCSS DSFR)"
+depends = ["services:cv"]
+run = "make dev"
+
+[tasks.migrate]
+description = "Applique les migrations Django"
+depends = ["services:ats"]
+run = "make migrate"
+
+[tasks."open:ats"]
+description = "Ouvre http://localhost:8000/ats/ quand le back répond"
+# depends parallèles : on sonde le back avant d'ouvrir. Opener portable, non-fatal.
+run = "URL=http://localhost:8000/ats/; for _ in $(seq 1 120); do curl -s -o /dev/null \"$URL\" && break; sleep 0.5; done; (open \"$URL\" || xdg-open \"$URL\") >/dev/null 2>&1 || true"
+
+[tasks.dev]
+description = "Stack complète pour dev le front de l'ATS"
+depends = ["back:ats", "front:dev", "open:ats"]
+
+[tasks.emulate-prod]
+description = "Émule la prod : build front + collectstatic + runserver :8001"
+run = "cd src/web && (cd presentation/frontend && corepack pnpm exec vite build --mode production) && DJANGO_SETTINGS_MODULE=config.settings.base direnv exec . python manage.py collectstatic --noinput --clear && DJANGO_SETTINGS_MODULE=config.settings.base direnv exec . env WEB_ALLOWED_HOSTS=localhost,127.0.0.1 python manage.py runserver 8001 --noreload"


### PR DESCRIPTION
## 📝 Description
Ajoute un `mise.toml` optionnel qui reprend les cibles make du scope frontend en tâches courtes et namespacées. 

Sépare le dev ats du volet candidat/cv :
- `services:ats` (postgres seul) vs `services:cv` (+ redis + qdrant),
- `back:ats` (vite, sans sass) vs `back:cv` (+ sass).
- `mise dev` lance back + vite et ouvre le navigateur quand le back répond.

Une config spécifique-machine (démarage du moteur docker, reverse-proxy) peut surcharger la config versionnée dans un `mise.local.toml` gitignoré.

## 🏷️ Type de changement
- [x] 🔧 Changement technique
- [x] 📚 Mise à jour de la documentation

## 🔧 Modifications
- `mise.toml` : install(:py/:js), docker:up, services:ats/:cv, back:ats/:cv, migrate, dev (auto-open), sb, check, emulate-prod
- `docs/local_https_named_host.md` : servir l'ats derrière un hôte https nommé (contrat proxy-agnostique + exemple portless)

## 🏝️ Comment tester
- installer [mise](https://mise.jdx.dev/installing-mise.html)
- `mise tasks` liste les tâches ; `mise dev` démarre la stack ats

## ✅ Liste de contrôle
- [x] 📝 Documentation ajoutée