### PR TITLE
♻️(recrutement-presentation) mise en place RBAC pour la mise à jour du pipeline d'une offre

### DIFF
--- a/src/web/application/recruteur/usecases/get_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_etapes.py
@@ -7,6 +7,10 @@ from application.recruteur.dtos.recrutement_request import RecrutementRequest
 from domain.identite.repositories.organisme_repository_interface import (
     IOrganismeRepository,
 )
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @dataclass(kw_only=True)
@@ -15,13 +19,24 @@ class GetRecrutementEtapesQuery(RecrutementRequest):
 
 
 # TODO: ajouter
-# - RBAC organisme, RBAC recrutement
 # - recuperer le Recrutement via IRecrutementRepository et mapper ses etapes reelles
 #   (EtapeRecrutement) vers EtapeData, au lieu du pipeline statique ci-dessous
 class GetRecrutementEtapesUsecase(IUseCase[GetRecrutementEtapesQuery, list[EtapeData]]):
-    def __init__(self, organisme_repository: IOrganismeRepository):
+    def __init__(
+        self,
+        organisme_repository: IOrganismeRepository,
+        organisme_permission_service: OrganismePermissionService,
+    ):
         self.organisme_repository = organisme_repository
+        self.organisme_permission_service = organisme_permission_service
 
     def execute(self, query: GetRecrutementEtapesQuery) -> list[EtapeData]:
         self.organisme_repository.get_by_id(query.organisme_id)
+        self.organisme_permission_service.est_autorise(
+            action=OrganismeAction.GET_RECRUTEMENT_ETAPES,
+            organisme_id=query.organisme_id,
+            agent_id=query.utilisateur_id,
+            recrutement_id=query.recrutement_id,
+            est_staff=query.est_staff,
+        )
         return etapes_par_defaut()

--- a/src/web/application/recruteur/usecases/init_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/init_recrutement_etapes.py
@@ -7,6 +7,10 @@ from application.recruteur.dtos.recrutement_request import RecrutementRequest
 from domain.identite.repositories.organisme_repository_interface import (
     IOrganismeRepository,
 )
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @dataclass(kw_only=True)
@@ -15,15 +19,26 @@ class InitRecrutementEtapesCommand(RecrutementRequest):
 
 
 # TODO: ajouter
-# - RBAC organisme, RBAC recrutement
 # - copier les etapes par defaut de l'organisme sur ce recrutement (au lieu du
 #   pipeline statique ci-dessous), sauvegarde + emission evenement + audit log
 class InitRecrutementEtapesUsecase(
     IUseCase[InitRecrutementEtapesCommand, list[EtapeData]]
 ):
-    def __init__(self, organisme_repository: IOrganismeRepository):
+    def __init__(
+        self,
+        organisme_repository: IOrganismeRepository,
+        organisme_permission_service: OrganismePermissionService,
+    ):
         self.organisme_repository = organisme_repository
+        self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: InitRecrutementEtapesCommand) -> list[EtapeData]:
         self.organisme_repository.get_by_id(command.organisme_id)
+        self.organisme_permission_service.est_autorise(
+            action=OrganismeAction.INIT_RECRUTEMENT_ETAPES,
+            organisme_id=command.organisme_id,
+            agent_id=command.utilisateur_id,
+            recrutement_id=command.recrutement_id,
+            est_staff=command.est_staff,
+        )
         return etapes_par_defaut()

--- a/src/web/application/recruteur/usecases/update_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/update_recrutement_etapes.py
@@ -7,6 +7,10 @@ from application.recruteur.dtos.recrutement_request import RecrutementRequest
 from domain.identite.repositories.organisme_repository_interface import (
     IOrganismeRepository,
 )
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @dataclass(kw_only=True)
@@ -15,16 +19,27 @@ class UpdateRecrutementEtapesCommand(RecrutementRequest):
 
 
 # TODO: ajouter
-# - RBAC organisme, RBAC recrutement
 # - validation coherence des etapes (categories, ordre)
 # - recuperer/muter le Recrutement (necessite une methode @mutate sur l'agregat)
 # - sauvegarde + emission evenement + drain par auditlog
 class UpdateRecrutementEtapesUsecase(
     IUseCase[UpdateRecrutementEtapesCommand, list[EtapeData]]
 ):
-    def __init__(self, organisme_repository: IOrganismeRepository):
+    def __init__(
+        self,
+        organisme_repository: IOrganismeRepository,
+        organisme_permission_service: OrganismePermissionService,
+    ):
         self.organisme_repository = organisme_repository
+        self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: UpdateRecrutementEtapesCommand) -> list[EtapeData]:
         self.organisme_repository.get_by_id(command.organisme_id)
+        self.organisme_permission_service.est_autorise(
+            action=OrganismeAction.UPDATE_RECRUTEMENT_ETAPES,
+            organisme_id=command.organisme_id,
+            agent_id=command.utilisateur_id,
+            recrutement_id=command.recrutement_id,
+            est_staff=command.est_staff,
+        )
         return command.etapes

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -41,6 +41,9 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.VOIR_DETAIL_RECRUTEMENT: frozenset(
         {AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE}
     ),
+    OrganismeAction.GET_RECRUTEMENT_ETAPES: frozenset(
+        {AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE}
+    ),
 }
 
 # -------------------------------------
@@ -59,6 +62,9 @@ _ROLES_RECRUTEMENT_REQUIS: dict[OrganismeAction, frozenset[AgentRecrutementRole]
             AgentRecrutementRole.RECRUTEUR,
             AgentRecrutementRole.CONTRIBUTEUR,
         }
