### PR TITLE
🐛(ats-presentation) fix storybook theme management

### DIFF
--- a/src/web/presentation/frontend/.storybook/preview.ts
+++ b/src/web/presentation/frontend/.storybook/preview.ts
@@ -3,6 +3,7 @@ import { setup } from '@storybook/vue3'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import '../src/app/icons'
 import '../src/styles/index.css'
+import './storybook.css'
 
 const storybookRouter = createRouter({
   history: createMemoryHistory(),

--- a/src/web/presentation/frontend/.storybook/preview.ts
+++ b/src/web/presentation/frontend/.storybook/preview.ts
@@ -13,7 +13,35 @@ setup((app) => {
   app.use(storybookRouter)
 })
 
+function applyTheme(theme: string) {
+  localStorage.setItem('csp_color_mode', theme)
+  document.documentElement.setAttribute('data-fr-theme', theme)
+}
+
 const preview: Preview = {
+  initialGlobals: {
+    theme: 'light',
+  },
+  globalTypes: {
+    theme: {
+      description: 'Thème DSFR',
+      toolbar: {
+        title: 'Thème',
+        icon: 'contrast',
+        items: [
+          { value: 'light', title: 'Clair', icon: 'sun' },
+          { value: 'dark', title: 'Sombre', icon: 'moon' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (story, context) => {
+      applyTheme(context.globals.theme ?? 'light')
+      return { components: { story }, template: '<story />' }
+    },
+  ],
   parameters: {
     options: {
       storySort: {

--- a/src/web/presentation/frontend/.storybook/storybook.css
+++ b/src/web/presentation/frontend/.storybook/storybook.css
@@ -1,0 +1,7 @@
+/* Storybook Docs renders story previews on a hardcoded white surface (an emotion
+   class on the same element). Carry the DSFR default surface token instead so
+   previews react to the DSFR theme; two classes outrank the emotion single-class
+   rule without needing !important. */
+.sbdocs.sbdocs-preview {
+  background-color: var(--background-default-grey);
+}

--- a/src/web/presentation/frontend/src/components/base/CspDataTable/CspDataTable.vue
+++ b/src/web/presentation/frontend/src/components/base/CspDataTable/CspDataTable.vue
@@ -418,6 +418,7 @@ function onActivate(id: string): void {
 .csp-table-wrapper {
   width: 100%;
   border: 1px solid var(--border-default-grey);
+  background: var(--background-default-grey);
   overflow: hidden;
 
   &.csp-table-wrapper--sm {

--- a/src/web/presentation/frontend/src/components/base/CspSkeleton/CspSkeletonTable.vue
+++ b/src/web/presentation/frontend/src/components/base/CspSkeleton/CspSkeletonTable.vue
@@ -66,6 +66,7 @@ withDefaults(defineProps<CspSkeletonTableProps>(), {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--border-default-grey);
+  background: var(--background-default-grey);
 }
 
 .csp-skeleton-table__row {


### PR DESCRIPTION
## 📝 Description
Le thème dsfr fuyait dans storybook : charger la story sidebarposait `data-fr-theme` sur le html partagé de l'iframe, faisant passer d'autres stories en sombre de façon incohérente. Par ailleurs le fond des previews ne réagissait pas au thème, ce qui révélait que certains composants (table, skeleton de table) étaient transparents et dépendaient du fond ambiant.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
- Toolbar de thème global + décorateur qui applique `data-fr-theme` de façon déterministe par story et synchronise `csp_color_mode` lu par `useColorMode`
- fond des previews porté sur `--background-default-grey` (réagit au thème) au lieu du blanc en dur de sb.
- ajout d'un fond opaque sur `CspDataTable` et `CspSkeletonTable`

## ✅ Liste de contrôle
- [x] 🚀 Impact vérifié visuellement (clair/sombre, vues story et docs)
- [ ] 💅 Tests (n/a, thème Storybook + surfaces CSS)
