### PR TITLE
🐛(ingestion) fix education level mapping for NIV_DIPL 6-9

### DIFF
--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -355,6 +355,12 @@ class OffersCleaner:
         "H": 8,
     }
     _NIV_DIPL_PATTERN = re.compile(r"NIV_DIPL(\d)")
+    _NIV_DIPL_LEVEL_OVERRIDES: dict[int, int] = {
+        6: 6,
+        7: 6,
+        8: 7,
+        9: 8,
+    }
 
     def _map_education_level(self, client_code: str) -> Optional[int]:
         if client_code in self._EDUCATION_LEVEL_MAPPING:
@@ -363,6 +369,7 @@ class OffersCleaner:
         match = self._NIV_DIPL_PATTERN.fullmatch(client_code)
         if match:
             level = int(match.group(1))
+            level = self._NIV_DIPL_LEVEL_OVERRIDES.get(level, level)
             if Diploma.MIN_DIPLOMA_LEVEL <= level <= Diploma.MAX_DIPLOMA_LEVEL:
                 return level
 

--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -354,6 +354,10 @@ class OffersCleaner:
         "G": 7,
         "H": 8,
     }
+
+    # ARS has a different pattern for education levels.
+    # NIV_DIPL(\d) can be mapped to just the digit, except for a few
+    # special cases for which we configure overrides.
     _NIV_DIPL_PATTERN = re.compile(r"NIV_DIPL(\d)")
     _NIV_DIPL_LEVEL_OVERRIDES: dict[int, int] = {
         6: 6,

--- a/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
+++ b/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
@@ -414,8 +414,10 @@ def test_clean_returns_none_end_publication_date_when_absent(cleaner):
         ("G", 7),
         ("H", 8),
         ("NIV_DIPL1", 1),
-        ("NIV_DIPL7", 7),
-        ("NIV_DIPL8", 8),
+        ("NIV_DIPL6", 6),
+        ("NIV_DIPL7", 6),
+        ("NIV_DIPL8", 7),
+        ("NIV_DIPL9", 8),
     ],
 )
 def test_clean_maps_education_level(cleaner, client_code, expected):
@@ -427,7 +429,7 @@ def test_clean_maps_education_level(cleaner, client_code, expected):
     assert offer.education_level == expected
 
 
-@pytest.mark.parametrize("client_code", ["UNKNOWN_CODE", "NIV_DIPL9", "NIV_DIPL0"])
+@pytest.mark.parametrize("client_code", ["UNKNOWN_CODE", "NIV_DIPL0"])
 def test_clean_maps_unknown_education_level_to_none(cleaner, client_code):
     education = TalentsoftCodedObjectFactory.build(clientCode=client_code)
     raw_offer = _make_raw_offer(educationLevel=education)


### PR DESCRIPTION
## 📝 Description

Retravaille le mapping du niveau de diplôme pour les codes venant de l'ARS.

PR précédente #1028

Voici le mapping côté ARS

<img width="588" height="192" alt="image002" src="https://github.com/user-attachments/assets/5cbd9425-fa5a-41f5-84d3-e57723910f8a" />

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