+    ),
+    OrganismeAction.GET_RECRUTEMENT_ETAPES: frozenset(
+        {AgentRecrutementRole.RESPONSABLE}
     ),
 }
 

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -44,6 +44,9 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.GET_RECRUTEMENT_ETAPES: frozenset(
         {AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE}
     ),
+    OrganismeAction.UPDATE_RECRUTEMENT_ETAPES: frozenset(
+        {AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE}
+    ),
 }
 
 # -------------------------------------
@@ -64,6 +67,9 @@ _ROLES_RECRUTEMENT_REQUIS: dict[OrganismeAction, frozenset[AgentRecrutementRole]
         }
     ),
     OrganismeAction.GET_RECRUTEMENT_ETAPES: frozenset(
+        {AgentRecrutementRole.RESPONSABLE}
+    ),
+    OrganismeAction.UPDATE_RECRUTEMENT_ETAPES: frozenset(
         {AgentRecrutementRole.RESPONSABLE}
     ),
 }

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -12,9 +12,23 @@ from domain.recruteur.repositories.recrutement_agent_repository_interface import
     IRecrutementAgentRepository,
 )
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
-from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
 
-# Actions pour lesquelles un AGENT doit avoir un rôle sur l'organisme
+# Actions pour lesquelles le statut staff dispense d'un rôle réel sur l'organisme
+_AUTORISE_POUR_STAFF: frozenset[OrganismeAction] = frozenset(
+    {
+        OrganismeAction.GET_ORGANISME,
+        OrganismeAction.INITIALIZE_ORGANISME_STEPS,
+        OrganismeAction.UPDATE_ORGANISME_STEPS,
+    }
+)
+
+# -------------------------------------
+# Authorisations niveau Organisme
+# -------------------------------------
 _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.GET_ORGANISME: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.INITIALIZE_ORGANISME_STEPS: frozenset(
@@ -29,19 +43,24 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     ),
 }
 
-# Actions pour lesquelles le statut staff dispense d'un rôle réel sur l'organisme
-_AUTORISE_POUR_STAFF: frozenset[OrganismeAction] = frozenset(
-    {
-        OrganismeAction.GET_ORGANISME,
-        OrganismeAction.INITIALIZE_ORGANISME_STEPS,
-        OrganismeAction.UPDATE_ORGANISME_STEPS,
-    }
+# -------------------------------------
+# Authorisations niveau Recrutement
+# -------------------------------------
+# Actions pour lesquelles un MEMBRE n'a besoin d'aucun rôle sur le recrutement
+_SANS_ROLE_RECRUTEMENT_REQUIS: frozenset[OrganismeAction] = frozenset(
+    {OrganismeAction.LISTER_MES_RECRUTEMENTS}
 )
 
-# Actions pour lesquelles un MEMBRE doit en plus être affecté au recrutement visé
-_REQUIERT_ROLE_RECRUTEMENT: frozenset[OrganismeAction] = frozenset(
-    {OrganismeAction.VOIR_DETAIL_RECRUTEMENT}
-)
+# Actions pour lesquelles un MEMBRE doit avoir un rôle sur le recrutement
+_ROLES_RECRUTEMENT_REQUIS: dict[OrganismeAction, frozenset[AgentRecrutementRole]] = {
+    OrganismeAction.VOIR_DETAIL_RECRUTEMENT: frozenset(
+        {
+            AgentRecrutementRole.RESPONSABLE,
+            AgentRecrutementRole.RECRUTEUR,
+            AgentRecrutementRole.CONTRIBUTEUR,
+        }
+    ),
+}
 
 
 class OrganismePermissionService:
@@ -72,14 +91,17 @@ class OrganismePermissionService:
         if role not in roles_requis:
             raise AccesOrganismeRefuse(organisme_id)
 
-        if role == AgentOrganismeRole.MEMBRE and action in _REQUIERT_ROLE_RECRUTEMENT:
+        if (
+            role == AgentOrganismeRole.MEMBRE
+            and action not in _SANS_ROLE_RECRUTEMENT_REQUIS
+        ):
             if recrutement_id is None:
                 raise AccesRecrutementInconnu()
 
             recrutement_role = self._recrutement_agent_repository.get_role(
                 recrutement_id=recrutement_id, agent_id=agent_id
             )
-            if recrutement_role is None:
+            if recrutement_role not in _ROLES_RECRUTEMENT_REQUIS[action]:
                 raise AccesRecrutementRefuse(recrutement_id)
 
         return role

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -47,6 +47,9 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.UPDATE_RECRUTEMENT_ETAPES: frozenset(
         {AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE}
     ),
+    OrganismeAction.INIT_RECRUTEMENT_ETAPES: frozenset(
+        {AgentOrganismeRole.RESPONSABLE, AgentOrganismeRole.MEMBRE}
+    ),
 }
 
 # -------------------------------------
@@ -70,6 +73,9 @@ _ROLES_RECRUTEMENT_REQUIS: dict[OrganismeAction, frozenset[AgentRecrutementRole]
         {AgentRecrutementRole.RESPONSABLE}
     ),
     OrganismeAction.UPDATE_RECRUTEMENT_ETAPES: frozenset(
+        {AgentRecrutementRole.RESPONSABLE}
+    ),
+    OrganismeAction.INIT_RECRUTEMENT_ETAPES: frozenset(
         {AgentRecrutementRole.RESPONSABLE}
     ),
 }

