### PR TITLE
✨(api) ajouter les en-têtes X-RateLimit-Limit/Remaining/Reset aux réponses

### DIFF
--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -125,6 +125,7 @@ MIDDLEWARE = [
     "django_htmx.middleware.HtmxMiddleware",
     "django.contrib.redirects.middleware.RedirectFallbackMiddleware",
     "presentation.middleware.api_request_logger.ApiRequestLoggerMiddleware",
+    "presentation.middleware.rate_limit_headers.RateLimitHeadersMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/src/web/infrastructure/authentication/jwt_token.py
+++ b/src/web/infrastructure/authentication/jwt_token.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from django.http import HttpRequest
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import AuthenticationFailed, TokenError
+from rest_framework_simplejwt.tokens import Token
+
+
+def get_validated_jwt(
+    request: HttpRequest, authenticator: JWTAuthentication
+) -> Optional[Token]:
+    try:
+        header = authenticator.get_header(request)
+        if header is None:
+            return None
+        raw_token = authenticator.get_raw_token(header)
+        if raw_token is None:
+            return None
+        return authenticator.get_validated_token(raw_token)
+    except (AuthenticationFailed, TokenError):
+        return None

--- a/src/web/presentation/middleware/api_request_logger.py
+++ b/src/web/presentation/middleware/api_request_logger.py
@@ -10,6 +10,7 @@ from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 
 from domain.ingestion.entities.api_log import ApiLog
 from domain.ingestion.repositories.api_log_repository_interface import IApiLogRepository
+from infrastructure.authentication.jwt_token import get_validated_jwt
 from infrastructure.di.shared.shared_container import SharedContainer
 
 
@@ -24,18 +25,14 @@ _jwt_auth = JWTStatelessUserAuthentication()
 
 
 def _decode_jwt_user_id(request: HttpRequest) -> Optional[str]:
+    validated_token = get_validated_jwt(request, _jwt_auth)
+    if validated_token is None:
+        return None
     try:
-        header = _jwt_auth.get_header(request)
-        if header is None:
-            return None
-        raw_token = _jwt_auth.get_raw_token(header)
-        if raw_token is None:
-            return None
-        validated_token = _jwt_auth.get_validated_token(raw_token)
         user = _jwt_auth.get_user(validated_token)
-        return str(user.pk)
     except (InvalidToken, TokenError):
         return None
+    return str(user.pk)
 
 
 def _extract_token_info(

--- a/src/web/presentation/middleware/rate_limit_headers.py
+++ b/src/web/presentation/middleware/rate_limit_headers.py
@@ -17,6 +17,7 @@ from infrastructure.authentication.api_key_authentication import (
     ApiKeyRateThrottle,
     ApiKeyRateThrottleDaily,
 )
+from infrastructure.authentication.jwt_token import get_validated_jwt
 
 _API_KEY_THROTTLES = [ApiKeyRateThrottle(), ApiKeyRateThrottleDaily()]
 _USER_THROTTLE = UserRateThrottle()
@@ -32,17 +33,10 @@ def _is_authenticated_api_key_request(request: HttpRequest) -> bool:
 
 
 def _authenticate_jwt_user(request: HttpRequest) -> Optional[AbstractBaseUser]:
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
+    validated_token = get_validated_jwt(request, _jwt_auth)
+    if validated_token is None:
         return None
     try:
-        header = _jwt_auth.get_header(request)
-        if header is None:
-            return None
-        raw_token = _jwt_auth.get_raw_token(header)
-        if raw_token is None:
-            return None
-        validated_token = _jwt_auth.get_validated_token(raw_token)
         return _jwt_auth.get_user(validated_token)
     except (AuthenticationFailed, TokenError):
         return None

--- a/src/web/presentation/middleware/rate_limit_headers.py
+++ b/src/web/presentation/middleware/rate_limit_headers.py
@@ -1,0 +1,93 @@
+import time
+from typing import Callable, Optional
+
+from django.conf import settings
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.core.cache import cache
+from django.http import HttpRequest, HttpResponse
+from rest_framework.throttling import (
+    AnonRateThrottle,
+    SimpleRateThrottle,
+    UserRateThrottle,
+)
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import AuthenticationFailed, TokenError
+
+from infrastructure.authentication.api_key_authentication import (
+    ApiKeyRateThrottle,
+    ApiKeyRateThrottleDaily,
+)
+
+_API_KEY_THROTTLES = [ApiKeyRateThrottle(), ApiKeyRateThrottleDaily()]
+_USER_THROTTLE = UserRateThrottle()
+_ANON_THROTTLE = AnonRateThrottle()
+_jwt_auth = JWTAuthentication()
+
+
+def _is_authenticated_api_key_request(request: HttpRequest) -> bool:
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Api-Key "):
+        return False
+    return auth_header[len("Api-Key ") :] == settings.INGESTION_API_KEY
+
+
+def _authenticate_jwt_user(request: HttpRequest) -> Optional[AbstractBaseUser]:
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    try:
+        header = _jwt_auth.get_header(request)
+        if header is None:
+            return None
+        raw_token = _jwt_auth.get_raw_token(header)
+        if raw_token is None:
+            return None
+        validated_token = _jwt_auth.get_validated_token(raw_token)
+        return _jwt_auth.get_user(validated_token)
+    except (AuthenticationFailed, TokenError):
+        return None
+
+
+def _rate_limit_state(throttle: SimpleRateThrottle, ident: str) -> tuple[int, int, int]:
+    cache_key = throttle.cache_format % {"scope": throttle.scope, "ident": ident}
+    num_requests, duration = throttle.parse_rate(throttle.get_rate())
+    history = cache.get(cache_key, [])
+    remaining = max(num_requests - len(history), 0)
+    reset = int(history[-1] + duration) if history else int(time.time())
+    return num_requests, remaining, reset
+
+
+def _collect_rate_limit_states(request: HttpRequest) -> list[tuple[int, int, int]]:
+    if _is_authenticated_api_key_request(request):
+        return [
+            _rate_limit_state(throttle, "ingestion-api-key")
+            for throttle in _API_KEY_THROTTLES
+        ]
+    user = _authenticate_jwt_user(request)
+    if user is not None:
+        return [_rate_limit_state(_USER_THROTTLE, str(user.pk))]
+    if not request.headers.get("Authorization") and request.path.startswith(
+        settings.PUBLIC_API_PREFIX
+    ):
+        ident = _ANON_THROTTLE.get_ident(request)
+        return [_rate_limit_state(_ANON_THROTTLE, ident)]
+    return []
+
+
+class RateLimitHeadersMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+
+        states = _collect_rate_limit_states(request)
+        if not states:
+            return response
+
+        limit, remaining, reset = min(states, key=lambda state: state[1])
+        response["X-RateLimit-Limit"] = str(limit)
+        response["X-RateLimit-Remaining"] = str(remaining)
+        response["X-RateLimit-Reset"] = str(reset)
+
+        return response

--- a/src/web/tests/utils/test_rate_limit_headers_middleware.py
+++ b/src/web/tests/utils/test_rate_limit_headers_middleware.py
@@ -1,0 +1,199 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+import time_machine
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.test import RequestFactory
+from rest_framework.throttling import AnonRateThrottle
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from infrastructure.authentication.api_key_authentication import (
+    ApiKeyRateThrottle,
+    ApiKeyRateThrottleDaily,
+    _IngestionApiKeyUser,
+)
+from presentation.middleware.rate_limit_headers import RateLimitHeadersMiddleware
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+
+
+@pytest.fixture
+def mock_response():
+    return HttpResponse()
+
+
+def make_middleware(mock_response):
+    get_response = MagicMock(return_value=mock_response)
+    middleware = RateLimitHeadersMiddleware(get_response=get_response)
+    return middleware, get_response
+
+
+class TestRateLimitHeadersMiddleware:
+    def test_adds_headers_for_valid_api_key_request(self, rf, mock_response, settings):
+        settings.INGESTION_API_KEY = "secret-key"
+        middleware, _ = make_middleware(mock_response)
+        request = rf.get("/api/v1/offres/", HTTP_AUTHORIZATION="Api-Key secret-key")
+
+        middleware(request)
+
+        assert "X-RateLimit-Limit" in mock_response.headers
+        assert "X-RateLimit-Remaining" in mock_response.headers
+        assert "X-RateLimit-Reset" in mock_response.headers
+
+    def test_does_not_add_headers_for_invalid_api_key(
+        self, rf, mock_response, settings
+    ):
+        settings.INGESTION_API_KEY = "secret-key"
+        middleware, _ = make_middleware(mock_response)
+        request = rf.get("/api/v1/offres/", HTTP_AUTHORIZATION="Api-Key wrong-key")
+
+        middleware(request)
+
+        assert "X-RateLimit-Limit" not in mock_response.headers
+
+    def test_does_not_add_headers_for_invalid_jwt(self, rf, mock_response, settings):
+        settings.INGESTION_API_KEY = "secret-key"
+        middleware, _ = make_middleware(mock_response)
+        request = rf.get("/api/v1/offres/", HTTP_AUTHORIZATION="Bearer some-token")
+
+        middleware(request)
+
+        assert "X-RateLimit-Limit" not in mock_response.headers
+
+    def test_adds_headers_for_valid_jwt_request(self, rf, mock_response, test_user):
+        middleware, _ = make_middleware(mock_response)
+        refresh = RefreshToken.for_user(test_user)
+        request = rf.get(
+            "/api/v1/offres/", HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}"
+        )
+
+        middleware(request)
+
+        assert mock_response.headers["X-RateLimit-Limit"] == "120"
+        assert "X-RateLimit-Remaining" in mock_response.headers
+        assert "X-RateLimit-Reset" in mock_response.headers
+
+    def test_does_not_add_headers_for_non_api_request_without_authorization(
+        self, rf, mock_response
+    ):
+        middleware, _ = make_middleware(mock_response)
+        request = rf.get("/candidate/upload/")
+
+        middleware(request)
+
+        assert "X-RateLimit-Limit" not in mock_response.headers
+
+    def test_adds_headers_for_anonymous_api_request(self, rf, mock_response):
+        middleware, _ = make_middleware(mock_response)
+        request = rf.get("/api/v1/offres/", REMOTE_ADDR="203.0.113.5")
+
+        middleware(request)
+
+        assert "X-RateLimit-Limit" in mock_response.headers
+        assert "X-RateLimit-Remaining" in mock_response.headers
+        assert "X-RateLimit-Reset" in mock_response.headers
+
+    @patch.object(AnonRateThrottle, "THROTTLE_RATES", {"anon": "3/minute"})
+    def test_anon_remaining_decreases_as_quota_is_consumed(self, rf, mock_response):
+        request = rf.get("/api/v1/offres/", REMOTE_ADDR="203.0.113.9")
+        request.user = AnonymousUser()
+        AnonRateThrottle().allow_request(request, view=None)
+        AnonRateThrottle().allow_request(request, view=None)
+
+        middleware, _ = make_middleware(mock_response)
+        header_request = rf.get("/api/v1/offres/", REMOTE_ADDR="203.0.113.9")
+
+        middleware(header_request)
+
+        assert mock_response.headers["X-RateLimit-Limit"] == "3"
+        assert mock_response.headers["X-RateLimit-Remaining"] == "1"
+
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "1000/hour"})
+    @patch.object(ApiKeyRateThrottleDaily, "THROTTLE_RATES", {"api_key_daily": "3/day"})
+    @time_machine.travel(
+        datetime(2026, 7, 29, 12, 0, 0, tzinfo=timezone.utc), tick=False
+    )
+    def test_reset_reflects_oldest_request_plus_window_duration(
+        self, rf, mock_response, settings
+    ):
+        settings.INGESTION_API_KEY = "secret-key"
+
+        request = rf.get("/")
+        request.user = _IngestionApiKeyUser()
+        ApiKeyRateThrottleDaily().allow_request(request, view=None)
+
+        middleware, _ = make_middleware(mock_response)
+        header_request = rf.get(
+            "/api/v1/offres/", HTTP_AUTHORIZATION="Api-Key secret-key"
+        )
+
+        middleware(header_request)
+
+        expected_reset = int(
+            datetime(2026, 7, 29, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+            + 86400  # 1 day, in seconds
+        )
+        assert mock_response.headers["X-RateLimit-Reset"] == str(expected_reset)
+
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "1000/hour"})
+    @patch.object(ApiKeyRateThrottleDaily, "THROTTLE_RATES", {"api_key_daily": "3/day"})
+    def test_remaining_decreases_as_daily_quota_is_consumed(
+        self, rf, mock_response, settings
+    ):
+        settings.INGESTION_API_KEY = "secret-key"
+
+        request = rf.get("/")
+        request.user = _IngestionApiKeyUser()
+        ApiKeyRateThrottleDaily().allow_request(request, view=None)
+        ApiKeyRateThrottleDaily().allow_request(request, view=None)
+
+        middleware, _ = make_middleware(mock_response)
+        header_request = rf.get(
+            "/api/v1/offres/", HTTP_AUTHORIZATION="Api-Key secret-key"
+        )
+
+        middleware(header_request)
+
+        assert mock_response.headers["X-RateLimit-Limit"] == "3"
+        assert mock_response.headers["X-RateLimit-Remaining"] == "1"
+
+    @patch.object(ApiKeyRateThrottle, "THROTTLE_RATES", {"api_key": "1000/hour"})
+    @patch.object(ApiKeyRateThrottleDaily, "THROTTLE_RATES", {"api_key_daily": "3/day"})
+    def test_returns_most_restrictive_throttle(self, rf, mock_response, settings):
+        settings.INGESTION_API_KEY = "secret-key"
+
+        request = rf.get("/")
+        request.user = _IngestionApiKeyUser()
+        for _ in range(3):
+            ApiKeyRateThrottleDaily().allow_request(request, view=None)
+
+        middleware, _ = make_middleware(mock_response)
+        header_request = rf.get(
+            "/api/v1/offres/", HTTP_AUTHORIZATION="Api-Key secret-key"
+        )
+
+        middleware(header_request)
+
+        assert mock_response.headers["X-RateLimit-Limit"] == "3"
+        assert mock_response.headers["X-RateLimit-Remaining"] == "0"
+
+    def test_passes_through_response_unchanged(self, rf, mock_response, settings):
+        settings.INGESTION_API_KEY = "secret-key"
+        middleware, get_response = make_middleware(mock_response)
+        request = rf.get("/api/v1/offres/")
+
+        result = middleware(request)
+
+        assert result is mock_response
+        get_response.assert_called_once_with(request)


