### PR TITLE
✨(recruteur-usecase) Mise en place RBAC pour les agents selon leurs rôles sur un recrutement

### DIFF
--- a/src/web/application/recruteur/usecases/get_recrutement_kanban.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_kanban.py
@@ -42,11 +42,11 @@ class GetRecrutementKanbanUsecase(
     def execute(
         self, query: GetRecrutementKanbanQuery
     ) -> RecrutementKanbanReadModel | None:
-        # TODO RBAC : handle MEMBRE role on recrutement
         self.organisme_permission_service.est_autorise(
             action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
             organisme_id=query.organisme_id,
             agent_id=query.utilisateur_id,
+            recrutement_id=query.recrutement_id,
             est_staff=query.est_staff,
         )
         self.organisme_repository.get_by_id(query.organisme_id)

--- a/src/web/application/recruteur/usecases/get_recrutement_liste.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_liste.py
@@ -43,11 +43,11 @@ class GetRecrutementListeUsecase(
     def execute(
         self, query: GetRecrutementListeQuery
     ) -> IPage[CandidatureListeReadModel] | None:
-        # TODO RBAC : handle MEMBRE role on recrutement
         self.organisme_permission_service.est_autorise(
             action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
             organisme_id=query.organisme_id,
             agent_id=query.utilisateur_id,
+            recrutement_id=query.recrutement_id,
             est_staff=query.est_staff,
         )
         self.organisme_repository.get_by_id(query.organisme_id)

--- a/src/web/domain/recruteur/errors/organisme_permission_errors.py
+++ b/src/web/domain/recruteur/errors/organisme_permission_errors.py
@@ -11,3 +11,14 @@ class AccesOrganismeRefuse(OrganismePermissionError):
     def __init__(self, organisme_id: UUID):
         super().__init__(f"Rôle non autorisé sur l'organisme {organisme_id}")
         self.organisme_id = organisme_id
+
+
+class AccesRecrutementRefuse(OrganismePermissionError):
+    def __init__(self, recrutement_id: UUID):
+        super().__init__(f"Rôle non autorisé sur le recrutement {recrutement_id}")
+        self.recrutement_id = recrutement_id
+
+
+class AccesRecrutementInconnu(OrganismePermissionError):
+    def __init__(self):
+        super().__init__("Recrutement inconnu")

--- a/src/web/domain/recruteur/repositories/recrutement_agent_repository_interface.py
+++ b/src/web/domain/recruteur/repositories/recrutement_agent_repository_interface.py
@@ -1,0 +1,10 @@
+from typing import Protocol
+from uuid import UUID
+
+from domain.recruteur.value_objects.roles import AgentRecrutementRole
+
+
+class IRecrutementAgentRepository(Protocol):
+    def get_role(
+        self, *, recrutement_id: UUID, agent_id: UUID
+    ) -> AgentRecrutementRole | None: ...

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -1,12 +1,20 @@
 from uuid import UUID
 
-from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    AccesRecrutementInconnu,
+    AccesRecrutementRefuse,
+)
 from domain.recruteur.repositories.organisme_agent_repository_interface import (
     IOrganismeAgentRepository,
+)
+from domain.recruteur.repositories.recrutement_agent_repository_interface import (
+    IRecrutementAgentRepository,
 )
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
 
+# Actions pour lesquelles un AGENT doit avoir un rôle sur l'organisme
 _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.GET_ORGANISME: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.INITIALIZE_ORGANISME_STEPS: frozenset(
@@ -30,10 +38,20 @@ _AUTORISE_POUR_STAFF: frozenset[OrganismeAction] = frozenset(
     }
 )
 
+# Actions pour lesquelles un MEMBRE doit en plus être affecté au recrutement visé
+_REQUIERT_ROLE_RECRUTEMENT: frozenset[OrganismeAction] = frozenset(
+    {OrganismeAction.VOIR_DETAIL_RECRUTEMENT}
+)
+
 
 class OrganismePermissionService:
-    def __init__(self, organisme_agent_repository: IOrganismeAgentRepository) -> None:
+    def __init__(
+        self,
+        organisme_agent_repository: IOrganismeAgentRepository,
+        recrutement_agent_repository: IRecrutementAgentRepository,
+    ) -> None:
         self._organisme_agent_repository = organisme_agent_repository
+        self._recrutement_agent_repository = recrutement_agent_repository
 
     def est_autorise(
         self,
@@ -42,13 +60,26 @@ class OrganismePermissionService:
         organisme_id: UUID,
         agent_id: UUID,
         est_staff: bool,
+        recrutement_id: UUID | None = None,
     ) -> AgentOrganismeRole | None:
         if est_staff and action in _AUTORISE_POUR_STAFF:
             return None
+
         roles_requis = _ROLES_REQUIS[action]
         role = self._organisme_agent_repository.get_role(
             organisme_id=organisme_id, agent_id=agent_id
         )
         if role not in roles_requis:
             raise AccesOrganismeRefuse(organisme_id)
+
+        if role == AgentOrganismeRole.MEMBRE and action in _REQUIERT_ROLE_RECRUTEMENT:
+            if recrutement_id is None:
+                raise AccesRecrutementInconnu()
+
+            recrutement_role = self._recrutement_agent_repository.get_role(
+                recrutement_id=recrutement_id, agent_id=agent_id
+            )
+            if recrutement_role is None:
+                raise AccesRecrutementRefuse(recrutement_id)
+
         return role

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -56,6 +56,9 @@ from infrastructure.repositories.recruteur.postgres_organisme_agent_repository i
 from infrastructure.repositories.recruteur.postgres_organisme_repository import (
     PostgresOrganismeRecruteurRepository,
 )
+from infrastructure.repositories.recruteur.postgres_recrutement_agent_repository import (  # noqa: E501
+    PostgresRecrutementAgentRepository,
+)
 from infrastructure.repositories.recruteur.postgres_recrutement_query_service import (
     PostgresRecrutementQueryService,
 )
@@ -78,9 +81,13 @@ class RecruteurContainer(containers.DeclarativeContainer):
     postgres_organisme_agent_repository = providers.Singleton(
         PostgresOrganismeAgentRepository
     )
+    postgres_recrutement_agent_repository = providers.Singleton(
+        PostgresRecrutementAgentRepository
+    )
     organisme_permission_service = providers.Factory(
         OrganismePermissionService,
         organisme_agent_repository=postgres_organisme_agent_repository,
+        recrutement_agent_repository=postgres_recrutement_agent_repository,
     )
     candidature_mapper = providers.Factory(CandidatureMapper)
     postgres_recrutement_query_service = providers.Singleton(

--- a/src/web/infrastructure/repositories/recruteur/postgres_recrutement_agent_repository.py
+++ b/src/web/infrastructure/repositories/recruteur/postgres_recrutement_agent_repository.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from domain.recruteur.repositories.recrutement_agent_repository_interface import (
+    IRecrutementAgentRepository,
+)
+from domain.recruteur.value_objects.roles import AgentRecrutementRole
+from infrastructure.django_apps.recruteur.models.recrutement import (
+    RecrutementAgentModel,
+)
+
+
+class PostgresRecrutementAgentRepository(IRecrutementAgentRepository):
+    def get_role(
+        self, *, recrutement_id: UUID, agent_id: UUID
+    ) -> AgentRecrutementRole | None:
+        try:
+            liaison = RecrutementAgentModel.objects.get(
+                recrutement_id=recrutement_id,
+                agent_id=str(agent_id),  # type: ignore[misc]
+            )
+        except RecrutementAgentModel.DoesNotExist:
+            return None
+        return AgentRecrutementRole(liaison.role)

--- a/src/web/presentation/recruteur/views/recrutements.py
+++ b/src/web/presentation/recruteur/views/recrutements.py
@@ -21,7 +21,10 @@ from application.recruteur.usecases.lister_mes_recrutements import (
     ListerMesRecrutementsQuery,
 )
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
-from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    OrganismePermissionError,
+)
 from domain.recruteur.value_objects.statut_recrutement import StatutRecrutement
 from infrastructure.di.recruteur.recruteur_factory import recruteur_container
 from presentation.api.serializers import GenericErrorSerializer, TokenErrorSerializer
@@ -179,7 +182,7 @@ class RecrutementKanbanView(APIView):
 
             serializer = RecrutementDetailKanbanSerializer(result)
             return Response(serializer.data)
-        except AccesOrganismeRefuse:
+        except OrganismePermissionError:
             return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except OrganismeNexistePas:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
@@ -297,7 +300,7 @@ class RecrutementListeView(APIView):
             return paginator.get_paginated_response(
                 CandidatureListeSerializer(items, many=True).data
             )
-        except AccesOrganismeRefuse:
+        except OrganismePermissionError:
             return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except OrganismeNexistePas:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)