--- a/src/web/domain/recruteur/value_objects/organisme_action.py
+++ b/src/web/domain/recruteur/value_objects/organisme_action.py
@@ -8,3 +8,4 @@ class OrganismeAction(Enum):
     LISTER_MES_RECRUTEMENTS = "lister_mes_recrutements"
     VOIR_DETAIL_RECRUTEMENT = "voir_detail_recrutement"
     GET_RECRUTEMENT_ETAPES = "get_recrutement_etapes"
+    UPDATE_RECRUTEMENT_ETAPES = "update_recrutement_etapes"

--- a/src/web/domain/recruteur/value_objects/organisme_action.py
+++ b/src/web/domain/recruteur/value_objects/organisme_action.py
@@ -7,3 +7,4 @@ class OrganismeAction(Enum):
     UPDATE_ORGANISME_STEPS = "update_organisme_steps"
     LISTER_MES_RECRUTEMENTS = "lister_mes_recrutements"
     VOIR_DETAIL_RECRUTEMENT = "voir_detail_recrutement"
+    GET_RECRUTEMENT_ETAPES = "get_recrutement_etapes"

--- a/src/web/domain/recruteur/value_objects/organisme_action.py
+++ b/src/web/domain/recruteur/value_objects/organisme_action.py
@@ -9,3 +9,4 @@ class OrganismeAction(Enum):
     VOIR_DETAIL_RECRUTEMENT = "voir_detail_recrutement"
     GET_RECRUTEMENT_ETAPES = "get_recrutement_etapes"
     UPDATE_RECRUTEMENT_ETAPES = "update_recrutement_etapes"
+    INIT_RECRUTEMENT_ETAPES = "init_recrutement_etapes"

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -185,6 +185,7 @@ class RecruteurContainer(containers.DeclarativeContainer):
     get_recrutement_etapes_usecase = providers.Factory(
         GetRecrutementEtapesUsecase,
         organisme_repository=postgres_organisme_repository,
+        organisme_permission_service=organisme_permission_service,
     )
 
     update_recrutement_etapes_usecase = providers.Factory(

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -197,4 +197,5 @@ class RecruteurContainer(containers.DeclarativeContainer):
     init_recrutement_etapes_usecase = providers.Factory(
         InitRecrutementEtapesUsecase,
         organisme_repository=postgres_organisme_repository,
+        organisme_permission_service=organisme_permission_service,
     )

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -191,6 +191,7 @@ class RecruteurContainer(containers.DeclarativeContainer):
     update_recrutement_etapes_usecase = providers.Factory(
         UpdateRecrutementEtapesUsecase,
         organisme_repository=postgres_organisme_repository,
+        organisme_permission_service=organisme_permission_service,
     )
 
     init_recrutement_etapes_usecase = providers.Factory(

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -1275,6 +1275,14 @@ export interface operations {
                     "application/json": components["schemas"]["TokenError"];
                 };
             };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
             404: {
                 headers: {
                     [name: string]: unknown;
@@ -1335,6 +1343,14 @@ export interface operations {
                     "application/json": components["schemas"]["TokenError"];
                 };
             };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
             404: {
                 headers: {
                     [name: string]: unknown;
@@ -1379,6 +1395,14 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
                 };
             };
             404: {

--- a/src/web/presentation/recruteur/views/recrutement_params.py
+++ b/src/web/presentation/recruteur/views/recrutement_params.py
@@ -59,6 +59,7 @@ def _etapes_to_serializer_data(etapes: list) -> list[dict]:
             200: EtapeRecrutementSerializer(many=True),
             400: GenericErrorSerializer,
             401: TokenErrorSerializer,
+            403: GenericErrorSerializer,
             404: GenericErrorSerializer,
             500: GenericErrorSerializer,
         },
@@ -129,6 +130,8 @@ class RecrutementEtapeView(APIView):
                 _etapes_to_serializer_data(resultat), many=True
             )
             return Response(out_serializer.data)
+        except OrganismePermissionError:
+            return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except OrganismeNexistePas:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except Exception:

--- a/src/web/presentation/recruteur/views/recrutement_params.py
+++ b/src/web/presentation/recruteur/views/recrutement_params.py
@@ -148,6 +148,7 @@ class RecrutementEtapeView(APIView):
     responses={
         201: EtapeRecrutementSerializer(many=True),
         401: TokenErrorSerializer,
+        403: GenericErrorSerializer,
         404: GenericErrorSerializer,
         500: GenericErrorSerializer,
     },
@@ -176,6 +177,8 @@ class InitRecrutementEtapeView(APIView):
                 _etapes_to_serializer_data(resultat), many=True
             )
             return Response(serializer.data, status=status.HTTP_201_CREATED)
+        except OrganismePermissionError:
+            return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except OrganismeNexistePas:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except Exception:

--- a/src/web/presentation/recruteur/views/recrutement_params.py
+++ b/src/web/presentation/recruteur/views/recrutement_params.py
@@ -18,6 +18,9 @@ from application.recruteur.usecases.update_recrutement_etapes import (
     UpdateRecrutementEtapesCommand,
 )
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import (
+    OrganismePermissionError,
+)
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
@@ -43,6 +46,7 @@ def _etapes_to_serializer_data(etapes: list) -> list[dict]:
         responses={
             200: EtapeRecrutementSerializer(many=True),
             401: TokenErrorSerializer,
+            403: GenericErrorSerializer,
             404: GenericErrorSerializer,
             500: GenericErrorSerializer,
         },
