### PR TITLE
🐛(api) autoriser un profil vide dans DescriptionInputSerializer

### DIFF
--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -174,7 +174,7 @@ class ProfessionInputSerializer(serializers.Serializer):
 
 class DescriptionInputSerializer(serializers.Serializer):
     mission = serializers.CharField(max_length=10000)
-    profil = serializers.CharField(max_length=10000)
+    profil = serializers.CharField(max_length=10000, allow_blank=True)
     employeur = serializers.CharField(max_length=3000)
     complements = serializers.CharField(max_length=5000, allow_blank=True)
 

--- a/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
@@ -58,6 +58,7 @@ COMPLETE_VALID_OFFER = PayloadOfferFactory.create(
     categories=["A", "B"],
     forme_contrat=["CDD"],
     vacance_poste="OUI",
+    description={"profil": ""},
     localisation=[
         {
             "zone_geographique": "EU",


### PR DESCRIPTION
## 📝 Description

Autorise un champ vide pour `description.profil` d'une offre.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