--- a/src/web/tests/application/recruteur/test_get_recrutement_kanban.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_kanban.py
@@ -24,6 +24,7 @@ from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRe
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
 
 
@@ -115,15 +116,23 @@ class TestGetRecrutementKanban:
         read_model = _recrutement_kanban_read_model()
         recrutement_query_service.get_kanban_by_recrutement.return_value = read_model
 
+        utilisateur_id = uuid4()
         result = usecase.execute(
             GetRecrutementKanbanQuery(
                 organisme_id=organisme_id,
                 recrutement_id=recrutement_id,
-                utilisateur_id=uuid4(),
+                utilisateur_id=utilisateur_id,
             )
         )
 
         assert result == read_model
+        organisme_permission_service.est_autorise.assert_called_once_with(
+            action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
+            organisme_id=organisme_id,
+            agent_id=utilisateur_id,
+            est_staff=False,
+            recrutement_id=recrutement_id,
+        )
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
         recrutement_query_service.get_kanban_by_recrutement.assert_called_once_with(
             organisme_id=organisme_id, recrutement_id=recrutement_id

--- a/src/web/tests/application/recruteur/test_get_recrutement_liste.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_liste.py
@@ -21,6 +21,7 @@ from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRe
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
 
 
@@ -86,15 +87,23 @@ class TestGetRecrutementListe:
             candidatures
         )
 