@@ -84,6 +88,8 @@ class RecrutementEtapeView(APIView):
                 _etapes_to_serializer_data(resultat), many=True
             )
             return Response(serializer.data)
+        except OrganismePermissionError:
+            return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
         except OrganismeNexistePas:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except Exception:

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -648,6 +648,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
         '404':
           content:
             application/json:
@@ -720,6 +726,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
         '404':
           content:
             application/json:
@@ -768,6 +780,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
           description: ''
         '404':
           content:

--- a/src/web/tests/application/recruteur/test_get_recrutement_etapes.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_etapes.py
@@ -8,6 +8,11 @@ from application.recruteur.usecases.get_recrutement_etapes import (
     GetRecrutementEtapesUsecase,
 )
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @pytest.fixture(name="organisme_repository")
@@ -17,20 +22,32 @@ def organisme_repository_fixture():
     return repo
 
 
+@pytest.fixture(name="organisme_permission_service")
+def organisme_permission_service_fixture():
+    return MagicMock(spec=OrganismePermissionService)
+
+
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository):
-    return GetRecrutementEtapesUsecase(organisme_repository=organisme_repository)
+def usecase_fixture(organisme_repository, organisme_permission_service):
+    return GetRecrutementEtapesUsecase(
+        organisme_repository=organisme_repository,
+        organisme_permission_service=organisme_permission_service,
+    )
 
 
 class TestGetRecrutementEtapesUsecase:
-    def test_returns_default_pipeline(self, organisme_repository, usecase):
+    def test_returns_default_pipeline(
+        self, organisme_repository, organisme_permission_service, usecase
+    ):
         organisme_id = uuid4()
+        recrutement_id = uuid4()
+        utilisateur_id = uuid4()
 
         resultat = usecase.execute(
             GetRecrutementEtapesQuery(
                 organisme_id=organisme_id,
-                recrutement_id=uuid4(),
-                utilisateur_id=uuid4(),
+                recrutement_id=recrutement_id,
+                utilisateur_id=utilisateur_id,
             )
         )
 
@@ -42,6 +59,13 @@ class TestGetRecrutementEtapesUsecase:
             "Refus",
             "Recrutement",
         ]
+        organisme_permission_service.est_autorise.assert_called_once_with(
+            action=OrganismeAction.GET_RECRUTEMENT_ETAPES,
+            organisme_id=organisme_id,
+            agent_id=utilisateur_id,
+            recrutement_id=recrutement_id,
+            est_staff=False,
+        )
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
@@ -51,6 +75,23 @@ class TestGetRecrutementEtapesUsecase:
         )
 
         with pytest.raises(OrganismeNexistePas):
+            usecase.execute(
+                GetRecrutementEtapesQuery(
+                    organisme_id=organisme_id,
+                    recrutement_id=uuid4(),
+                    utilisateur_id=uuid4(),
+                )
+            )
+
+    def test_raises_when_not_authorized(
+        self, organisme_repository, organisme_permission_service, usecase
+    ):
+        organisme_id = uuid4()
+        organisme_permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
+            organisme_id
+        )
+
+        with pytest.raises(AccesOrganismeRefuse):
             usecase.execute(
                 GetRecrutementEtapesQuery(
                     organisme_id=organisme_id,

--- a/src/web/tests/application/recruteur/test_init_recrutement_etapes.py
+++ b/src/web/tests/application/recruteur/test_init_recrutement_etapes.py
@@ -8,6 +8,11 @@ from application.recruteur.usecases.init_recrutement_etapes import (
     InitRecrutementEtapesUsecase,
 )
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @pytest.fixture(name="organisme_repository")
@@ -17,20 +22,32 @@ def organisme_repository_fixture():
     return repo
 
 
+@pytest.fixture(name="organisme_permission_service")
+def organisme_permission_service_fixture():
+    return MagicMock(spec=OrganismePermissionService)
+
+
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository):
-    return InitRecrutementEtapesUsecase(organisme_repository=organisme_repository)
+def usecase_fixture(organisme_repository, organisme_permission_service):
+    return InitRecrutementEtapesUsecase(
+        organisme_repository=organisme_repository,
+        organisme_permission_service=organisme_permission_service,
+    )
 
 
 class TestInitRecrutementEtapesUsecase:
-    def test_returns_default_pipeline(self, organisme_repository, usecase):
+    def test_returns_default_pipeline(
+        self, organisme_repository, organisme_permission_service, usecase
+    ):
         organisme_id = uuid4()
+        recrutement_id = uuid4()
+        utilisateur_id = uuid4()
 
         resultat = usecase.execute(
             InitRecrutementEtapesCommand(
                 organisme_id=organisme_id,
-                recrutement_id=uuid4(),
-                utilisateur_id=uuid4(),
+                recrutement_id=recrutement_id,
+                utilisateur_id=utilisateur_id,
             )
         )
 
@@ -42,6 +59,13 @@ class TestInitRecrutementEtapesUsecase:
             "Refus",
             "Recrutement",
         ]
+        organisme_permission_service.est_autorise.assert_called_once_with(
+            action=OrganismeAction.INIT_RECRUTEMENT_ETAPES,
+            organisme_id=organisme_id,
+            agent_id=utilisateur_id,
+            recrutement_id=recrutement_id,
+            est_staff=False,
+        )
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
@@ -51,6 +75,23 @@ class TestInitRecrutementEtapesUsecase:
         )
 
         with pytest.raises(OrganismeNexistePas):