### PR DESCRIPTION
## 📝 Description

Ajouter des headers de réponse à l'API concernant le rate limit : requêtes autorisées, requêtes restantes, quand ce sera reset.

Fonctionne pour les requêtes anonymes (pour générer un token), JWT et clé API.

```sh
$ curl -vvv -X POST http://localhost:8000/api/token
* Host localhost:8000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8000...
* connect to ::1 port 8000 from ::1 port 60560 failed: Connection refused
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000
> POST /api/token HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 400 Bad Request
< Date: Wed, 29 Jul 2026 08:52:53 GMT
< Server: WSGIServer/0.2 CPython/3.12.11
< Content-Type: application/json
< Allow: POST, OPTIONS
< djdt-request-id: 074faef05bb54222915e5c0df9be06aa
< Server-Timing: TimerPanel_utime;dur=37.72899999999968;desc="User CPU time", TimerPanel_stime;dur=86.82400000000001;desc="System CPU time", TimerPanel_total;dur=124.55299999999968;desc="Total CPU time", TimerPanel_total_time;dur=126.10720901284367;desc="Elapsed time", SQLPanel_sql_time;dur=0;desc="SQL 0 queries", CachePanel_total_time;dur=0.08296000305563211;desc="Cache 4 Calls"
< X-RateLimit-Limit: 5
< X-RateLimit-Remaining: 4
< X-RateLimit-Reset: 1785315233
< X-Frame-Options: DENY
< Content-Security-Policy: default-src 'self'; connect-src 'self' *.sentry.io http://localhost:5173 ws://localhost:5173; img-src 'self' data: blob: https://cdn.redoc.ly; frame-src 'self' https://tally.so; font-src 'self' https://fonts.gstatic.com/ data: http://localhost:5173; script-src 'self' https://tally.so http://localhost:5173; script-src-elem 'self' https://tally.so http://localhost:5173; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; worker-src 'self' blob:
< Content-Length: 80
< Vary: Cookie
< X-Content-Type-Options: nosniff
< Referrer-Policy: same-origin
< Cross-Origin-Opener-Policy: same-origin
< 
* Connection #0 to host localhost left intact
{"email":["Ce champ est obligatoire."],"password":["Ce champ est obligatoire."]}
```

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
