### PR TITLE
✨(recruteur-usecase) Pipeline Offre - reinitialisation des étapes - INTERFACE

### DIFF
--- a/src/web/application/recruteur/usecases/init_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/init_recrutement_etapes.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+from ddd.usecase_interface import IUseCase
+
+from application.recruteur.dtos.etape_data import EtapeData, etapes_par_defaut
+from application.recruteur.dtos.recrutement_request import RecrutementRequest
+from domain.identite.repositories.organisme_repository_interface import (
+    IOrganismeRepository,
+)
+
+
+@dataclass(kw_only=True)
+class InitRecrutementEtapesCommand(RecrutementRequest):
+    pass
+
+
+# TODO: ajouter
+# - RBAC organisme, RBAC recrutement
+# - copier les etapes par defaut de l'organisme sur ce recrutement (au lieu du
+#   pipeline statique ci-dessous), sauvegarde + emission evenement + audit log
+class InitRecrutementEtapesUsecase(
+    IUseCase[InitRecrutementEtapesCommand, list[EtapeData]]
+):
+    def __init__(self, organisme_repository: IOrganismeRepository):
+        self.organisme_repository = organisme_repository
+
+    def execute(self, command: InitRecrutementEtapesCommand) -> list[EtapeData]:
+        self.organisme_repository.get_by_id(command.organisme_id)
+        return etapes_par_defaut()

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -17,6 +17,9 @@ from application.recruteur.usecases.get_recrutement_kanban import (
 from application.recruteur.usecases.get_recrutement_liste import (
     GetRecrutementListeUsecase,
 )
+from application.recruteur.usecases.init_recrutement_etapes import (
+    InitRecrutementEtapesUsecase,
+)
 from application.recruteur.usecases.initialize_organisme_steps import (
     InitializeOrganismeStepsUsecase,
 )
@@ -186,5 +189,10 @@ class RecruteurContainer(containers.DeclarativeContainer):
 
     update_recrutement_etapes_usecase = providers.Factory(
         UpdateRecrutementEtapesUsecase,
+        organisme_repository=postgres_organisme_repository,
+    )
+
+    init_recrutement_etapes_usecase = providers.Factory(
+        InitRecrutementEtapesUsecase,
         organisme_repository=postgres_organisme_repository,
     )

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -167,6 +167,23 @@ export interface paths {
         patch: operations["recruteur_organisme_recrutements_etapes_partial_update"];
         trace?: never;
     };
+    "/recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes/init": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Réinitialiser les étapes par défaut d'un recrutement */
+        post: operations["recruteur_organisme_recrutements_etapes_init_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/kanban": {
         parameters: {
             query?: never;
@@ -1308,6 +1325,52 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+        };
+    };
+    recruteur_organisme_recrutements_etapes_init_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organisme_uuid: string;
+                recrutement_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EtapeRecrutement"][];
                 };
             };
             401: {

--- a/src/web/presentation/recruteur/urls.py
+++ b/src/web/presentation/recruteur/urls.py
@@ -10,6 +10,7 @@ from presentation.recruteur.views.organismes import (
     OrganismeView,
 )
 from presentation.recruteur.views.recrutements import (
+    InitRecrutementEtapeView,
     RecrutementCandidaturesEtapeView,
     RecrutementEtapeView,
     RecrutementKanbanView,
@@ -65,6 +66,11 @@ urlpatterns = [
         "organisme/<uuid:organisme_uuid>/recrutements/<uuid:recrutement_uuid>/etapes",
         RecrutementEtapeView.as_view(),
         name="organisme-recrutement-etapes",
+    ),
+    path(
+        "organisme/<uuid:organisme_uuid>/recrutements/<uuid:recrutement_uuid>/etapes/init",
+        InitRecrutementEtapeView.as_view(),
+        name="organisme-recrutement-etapes-init",
     ),
     path(
         "candidature/<uuid:candidature_uuid>/notes",

--- a/src/web/presentation/recruteur/views/recrutements.py
+++ b/src/web/presentation/recruteur/views/recrutements.py
@@ -21,6 +21,9 @@ from application.recruteur.usecases.get_recrutement_kanban import (
 from application.recruteur.usecases.get_recrutement_liste import (
     GetRecrutementListeQuery,
 )
+from application.recruteur.usecases.init_recrutement_etapes import (
+    InitRecrutementEtapesCommand,
+)
 from application.recruteur.usecases.lister_mes_recrutements import (
     ListerMesRecrutementsQuery,
 )
@@ -417,6 +420,50 @@ class RecrutementEtapeView(APIView):
                 _etapes_to_serializer_data(resultat), many=True
             )
             return Response(out_serializer.data)
+        except OrganismeNexistePas:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        except Exception:
+            error_serializer = GenericErrorSerializer({"error": "Unexpected error"})
+            return Response(
+                error_serializer.data, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+
+@extend_schema(
+    summary="Réinitialiser les étapes par défaut d'un recrutement",
+    tags=["recruteur"],
+    request=None,
+    responses={
+        201: EtapeRecrutementSerializer(many=True),
+        401: TokenErrorSerializer,
+        404: GenericErrorSerializer,
+        500: GenericErrorSerializer,
+    },
+)
+class InitRecrutementEtapeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.container = recruteur_container()
+
+    def post(
+        self, request: Request, organisme_uuid: UUID, recrutement_uuid: UUID
+    ) -> Response:
+        try:
+            usecase = self.container.init_recrutement_etapes_usecase()
+            resultat = usecase.execute(
+                InitRecrutementEtapesCommand(
+                    organisme_id=organisme_uuid,
+                    recrutement_id=recrutement_uuid,
+                    utilisateur_id=UUID(request.user.username),
+                    est_staff=request.user.is_staff,
+                )
+            )
+            serializer = EtapeRecrutementSerializer(
+                _etapes_to_serializer_data(resultat), many=True
+            )
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
         except OrganismeNexistePas:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except Exception:

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -732,6 +732,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+  /recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes/init:
+    post:
+      operationId: recruteur_organisme_recrutements_etapes_init_create
+      summary: Réinitialiser les étapes par défaut d'un recrutement
+      parameters:
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: recrutement_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - recruteur
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EtapeRecrutement'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/kanban:
     get:
       operationId: recruteur_organisme_recrutements_kanban_retrieve

--- a/src/web/tests/application/recruteur/test_init_recrutement_etapes.py
+++ b/src/web/tests/application/recruteur/test_init_recrutement_etapes.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from application.recruteur.usecases.init_recrutement_etapes import (
+    InitRecrutementEtapesCommand,
+    InitRecrutementEtapesUsecase,
+)
+from domain.identite.errors.organisme_errors import OrganismeNexistePas
+
+
+@pytest.fixture(name="organisme_repository")
+def organisme_repository_fixture():
+    repo = MagicMock()
+    repo.get_by_id.return_value = MagicMock()
+    return repo
+
+
+@pytest.fixture(name="usecase")
+def usecase_fixture(organisme_repository):
+    return InitRecrutementEtapesUsecase(organisme_repository=organisme_repository)
+
+
+class TestInitRecrutementEtapesUsecase:
+    def test_returns_default_pipeline(self, organisme_repository, usecase):
+        organisme_id = uuid4()
+
+        resultat = usecase.execute(
+            InitRecrutementEtapesCommand(
+                organisme_id=organisme_id,
+                recrutement_id=uuid4(),
+                utilisateur_id=uuid4(),
+            )
+        )
+
+        assert [e.nom for e in resultat] == [
+            "Réception des candidatures",
+            "Présélection",
+            "Entretien",
+            "Proposition",
+            "Refus",
+            "Recrutement",
+        ]
+        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
+
+    def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
+        organisme_id = uuid4()
+        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
+            str(organisme_id)
+        )
+
+        with pytest.raises(OrganismeNexistePas):
+            usecase.execute(
+                InitRecrutementEtapesCommand(
+                    organisme_id=organisme_id,
+                    recrutement_id=uuid4(),
+                    utilisateur_id=uuid4(),
+                )
+            )

--- a/src/web/tests/infrastructure/recruteur/test_init_recrutement_etapes.py
+++ b/src/web/tests/infrastructure/recruteur/test_init_recrutement_etapes.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from application.recruteur.usecases.init_recrutement_etapes import (
+    InitRecrutementEtapesCommand,
+)
+from config.app_config import AppConfig
+from domain.commons.services.audit_log_writer import AuditLogWriter
+from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
+from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.gateways.shared.logger import LoggerService
+
+NB_ETAPES_PAR_DEFAUT = 6
+
+
+@pytest.fixture(name="recruteur_integration_container")
+def recruteur_integration_container_fixture(db):
+    container = RecruteurContainer()
+    app_config = AppConfig.from_django_settings()
+    logger_service = LoggerService()
+    container.app_config.override(app_config)
+    container.logger_service.override(logger_service)
+    container.audit_log_writer.override(MagicMock(spec=AuditLogWriter))
+    return container
+
+
+class TestInitRecrutementEtapes:
+    # TODO : update this class after persistence is implemented
+    def test_init_recrutement_etapes(self, db, recruteur_integration_container):
+        organisme_model = OrganismeFactory.create_model()
+        usecase = recruteur_integration_container.init_recrutement_etapes_usecase()
+
+        resultat = usecase.execute(
+            InitRecrutementEtapesCommand(
+                organisme_id=organisme_model.id,
+                recrutement_id=uuid4(),
+                utilisateur_id=uuid4(),
+            )
+        )
+
+        assert len(resultat) == NB_ETAPES_PAR_DEFAUT
+
+    def test_init_recrutement_etapes_raises_when_organisme_introuvable(
+        self, db, recruteur_integration_container
+    ):
+        usecase = recruteur_integration_container.init_recrutement_etapes_usecase()
+
+        with pytest.raises(OrganismeNexistePas):
+            usecase.execute(
+                InitRecrutementEtapesCommand(
+                    organisme_id=uuid4(),
+                    recrutement_id=uuid4(),
+                    utilisateur_id=uuid4(),
+                )
+            )

--- a/src/web/tests/presentation/recruteur/test_views_recrutements.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutements.py
@@ -135,6 +135,10 @@ RECRUTEMENT_ETAPES_URL = reverse(
     "recruteur:organisme-recrutement-etapes",
     kwargs={"organisme_uuid": ORGANISME_UUID, "recrutement_uuid": RECRUTEMENT_UUID},
 )
+RECRUTEMENT_ETAPES_INIT_URL = reverse(
+    "recruteur:organisme-recrutement-etapes-init",
+    kwargs={"organisme_uuid": ORGANISME_UUID, "recrutement_uuid": RECRUTEMENT_UUID},
+)
 
 
 @pytest.fixture
@@ -723,6 +727,46 @@ class TestRecrutementEtapeView:
             data=[{"nom": "Réception", "categorie": "ENTREE"}],
             format="json",
         )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"error": "Unexpected error"}
+
+
+class TestInitRecrutementEtapeView:
+    def test_anonymous_access_is_unauthorized(self, api_client):
+        response = api_client.post(RECRUTEMENT_ETAPES_INIT_URL)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_201_with_default_pipeline(self, container, authenticated_client):
+        etapes = _etapes_stub()
+        container.init_recrutement_etapes_usecase.return_value.execute.return_value = (
+            etapes
+        )
+
+        response = authenticated_client.post(RECRUTEMENT_ETAPES_INIT_URL)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert len(data) == NB_ETAPES_STUB
+        assert data[1]["nom"] == "Recrutement"
+        assert data[1]["categorie"] == "ACCEPTE"
+
+    def test_returns_404_for_unknown_organisme(self, container, authenticated_client):
+        container.init_recrutement_etapes_usecase.return_value.execute.side_effect = (
+            OrganismeNexistePas("not found")
+        )
+
+        response = authenticated_client.post(RECRUTEMENT_ETAPES_INIT_URL)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {"detail": "Not found."}
+
+    def test_returns_500_on_unexpected_error(self, container, authenticated_client):
+        container.init_recrutement_etapes_usecase.return_value.execute.side_effect = (
+            Exception("unexpected")
+        )
+
+        response = authenticated_client.post(RECRUTEMENT_ETAPES_INIT_URL)
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json() == {"error": "Unexpected error"}


### PR DESCRIPTION
📢 requiert #1048 

## 📝 Description
🎸  Ajoute la reinitialisation aux étapes par défaut d'un recrutement (pipeline de recrutement)
🧇 implémentation statique en attendant le branchement complet sur l'agrégat `Recrutement`.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
- **Application (`recruteur`)** : ajout de `InitRecrutementEtapesUsecase`
- **Infrastructure (`recruteur`)** : câblage du nouveau use case dans `RecruteurContainer`
- **Presentation (`recruteur`)** : nouvelle vue `InitRecrutementEtapeView`
- mise à jour des schémas

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