+            usecase.execute(
+                InitRecrutementEtapesCommand(
+                    organisme_id=organisme_id,
+                    recrutement_id=uuid4(),
+                    utilisateur_id=uuid4(),
+                )
+            )
+
+    def test_raises_when_not_authorized(
+        self, organisme_repository, organisme_permission_service, usecase
+    ):
+        organisme_id = uuid4()
+        organisme_permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
+            organisme_id
+        )
+
+        with pytest.raises(AccesOrganismeRefuse):
             usecase.execute(
                 InitRecrutementEtapesCommand(
                     organisme_id=organisme_id,

--- a/src/web/tests/application/recruteur/test_update_recrutement_etapes.py
+++ b/src/web/tests/application/recruteur/test_update_recrutement_etapes.py
@@ -9,9 +9,14 @@ from application.recruteur.usecases.update_recrutement_etapes import (
     UpdateRecrutementEtapesUsecase,
 )
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
+from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
 @pytest.fixture(name="organisme_repository")
@@ -21,14 +26,26 @@ def organisme_repository_fixture():
     return repo
 
 
+@pytest.fixture(name="organisme_permission_service")
+def organisme_permission_service_fixture():
+    return MagicMock(spec=OrganismePermissionService)
+
+
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository):
-    return UpdateRecrutementEtapesUsecase(organisme_repository=organisme_repository)
+def usecase_fixture(organisme_repository, organisme_permission_service):
+    return UpdateRecrutementEtapesUsecase(
+        organisme_repository=organisme_repository,
+        organisme_permission_service=organisme_permission_service,
+    )
 
 
 class TestUpdateRecrutementEtapesUsecase:
-    def test_echoes_etapes_back_unchanged(self, organisme_repository, usecase):
+    def test_echoes_etapes_back_unchanged(
+        self, organisme_repository, organisme_permission_service, usecase
+    ):
         organisme_id = uuid4()
+        recrutement_id = uuid4()
+        utilisateur_id = uuid4()
         etapes = [
             EtapeData(
                 etape_uuid=uuid4(),
@@ -45,13 +62,20 @@ class TestUpdateRecrutementEtapesUsecase:
         resultat = usecase.execute(
             UpdateRecrutementEtapesCommand(
                 organisme_id=organisme_id,
-                recrutement_id=uuid4(),
-                utilisateur_id=uuid4(),
+                recrutement_id=recrutement_id,
+                utilisateur_id=utilisateur_id,
                 etapes=etapes,
             )
         )
 
         assert resultat == etapes
+        organisme_permission_service.est_autorise.assert_called_once_with(
+            action=OrganismeAction.UPDATE_RECRUTEMENT_ETAPES,
+            organisme_id=organisme_id,
+            agent_id=utilisateur_id,
+            recrutement_id=recrutement_id,
+            est_staff=False,
+        )
         organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_empty_etapes_returns_empty_result(self, usecase):
@@ -73,6 +97,24 @@ class TestUpdateRecrutementEtapesUsecase:
         )
 
         with pytest.raises(OrganismeNexistePas):
+            usecase.execute(
+                UpdateRecrutementEtapesCommand(
+                    organisme_id=organisme_id,
+                    recrutement_id=uuid4(),
+                    utilisateur_id=uuid4(),
+                    etapes=[],
+                )
+            )
+
+    def test_raises_when_not_authorized(
+        self, organisme_repository, organisme_permission_service, usecase
+    ):
+        organisme_id = uuid4()
+        organisme_permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
+            organisme_id
+        )
+
+        with pytest.raises(AccesOrganismeRefuse):
             usecase.execute(
                 UpdateRecrutementEtapesCommand(
                     organisme_id=organisme_id,

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -15,6 +15,9 @@ from domain.recruteur.repositories.recrutement_agent_repository_interface import
     IRecrutementAgentRepository,
 )
 from domain.recruteur.services.organisme_permission_service import (
+    _ROLES_RECRUTEMENT_REQUIS,
+    _ROLES_REQUIS,
+    _SANS_ROLE_RECRUTEMENT_REQUIS,
     OrganismePermissionService,
 )
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
@@ -194,3 +197,15 @@ class TestVoirDetailRecrutementRbac:
                 est_staff=True,
                 recrutement_id=uuid4(),
             )
+
+
+def test_toute_action_membre_est_classee() -> None:
+    actions_membre = frozenset(
+        action
+        for action, roles in _ROLES_REQUIS.items()
+        if AgentOrganismeRole.MEMBRE in roles
+    )
+
+    assert actions_membre <= (
+        _ROLES_RECRUTEMENT_REQUIS.keys() | _SANS_ROLE_RECRUTEMENT_REQUIS
+    )

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -201,6 +201,7 @@ class TestVoirDetailRecrutementRbac:
 
 RECRUTEMENT_ETAPES_ACTIONS = [
     OrganismeAction.GET_RECRUTEMENT_ETAPES,
+    OrganismeAction.UPDATE_RECRUTEMENT_ETAPES,
 ]
 
 

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -202,6 +202,7 @@ class TestVoirDetailRecrutementRbac:
 RECRUTEMENT_ETAPES_ACTIONS = [
     OrganismeAction.GET_RECRUTEMENT_ETAPES,
     OrganismeAction.UPDATE_RECRUTEMENT_ETAPES,
+    OrganismeAction.INIT_RECRUTEMENT_ETAPES,
 ]
 
 

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -199,6 +199,97 @@ class TestVoirDetailRecrutementRbac:
             )
 
 
