### PR TITLE
✨(ingestion) mapper MENJ vers le versant FPE

### DIFF
--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -167,7 +167,7 @@ class OffersCleaner:
             return Verse.FPT
         elif "FPH" in verse_upper or "APHP" in reference.upper():
             return Verse.FPH
-        elif "FPE" in verse_upper:
+        elif "FPE" in verse_upper or "MENJ" in reference.upper():
             return Verse.FPE
         return None
 

--- a/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
+++ b/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
@@ -99,6 +99,14 @@ def test_clean_maps_verse_fph_from_aphp_reference(cleaner):
     assert offer.verse == Verse.FPH
 
 
+def test_clean_maps_verse_fpe_from_menj_reference(cleaner):
+    raw_offer = _make_raw_offer(reference="MENJ-2024-001")
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.verse == Verse.FPE
+
+
 @pytest.mark.parametrize(
     "category_code, expected_category",
     [


### PR DESCRIPTION
## 📝 Description

On ne détectait pas le versant pour certaines offres du MENJ (Ministère de l'Éducation nationale et de la Jeunesse). Certaines offres n'ont pas de `salaryRange` et le champ `reference` ne contenait pas `FPE`.

Adapte le code pour mapper le MENJ vers le versant `FPE`.

[Voir un exemple d'erreur](https://sentry.incubateur.net/organizations/betagouv/issues/299174/events/82ad32e9ede841018110a695e3246e3a/)

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
