### PR TITLE
✨(api) ajouter une limite quotidienne au débit de l'API key

### DIFF
--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -339,11 +339,13 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
         "infrastructure.authentication.api_key_authentication.ApiKeyRateThrottle",
+        "infrastructure.authentication.api_key_authentication.ApiKeyRateThrottleDaily",
     ],
     "DEFAULT_THROTTLE_RATES": {
         "anon": "5/minute",
         "user": "120/minute",
-        "api_key": "2000/hour",
+        "api_key": "70000/hour",
+        "api_key_daily": "100000/day",
     },
 }
 

--- a/src/web/infrastructure/authentication/api_key_authentication.py
+++ b/src/web/infrastructure/authentication/api_key_authentication.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.throttling import SimpleRateThrottle, UserRateThrottle
+from rest_framework.throttling import SimpleRateThrottle
 
 
 class _IngestionApiKeyUser:
@@ -77,8 +77,5 @@ class ApiKeyRateThrottle(SimpleRateThrottle):
         return None
 
 
-class UserRateThrottleExceptApiKey(UserRateThrottle):
-    def allow_request(self, request, view):
-        if isinstance(request.user, _IngestionApiKeyUser):
-            return True
-        return super().allow_request(request, view)
+class ApiKeyRateThrottleDaily(ApiKeyRateThrottle):
+    scope = "api_key_daily"

--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -27,7 +27,6 @@ from domain.ingestion.exceptions.source_authorization_error import (
 )
 from infrastructure.authentication.api_key_authentication import (
     ApiKeyAuthentication,
-    UserRateThrottleExceptApiKey,
 )
 from infrastructure.di.ingestion.ingestion_factory import create_ingestion_container
 from infrastructure.django_apps.users.models import UserModel
@@ -198,7 +197,6 @@ class OffersBySourceView(APIView):
 )
 class ArchiveOffersView(APIView):
     authentication_classes = [JWTAuthentication, ApiKeyAuthentication]
-    throttle_classes = [UserRateThrottleExceptApiKey]
 
     serializer_class = ArchiveOfferSuccessSerializer
 

--- a/src/web/tests/infrastructure/authentification/test_api_key_authentication.py
+++ b/src/web/tests/infrastructure/authentification/test_api_key_authentication.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from infrastructure.authentication.api_key_authentication import (
     ApiKeyAuthentication,
     ApiKeyRateThrottle,
+    ApiKeyRateThrottleDaily,
     _IngestionApiKeyUser,
     _ip_is_allowed,
 )
@@ -165,3 +166,76 @@ class TestApiKeyRateThrottle:
         request.user = object()
         for _ in range(10):
             assert ApiKeyRateThrottle().allow_request(request, view=None) is True
+
+
+class TestApiKeyRateThrottleDaily:
+    def test_scope_is_api_key_daily(self):
+        assert ApiKeyRateThrottleDaily.scope == "api_key_daily"
+
+    def test_returns_cache_key_for_api_key_user(self, rf):
+        request = rf.get("/")
+        request.user = API_KEY_USER
+        throttle = ApiKeyRateThrottleDaily()
+        cache_key = throttle.get_cache_key(request, view=None)
+        assert cache_key is not None
+        assert "ingestion-api-key" in cache_key
+
+    @patch.object(ApiKeyRateThrottleDaily, "THROTTLE_RATES", {"api_key_daily": "3/day"})
+    def test_rate_limit_allows_requests_within_limit(self, rf):
+        cache.clear()
+        request = rf.get("/")
+        request.user = API_KEY_USER
+        for _ in range(3):
+            assert ApiKeyRateThrottleDaily().allow_request(request, view=None) is True
+
+    @patch.object(ApiKeyRateThrottleDaily, "THROTTLE_RATES", {"api_key_daily": "3/day"})
+    def test_rate_limit_blocks_requests_over_limit(self, rf):
+        cache.clear()
+        request = rf.get("/")
+        request.user = API_KEY_USER
+        for _ in range(3):
+            ApiKeyRateThrottleDaily().allow_request(request, view=None)
+        assert ApiKeyRateThrottleDaily().allow_request(request, view=None) is False
+
+
+class TestApiKeyRateThrottleAndDailyBothTrack:
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "1000/hour"})
+    @patch.object(
+        ApiKeyRateThrottleDaily, "THROTTLE_RATES", {"api_key_daily": "1000/day"}
+    )
+    def test_a_single_request_increments_both_hourly_and_daily_counters(self, rf):
+        cache.clear()
+        request = rf.get("/")
+        request.user = API_KEY_USER
+
+        hourly = ApiKeyRateThrottle()
+        daily = ApiKeyRateThrottleDaily()
+
+        assert hourly.get_cache_key(request, view=None) != daily.get_cache_key(
+            request, view=None
+        )
+
+        assert hourly.allow_request(request, view=None) is True
+        assert daily.allow_request(request, view=None) is True
+
+        assert len(cache.get(hourly.get_cache_key(request, view=None))) == 1
+        assert len(cache.get(daily.get_cache_key(request, view=None))) == 1
+
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "2/hour"})
+    @patch.object(
+        ApiKeyRateThrottleDaily, "THROTTLE_RATES", {"api_key_daily": "1000/day"}
+    )
+    def test_hourly_limit_can_block_while_daily_limit_still_allows(self, rf):
+        cache.clear()
+        request = rf.get("/")
+        request.user = API_KEY_USER
+
+        hourly = ApiKeyRateThrottle()
+        daily = ApiKeyRateThrottleDaily()
+
+        for _ in range(2):
+            assert hourly.allow_request(request, view=None) is True
+            assert daily.allow_request(request, view=None) is True
+
+        assert hourly.allow_request(request, view=None) is False
+        assert daily.allow_request(request, view=None) is True


### PR DESCRIPTION
## 📝 Description

- Ajoute ApiKeyRateThrottleDaily (scope api_key_daily) en plus du throttle horaire existant afin de plafonner à la fois 70 000 requêtes/heure et 100 000 requêtes/jour pour l'authentification par clé API.
- Supprime UserRateThrottleExceptApiKey, devenu inutile.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