+RECRUTEMENT_ETAPES_ACTIONS = [
+    OrganismeAction.GET_RECRUTEMENT_ETAPES,
+]
+
+
+@pytest.mark.parametrize("action", RECRUTEMENT_ETAPES_ACTIONS)
+class TestRecrutementEtapesRbac:
+    def test_organisme_responsable_bypasses_recrutement_check(
+        self, action: OrganismeAction
+    ) -> None:
+        service, _, recrutement_repository = _service(
+            AgentOrganismeRole.RESPONSABLE, None
+        )
+
+        result = service.est_autorise(
+            action=action,
+            organisme_id=uuid4(),
+            agent_id=uuid4(),
+            est_staff=False,
+            recrutement_id=uuid4(),
+        )
+
+        assert result == AgentOrganismeRole.RESPONSABLE
+        recrutement_repository.get_role.assert_not_called()
+
+    def test_membre_with_recrutement_responsable_is_allowed(
+        self, action: OrganismeAction
+    ) -> None:
+        service, _, recrutement_repository = _service(
+            AgentOrganismeRole.MEMBRE, AgentRecrutementRole.RESPONSABLE
+        )
+        organisme_id, agent_id, recrutement_id = uuid4(), uuid4(), uuid4()
+
+        result = service.est_autorise(
+            action=action,
+            organisme_id=organisme_id,
+            agent_id=agent_id,
+            est_staff=False,
+            recrutement_id=recrutement_id,
+        )
+
+        assert result == AgentOrganismeRole.MEMBRE
+        recrutement_repository.get_role.assert_called_once_with(
+            recrutement_id=recrutement_id, agent_id=agent_id
+        )
+
+    @pytest.mark.parametrize(
+        "recrutement_role",
+        [AgentRecrutementRole.RECRUTEUR, AgentRecrutementRole.CONTRIBUTEUR, None],
+    )
+    def test_membre_without_recrutement_responsable_is_denied(
+        self, action: OrganismeAction, recrutement_role: AgentRecrutementRole
+    ) -> None:
+        service, _, _ = _service(AgentOrganismeRole.MEMBRE, recrutement_role)
+
+        with pytest.raises(AccesRecrutementRefuse):
+            service.est_autorise(
+                action=action,
+                organisme_id=uuid4(),
+                agent_id=uuid4(),
+                est_staff=False,
+                recrutement_id=uuid4(),
+            )
+
+    def test_unprovided_recrutement_id_is_denied(self, action: OrganismeAction) -> None:
+        service, _, recrutement_repository = _service(AgentOrganismeRole.MEMBRE, None)
+
+        with pytest.raises(AccesRecrutementInconnu):
+            service.est_autorise(
+                action=action,
+                organisme_id=uuid4(),
+                agent_id=uuid4(),
+                est_staff=False,
+            )
+        recrutement_repository.get_role.assert_not_called()
+
+    def test_staff_without_organisme_role_is_denied(
+        self, action: OrganismeAction
+    ) -> None:
+        service, _, _ = _service(None)
+
+        with pytest.raises(AccesOrganismeRefuse):
+            service.est_autorise(
+                action=action,
+                organisme_id=uuid4(),
+                agent_id=uuid4(),
+                est_staff=True,
+                recrutement_id=uuid4(),
+            )
+
+
 def test_toute_action_membre_est_classee() -> None:
     actions_membre = frozenset(
         action

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_etapes.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_etapes.py
@@ -9,8 +9,16 @@ from application.recruteur.usecases.get_recrutement_etapes import (
 from config.app_config import AppConfig
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    AccesRecrutementRefuse,
+)
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
-from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
 from infrastructure.gateways.shared.logger import LoggerService
 
 NB_ETAPES_PAR_DEFAUT = 6
@@ -27,21 +35,62 @@ def recruteur_integration_container_fixture(db):
     return container
 
 
+# TODO : update this class after persistence is implemented
 class TestGetRecrutementEtapes:
-    # TODO : update this class after persistence is implemented
-    def test_get_recrutement_etapes(self, db, recruteur_integration_container):
-        organisme_model = OrganismeFactory.create_model()
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"organisme_role": AgentOrganismeRole.RESPONSABLE},
+            {
+                "organisme_role": AgentOrganismeRole.MEMBRE,
+                "agent_role": AgentRecrutementRole.RESPONSABLE,
+            },
+        ],
+        ids=["responsable_organisme", "responsable_recrutement"],
+    )
+    def test_get_recrutement_etapes(self, db, recruteur_integration_container, kwargs):
+        recrutement_model = RecrutementFactory.create_model(**kwargs)
         usecase = recruteur_integration_container.get_recrutement_etapes_usecase()
 
         resultat = usecase.execute(
             GetRecrutementEtapesQuery(
-                organisme_id=organisme_model.id,
-                recrutement_id=uuid4(),
-                utilisateur_id=uuid4(),
+                organisme_id=recrutement_model.organisme_id,
+                recrutement_id=recrutement_model.offre_id,
+                utilisateur_id=recrutement_model.agents_liaisons.get().agent_id,
             )
         )
 
         assert len(resultat) == NB_ETAPES_PAR_DEFAUT