+        utilisateur_id = uuid4()
         result = usecase.execute(
             GetRecrutementListeQuery(
                 organisme_id=organisme_id,
                 recrutement_id=recrutement_id,
-                utilisateur_id=uuid4(),
+                utilisateur_id=utilisateur_id,
             )
         )
 
         assert result == candidatures
+        organisme_permission_service.est_autorise.assert_called_once_with(
+            action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
+            organisme_id=organisme_id,
+            agent_id=utilisateur_id,
+            est_staff=False,
+            recrutement_id=recrutement_id,
+        )
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
         recrutement_query_service.get_candidatures_by_recrutement.assert_called_once_with(
             organisme_id=organisme_id, recrutement_id=recrutement_id

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -3,24 +3,30 @@ from uuid import uuid4
 
 import pytest
 
-from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    AccesRecrutementInconnu,
+    AccesRecrutementRefuse,
+)
 from domain.recruteur.repositories.organisme_agent_repository_interface import (
     IOrganismeAgentRepository,
+)
+from domain.recruteur.repositories.recrutement_agent_repository_interface import (
+    IRecrutementAgentRepository,
 )
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
-from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
 
 RESPONSABLE_ACTIONS = [
     OrganismeAction.GET_ORGANISME,
     OrganismeAction.INITIALIZE_ORGANISME_STEPS,
     OrganismeAction.UPDATE_ORGANISME_STEPS,
-]
-RESPONSABLE_AND_MEMBRE_ACTIONS = [
-    OrganismeAction.LISTER_MES_RECRUTEMENTS,
-    OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
 ]
 STAFF_BYPASS_ACTIONS = [
     OrganismeAction.GET_ORGANISME,
@@ -31,18 +37,25 @@ STAFF_BYPASS_ACTIONS = [
 
 def _service(
     role: AgentOrganismeRole | None,
-) -> tuple[OrganismePermissionService, Mock]:
+    recrutement_role: AgentRecrutementRole | None = None,
+) -> tuple[OrganismePermissionService, Mock, Mock]:
     repository = Mock(spec=IOrganismeAgentRepository)
     repository.get_role.return_value = role
-    return OrganismePermissionService(organisme_agent_repository=repository), repository
+    recrutement_repository = Mock(spec=IRecrutementAgentRepository)
+    recrutement_repository.get_role.return_value = recrutement_role
+    service = OrganismePermissionService(
+        organisme_agent_repository=repository,
+        recrutement_agent_repository=recrutement_repository,
+    )
+    return service, repository, recrutement_repository
 
 
-class TestEstAutorise:
-    @pytest.mark.parametrize("action", RESPONSABLE_ACTIONS)
-    def test_responsable_only_actions_allow_responsable(
+@pytest.mark.parametrize("action", RESPONSABLE_ACTIONS)
+class TestResponsableActions:
+    def test_responsable_actions_allow_responsable(
         self, action: OrganismeAction
     ) -> None:
-        service, repository = _service(AgentOrganismeRole.RESPONSABLE)
+        service, repository, _ = _service(AgentOrganismeRole.RESPONSABLE)
         organisme_id, agent_id = uuid4(), uuid4()
 
         result = service.est_autorise(
@@ -57,47 +70,8 @@ class TestEstAutorise:
             organisme_id=organisme_id, agent_id=agent_id
         )
 
-    @pytest.mark.parametrize("action", RESPONSABLE_ACTIONS)
-    @pytest.mark.parametrize("role", [AgentOrganismeRole.MEMBRE, None])
-    def test_responsable_only_actions_reject_non_responsable(
-        self, action: OrganismeAction, role: AgentOrganismeRole | None
-    ) -> None:
-        service, _ = _service(role)
-
-        with pytest.raises(AccesOrganismeRefuse):
-            service.est_autorise(
-                action=action, organisme_id=uuid4(), agent_id=uuid4(), est_staff=False
-            )
-
-    @pytest.mark.parametrize("action", RESPONSABLE_AND_MEMBRE_ACTIONS)
-    @pytest.mark.parametrize(
-        "role", [AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE]
-    )
-    def test_shared_actions_allow_responsable_and_membre(
-        self, action: OrganismeAction, role: AgentOrganismeRole
-    ) -> None:
-        service, _ = _service(role)
-
-        result = service.est_autorise(
-            action=action, organisme_id=uuid4(), agent_id=uuid4(), est_staff=False
-        )
-
-        assert result == role
-
-    @pytest.mark.parametrize("action", RESPONSABLE_AND_MEMBRE_ACTIONS)
-    def test_shared_actions_reject_no_role(self, action: OrganismeAction) -> None:
-        service, _ = _service(None)
-
-        with pytest.raises(AccesOrganismeRefuse):
-            service.est_autorise(
-                action=action, organisme_id=uuid4(), agent_id=uuid4(), est_staff=False
-            )
-
-
-class TestStaffBypass:
-    @pytest.mark.parametrize("action", STAFF_BYPASS_ACTIONS)
     def test_staff_bypasses_role_check(self, action: OrganismeAction) -> None:
-        service, repository = _service(None)
+        service, repository, _ = _service(None)
 
         result = service.est_autorise(
             action=action, organisme_id=uuid4(), agent_id=uuid4(), est_staff=True
@@ -106,17 +80,117 @@ class TestStaffBypass:
         assert result is None
         repository.get_role.assert_not_called()
 
-    @pytest.mark.parametrize(
-        "action", [a for a in OrganismeAction if a not in STAFF_BYPASS_ACTIONS]
-    )
-    def test_staff_does_not_bypass_for_other_actions(
-        self, action: OrganismeAction
+    @pytest.mark.parametrize("role", [AgentOrganismeRole.MEMBRE, None])
+    def test_responsable_actions_reject_non_responsable(
+        self, action: OrganismeAction, role: AgentOrganismeRole | None
     ) -> None:
-        service, repository = _service(None)
+        service, _, _ = _service(role)
 
         with pytest.raises(AccesOrganismeRefuse):
             service.est_autorise(
-                action=action, organisme_id=uuid4(), agent_id=uuid4(), est_staff=True
+                action=action, organisme_id=uuid4(), agent_id=uuid4(), est_staff=False
             )
 
-        repository.get_role.assert_called_once()
+
+class TestListerMesRecrutementRbac:
+    @pytest.mark.parametrize(
+        "role", [AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE]
+    )
+    def test_allow_responsable_and_membre(self, role: AgentOrganismeRole) -> None:
+        service, _, _ = _service(role)
+
+        result = service.est_autorise(
+            action=OrganismeAction.LISTER_MES_RECRUTEMENTS,
+            organisme_id=uuid4(),
+            agent_id=uuid4(),
+            est_staff=False,
+        )
+
+        assert result == role
+
+    @pytest.mark.parametrize("est_staff", [False, True])
+    def test_reject_no_role_nor_staff(self, est_staff: bool) -> None:
+        service, _, _ = _service(None)
+
+        with pytest.raises(AccesOrganismeRefuse):
+            service.est_autorise(
+                action=OrganismeAction.LISTER_MES_RECRUTEMENTS,
+                organisme_id=uuid4(),
+                agent_id=uuid4(),
+                est_staff=est_staff,
+            )
+
+
+class TestVoirDetailRecrutementRbac:
+    @pytest.mark.parametrize("recrutement_role", list(AgentRecrutementRole))
+    def test_membre_with_recrutement_role_is_allowed(
+        self, recrutement_role: AgentRecrutementRole
+    ) -> None:
+        service, _, recrutement_repository = _service(
+            AgentOrganismeRole.MEMBRE, recrutement_role
+        )
+        organisme_id, agent_id, recrutement_id = uuid4(), uuid4(), uuid4()
+
+        result = service.est_autorise(
+            action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
+            organisme_id=organisme_id,
+            agent_id=agent_id,
+            est_staff=False,
+            recrutement_id=recrutement_id,
+        )
+
+        assert result == AgentOrganismeRole.MEMBRE
+        recrutement_repository.get_role.assert_called_once_with(
+            recrutement_id=recrutement_id, agent_id=agent_id
+        )
+
+    def test_responsable_bypasses_recrutement_check(self) -> None:
+        service, _, recrutement_repository = _service(
+            AgentOrganismeRole.RESPONSABLE, None
+        )
+
+        result = service.est_autorise(
+            action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
+            organisme_id=uuid4(),
+            agent_id=uuid4(),
+            est_staff=False,
+            recrutement_id=uuid4(),
+        )
+
+        assert result == AgentOrganismeRole.RESPONSABLE
+        recrutement_repository.get_role.assert_not_called()
+
+    def test_membre_without_recrutement_role_is_denied(self) -> None:
+        service, _, _ = _service(AgentOrganismeRole.MEMBRE, None)
+
+        with pytest.raises(AccesRecrutementRefuse):
+            service.est_autorise(
+                action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
+                organisme_id=uuid4(),
+                agent_id=uuid4(),
+                est_staff=False,
+                recrutement_id=uuid4(),
+            )
+
+    def test_unprovided_recrutement_id_is_denied(self) -> None:
+        service, _, recrutement_repository = _service(AgentOrganismeRole.MEMBRE, None)
+
+        with pytest.raises(AccesRecrutementInconnu):
+            service.est_autorise(
+                action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
+                organisme_id=uuid4(),
+                agent_id=uuid4(),
+                est_staff=False,
+            )
+
+    def test_staff_without_role_is_denied(self) -> None:
+        service, _, _ = _service(AgentOrganismeRole.MEMBRE, None)
+
+        with pytest.raises(AccesRecrutementRefuse):
+            service.est_autorise(
+                action=OrganismeAction.VOIR_DETAIL_RECRUTEMENT,
+                organisme_id=uuid4(),
+                agent_id=uuid4(),
+                est_staff=True,
+                recrutement_id=uuid4(),
+            )

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_kanban.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_kanban.py
@@ -6,7 +6,10 @@ from application.recruteur.usecases.get_recrutement_kanban import (
     GetRecrutementKanbanQuery,
 )
 from config.app_config import AppConfig
-from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    AccesRecrutementRefuse,
+)
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
@@ -35,14 +38,23 @@ def usecase_fixture(recruteur_integration_container):
 
 class TestGetRecrutementKanbanRbac:
     @pytest.mark.parametrize(
-        "role", [AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE]
+        ("role", "assign_agent_to_recrutement"),
+        [
+            pytest.param(AgentOrganismeRole.RESPONSABLE, False, id="responsable"),
+            pytest.param(AgentOrganismeRole.MEMBRE, True, id="membre_assigned"),
+        ],
     )
-    def test_authorized_when_agent_has_organisme_role(self, usecase, role):
+    def test_authorized(self, usecase, role, assign_agent_to_recrutement):
         agent = AgentFactory.create_model()
         organisme = OrganismeFactory.create_model(
             agent_id=agent.utilisateur_id, role=role
         )
-        recrutement = RecrutementFactory.create_model(organisme_id=organisme.id)
+        agent_ids = (
+            (UUID(agent.utilisateur_id),) if assign_agent_to_recrutement else None
+        )
+        recrutement = RecrutementFactory.create_model(
+            organisme_id=organisme.id, agent_ids=agent_ids
+        )
         etape_entree = EtapeModel.objects.get(
             recrutement_id=recrutement.offre_id,
             categorie=CategorieEtapeRecrutement.ENTREE.value,
@@ -67,6 +79,22 @@ class TestGetRecrutementKanbanRbac:
         assert result.etapes[-1].categorie == "ACCEPTE"
         assert result.etapes[-1].candidatures == []
         assert result.organisme_recruteur.siret == organisme.siret
+
+    def test_forbidden_when_membre_not_assigned_to_recrutement(self, usecase):
+        agent = AgentFactory.create_model()
+        organisme = OrganismeFactory.create_model(
+            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.MEMBRE
+        )
+        recrutement = RecrutementFactory.create_model(organisme_id=organisme.id)
+
+        with pytest.raises(AccesRecrutementRefuse):
+            usecase.execute(
+                GetRecrutementKanbanQuery(
+                    organisme_id=organisme.id,
+                    recrutement_id=recrutement.offre_id,
+                    utilisateur_id=agent.utilisateur_id,
+                )
+            )
 
     @pytest.mark.parametrize("est_staff", [False, True])
     def test_forbidden_when_agent_has_no_organisme_role(self, usecase, est_staff):

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
@@ -6,7 +6,10 @@ from application.recruteur.usecases.get_recrutement_liste import (
     GetRecrutementListeQuery,
 )
 from config.app_config import AppConfig
-from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    AccesRecrutementRefuse,
+)
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
@@ -35,14 +38,23 @@ def usecase_fixture(recruteur_integration_container):
 
 class TestGetRecrutementListeRbac:
     @pytest.mark.parametrize(
-        "role", [AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE]
+        ("role", "assign_agent_to_recrutement"),
+        [
+            pytest.param(AgentOrganismeRole.RESPONSABLE, False, id="responsable"),
+            pytest.param(AgentOrganismeRole.MEMBRE, True, id="membre_assigned"),
+        ],
     )
-    def test_authorized_when_agent_has_organisme_role(self, usecase, role):
+    def test_authorized(self, usecase, role, assign_agent_to_recrutement):
         agent = AgentFactory.create_model()
         organisme = OrganismeFactory.create_model(
             agent_id=agent.utilisateur_id, role=role
         )
-        recrutement = RecrutementFactory.create_model(organisme_id=organisme.id)
+        agent_ids = (
+            (UUID(agent.utilisateur_id),) if assign_agent_to_recrutement else None
+        )
+        recrutement = RecrutementFactory.create_model(
+            organisme_id=organisme.id, agent_ids=agent_ids
+        )
         etape_entree = EtapeModel.objects.get(
             recrutement_id=recrutement.offre_id,
             categorie=CategorieEtapeRecrutement.ENTREE.value,
@@ -67,6 +79,22 @@ class TestGetRecrutementListeRbac:
         assert item.candidat.uuid == UUID(candidature.candidat_id)
         assert item.etape.etape_uuid == etape_entree.id
         assert item.etape.categorie == "ENTREE"
+
+    def test_forbidden_when_membre_not_assigned_to_recrutement(self, usecase):
+        agent = AgentFactory.create_model()
+        organisme = OrganismeFactory.create_model(
+            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.MEMBRE
+        )
+        recrutement = RecrutementFactory.create_model(organisme_id=organisme.id)
+
+        with pytest.raises(AccesRecrutementRefuse):
+            usecase.execute(
+                GetRecrutementListeQuery(
+                    organisme_id=organisme.id,
+                    recrutement_id=recrutement.offre_id,
+                    utilisateur_id=agent.utilisateur_id,
+                )
+            )
 
     @pytest.mark.parametrize("est_staff", [False, True])
     def test_forbidden_when_agent_has_no_organisme_role(self, usecase, est_staff):

--- a/src/web/tests/infrastructure/recruteur/test_recrutement_agent_repository.py
+++ b/src/web/tests/infrastructure/recruteur/test_recrutement_agent_repository.py
@@ -1,0 +1,39 @@
+from uuid import UUID
+
+import pytest
+
+from domain.recruteur.value_objects.roles import AgentRecrutementRole
+from infrastructure.factories.identite.agent_factory import AgentFactory
+from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
+from infrastructure.repositories.recruteur.postgres_recrutement_agent_repository import (  # noqa: E501
+    PostgresRecrutementAgentRepository,
+)
+
+
+@pytest.fixture(name="repository")
+def repository_fixture():
+    return PostgresRecrutementAgentRepository()
+
+
+def test_get_role_returns_assigned_role(db, repository):
+    agent = AgentFactory.create_model()
+    agent_id = UUID(agent.utilisateur_id)
+    recrutement = RecrutementFactory.create_model(
+        agent_ids=(agent_id,),
+        agent_roles={agent_id: AgentRecrutementRole.RECRUTEUR},
+    )
+
+    role = repository.get_role(recrutement_id=recrutement.offre_id, agent_id=agent_id)
+
+    assert role == AgentRecrutementRole.RECRUTEUR
+
+
+def test_get_role_returns_none_when_no_liaison(db, repository):
+    agent = AgentFactory.create_model()
+    recrutement = RecrutementFactory.create_model()
+
+    role = repository.get_role(
+        recrutement_id=recrutement.offre_id, agent_id=UUID(agent.utilisateur_id)
+    )
+
+    assert role is None


### PR DESCRIPTION
## 📝 Description
🎸 Le contrôle d'accès vérifie que l'agent MEMBRE est bien rattaché au recrutement demandé avant d'autoriser l'accès.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
* `OrganismePermissionService.est_autorise` pour vérifier le rôle de l'agent sur le recrutement quand son rôle organisme est MEMBRE
* ajout de `PostgresRecrutementAgentRepository`
* `RecrutementKanbanView` et `RecrutementListeView` renvoient 403 sur `OrganismePermissionError`


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