+
+    @pytest.mark.parametrize(
+        "agent_role",
+        [AgentRecrutementRole.RECRUTEUR, AgentRecrutementRole.CONTRIBUTEUR],
+    )
+    def test_denied_agents(self, db, recruteur_integration_container, agent_role):
+        recrutement_model = RecrutementFactory.create_model(agent_role=agent_role)
+        usecase = recruteur_integration_container.get_recrutement_etapes_usecase()
+
+        with pytest.raises(AccesRecrutementRefuse):
+            usecase.execute(
+                GetRecrutementEtapesQuery(
+                    organisme_id=recrutement_model.organisme_id,
+                    recrutement_id=recrutement_model.offre_id,
+                    utilisateur_id=recrutement_model.agents_liaisons.get().agent_id,
+                )
+            )
+
+    def test_agents_without_role(self, db, recruteur_integration_container):
+        recrutement_model = RecrutementFactory.create_model()
+        usecase = recruteur_integration_container.get_recrutement_etapes_usecase()
+
+        with pytest.raises(AccesOrganismeRefuse):
+            usecase.execute(
+                GetRecrutementEtapesQuery(
+                    organisme_id=recrutement_model.organisme_id,
+                    recrutement_id=recrutement_model.offre_id,
+                    utilisateur_id=uuid4(),
+                )
+            )
 
     def test_get_recrutement_etapes_raises_when_organisme_introuvable(
         self, db, recruteur_integration_container

--- a/src/web/tests/infrastructure/recruteur/test_init_recrutement_etapes.py
+++ b/src/web/tests/infrastructure/recruteur/test_init_recrutement_etapes.py
@@ -9,8 +9,16 @@ from application.recruteur.usecases.init_recrutement_etapes import (
 from config.app_config import AppConfig
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    AccesRecrutementRefuse,
+)
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
-from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
 from infrastructure.gateways.shared.logger import LoggerService
 
 NB_ETAPES_PAR_DEFAUT = 6
@@ -27,21 +35,62 @@ def recruteur_integration_container_fixture(db):
     return container
 
 
+# TODO : update this class after persistence is implemented
 class TestInitRecrutementEtapes:
-    # TODO : update this class after persistence is implemented
-    def test_init_recrutement_etapes(self, db, recruteur_integration_container):
-        organisme_model = OrganismeFactory.create_model()
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"organisme_role": AgentOrganismeRole.RESPONSABLE},
+            {
+                "organisme_role": AgentOrganismeRole.MEMBRE,
+                "agent_role": AgentRecrutementRole.RESPONSABLE,
+            },
+        ],
+        ids=["responsable_organisme", "responsable_recrutement"],
+    )
+    def test_init_recrutement_etapes(self, db, recruteur_integration_container, kwargs):
+        recrutement_model = RecrutementFactory.create_model(**kwargs)
         usecase = recruteur_integration_container.init_recrutement_etapes_usecase()
 
         resultat = usecase.execute(
             InitRecrutementEtapesCommand(
-                organisme_id=organisme_model.id,
-                recrutement_id=uuid4(),
-                utilisateur_id=uuid4(),
+                organisme_id=recrutement_model.organisme_id,
+                recrutement_id=recrutement_model.offre_id,
+                utilisateur_id=recrutement_model.agents_liaisons.get().agent_id,
             )
         )
 
         assert len(resultat) == NB_ETAPES_PAR_DEFAUT
+
+    @pytest.mark.parametrize(
+        "agent_role",
+        [AgentRecrutementRole.RECRUTEUR, AgentRecrutementRole.CONTRIBUTEUR],
+    )
+    def test_denied_agents(self, db, recruteur_integration_container, agent_role):
+        recrutement_model = RecrutementFactory.create_model(agent_role=agent_role)
+        usecase = recruteur_integration_container.init_recrutement_etapes_usecase()
+
+        with pytest.raises(AccesRecrutementRefuse):
+            usecase.execute(
+                InitRecrutementEtapesCommand(
+                    organisme_id=recrutement_model.organisme_id,
+                    recrutement_id=recrutement_model.offre_id,
+                    utilisateur_id=recrutement_model.agents_liaisons.get().agent_id,
+                )
+            )
+
+    def test_agents_without_role(self, db, recruteur_integration_container):
+        recrutement_model = RecrutementFactory.create_model()
+        usecase = recruteur_integration_container.init_recrutement_etapes_usecase()
+
+        with pytest.raises(AccesOrganismeRefuse):
+            usecase.execute(
+                InitRecrutementEtapesCommand(
+                    organisme_id=recrutement_model.organisme_id,
+                    recrutement_id=recrutement_model.offre_id,
+                    utilisateur_id=uuid4(),
+                )
+            )
 
     def test_init_recrutement_etapes_raises_when_organisme_introuvable(
         self, db, recruteur_integration_container

--- a/src/web/tests/infrastructure/recruteur/test_update_recrutement_etapes.py
+++ b/src/web/tests/infrastructure/recruteur/test_update_recrutement_etapes.py
@@ -10,11 +10,19 @@ from application.recruteur.usecases.update_recrutement_etapes import (
 from config.app_config import AppConfig
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    AccesRecrutementRefuse,
+)
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
-from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
 from infrastructure.gateways.shared.logger import LoggerService
 
 
@@ -29,10 +37,23 @@ def recruteur_integration_container_fixture(db):
     return container
 
 
+# TODO : update this class after persistence is implemented
 class TestUpdateRecrutementEtapes:
-    # TODO : update this class after persistence is implemented
-    def test_update_recrutement_etapes(self, db, recruteur_integration_container):
-        organisme_model = OrganismeFactory.create_model()
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"organisme_role": AgentOrganismeRole.RESPONSABLE},
+            {
+                "organisme_role": AgentOrganismeRole.MEMBRE,
+                "agent_role": AgentRecrutementRole.RESPONSABLE,
+            },
+        ],
+        ids=["responsable_organisme", "responsable_recrutement"],
+    )
+    def test_update_recrutement_etapes(
+        self, db, recruteur_integration_container, kwargs
+    ):
+        recrutement_model = RecrutementFactory.create_model(**kwargs)
         etapes = [
             EtapeData(
                 etape_uuid=uuid4(),
@@ -44,14 +65,46 @@ class TestUpdateRecrutementEtapes:
 
         resultat = usecase.execute(
             UpdateRecrutementEtapesCommand(
-                organisme_id=organisme_model.id,
-                recrutement_id=uuid4(),
-                utilisateur_id=uuid4(),
+                organisme_id=recrutement_model.organisme_id,
+                recrutement_id=recrutement_model.offre_id,
+                utilisateur_id=recrutement_model.agents_liaisons.get().agent_id,
                 etapes=etapes,
             )
         )
 
         assert resultat == etapes
+
+    @pytest.mark.parametrize(
+        "agent_role",
+        [AgentRecrutementRole.RECRUTEUR, AgentRecrutementRole.CONTRIBUTEUR],
+    )
+    def test_denied_agents(self, db, recruteur_integration_container, agent_role):
+        recrutement_model = RecrutementFactory.create_model(agent_role=agent_role)
+        usecase = recruteur_integration_container.update_recrutement_etapes_usecase()
+
+        with pytest.raises(AccesRecrutementRefuse):
+            usecase.execute(
+                UpdateRecrutementEtapesCommand(
+                    organisme_id=recrutement_model.organisme_id,
+                    recrutement_id=recrutement_model.offre_id,
+                    utilisateur_id=recrutement_model.agents_liaisons.get().agent_id,
+                    etapes=[],
+                )
+            )
+
+    def test_agents_without_role(self, db, recruteur_integration_container):
+        recrutement_model = RecrutementFactory.create_model()
+        usecase = recruteur_integration_container.update_recrutement_etapes_usecase()
+
+        with pytest.raises(AccesOrganismeRefuse):
+            usecase.execute(
+                UpdateRecrutementEtapesCommand(
+                    organisme_id=recrutement_model.organisme_id,
+                    recrutement_id=recrutement_model.offre_id,
+                    utilisateur_id=uuid4(),
+                    etapes=[],
+                )
+            )
 
     def test_update_recrutement_etapes_raises_when_organisme_introuvable(
         self, db, recruteur_integration_container

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
@@ -102,6 +102,7 @@ class TestRecrutementEtapeView:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {"detail": "Forbidden."}
+
     def test_get_returns_500_on_unexpected_error(self, container, authenticated_client):
         container.get_recrutement_etapes_usecase.return_value.execute.side_effect = (
             Exception("unexpected")
@@ -195,6 +196,16 @@ class TestInitRecrutementEtapeView:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found."}
+
+    def test_returns_403_when_forbidden(self, container, authenticated_client):
+        container.init_recrutement_etapes_usecase.return_value.execute.side_effect = (
+            AccesOrganismeRefuse(uuid4())
+        )
+
+        response = authenticated_client.post(RECRUTEMENT_ETAPES_INIT_URL)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"detail": "Forbidden."}
 
     def test_returns_500_on_unexpected_error(self, container, authenticated_client):
         container.init_recrutement_etapes_usecase.return_value.execute.side_effect = (

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
@@ -136,6 +136,20 @@ class TestRecrutementEtapeView:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found."}
 
+    def test_patch_returns_403_when_forbidden(self, container, authenticated_client):
+        container.update_recrutement_etapes_usecase.return_value.execute.side_effect = (
+            AccesOrganismeRefuse(uuid4())
+        )
+
+        response = authenticated_client.patch(
+            RECRUTEMENT_ETAPES_URL,
+            data=[{"nom": "Réception", "categorie": "ENTREE"}],
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"detail": "Forbidden."}
+
     def test_patch_returns_500_on_unexpected_error(
         self, container, authenticated_client
     ):

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
@@ -8,6 +8,7 @@ from rest_framework import status
 
 from application.recruteur.dtos.etape_data import EtapeData
 from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
@@ -92,6 +93,15 @@ class TestRecrutementEtapeView:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found."}
 
+    def test_get_returns_403_when_forbidden(self, container, authenticated_client):
+        container.get_recrutement_etapes_usecase.return_value.execute.side_effect = (
+            AccesOrganismeRefuse(uuid4())
+        )
+
+        response = authenticated_client.get(RECRUTEMENT_ETAPES_URL)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {"detail": "Forbidden."}
     def test_get_returns_500_on_unexpected_error(self, container, authenticated_client):
         container.get_recrutement_etapes_usecase.return_value.execute.side_effect = (
             Exception("unexpected")


### PR DESCRIPTION
## 📝 Description
🎸 Application du contrôle d'accès (RBAC) aux endpoints de gestion des étapes de recrutement 

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
- **Domain (recruteur)** : réorganisation de `OrganismePermissionService` en deux niveaux
- **Application (recruteur)** : les use cases `GetRecrutementEtapesUsecase`, `InitRecrutementEtapesUsecase`, `UpdateRecrutementEtapesUsecase` appellent désormais `OrganismePermissionService.est_autorise` avant d'exécuter l'action
- **Presentation (recruteur)** : `RecrutementEtapeView` et `InitRecrutementEtapeView` interceptent `OrganismePermissionError` et renvoient `403 Forbidden`

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
