### PR TITLE
♻️(recrutement-tooling) amélioration de OrganismeFactory, RecruteurFactory et du seed

### DIFF
--- a/src/web/infrastructure/factories/identite/organisme_factory.py
+++ b/src/web/infrastructure/factories/identite/organisme_factory.py
@@ -12,7 +12,12 @@ from domain.identite.entities.organisme import Organisme
 from domain.identite.value_objects.siret import SIRET
 from domain.recruteur.entities.etape_recrutement import EtapeRecrutement
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
-from infrastructure.django_apps.recruteur.models.organisme import OrganismeAgentModel
+from infrastructure.django_apps.recruteur.models.organisme import (
+    OrganismeAgentModel,
+    OrganismeModel,
+)
+from infrastructure.django_apps.users.models import ProfilAgentModel
+from infrastructure.factories.identite.agent_factory import AgentFactory
 from infrastructure.mappers.organisme_identite_mapper import (
     OrganismeIdentiteMapper,
 )
@@ -85,3 +90,17 @@ class OrganismeFactory:
                 role=(role or AgentOrganismeRole.MEMBRE).value,
             ).save()
         return model
+
+    @staticmethod
+    def create_model_with_agent(
+        role: AgentOrganismeRole | None = None,
+        **organisme_kwargs,
+    ) -> tuple[ProfilAgentModel, OrganismeModel]:
+        agent = AgentFactory.create_model()
+        if role is not None:
+            organisme = OrganismeFactory.create_model(
+                agent_id=UUID(agent.utilisateur_id), role=role, **organisme_kwargs
+            )
+        else:
+            organisme = OrganismeFactory.create_model(**organisme_kwargs)
+        return agent, organisme

--- a/src/web/infrastructure/factories/recruteur/recrutement_factory.py
+++ b/src/web/infrastructure/factories/recruteur/recrutement_factory.py
@@ -99,8 +99,8 @@ class RecrutementFactory:
         organisme_id: UUID | None = None,
         etapes: tuple[EtapeRecrutement, ...] | None = None,
         ordre_etapes: list[str] | None = None,
-        agent_ids: tuple[UUID, ...] | None = None,
-        agent_roles: dict[UUID, AgentRecrutementRole] | None = None,
+        agent_id: UUID | None = None,
+        agent_role: AgentRecrutementRole | None = None,
     ) -> RecrutementModel:
         if offre_id is None:
             archived_at = datetime(2024, 1, 1) if offre_archivee else None
@@ -127,16 +127,14 @@ class RecrutementFactory:
             )
             model.save()
 
-        if agent_ids is None:
-            agent_ids = (UUID(AgentFactory.create_model().utilisateur_id),)
+        if agent_id is None:
+            agent_id = UUID(AgentFactory.create_model().utilisateur_id)
 
-        for agent_id in agent_ids:
-            role = (agent_roles or {}).get(agent_id, AgentRecrutementRole.CONTRIBUTEUR)
-            RecrutementAgentModel(
-                id=uuid4(),
-                recrutement=recrutement,
-                agent_id=str(agent_id),
-                role=role.value,
-            ).save()
+        RecrutementAgentModel(
+            id=uuid4(),
+            recrutement=recrutement,
+            agent_id=str(agent_id),
+            role=(agent_role or AgentRecrutementRole.CONTRIBUTEUR).value,
+        ).save()
 
         return recrutement

--- a/src/web/infrastructure/factories/recruteur/recrutement_factory.py
+++ b/src/web/infrastructure/factories/recruteur/recrutement_factory.py
@@ -9,7 +9,10 @@ from application.recruteur.dtos.recrutement_read_models import (
 )
 from domain.recruteur.entities.etape_recrutement import EtapeRecrutement
 from domain.recruteur.entities.recrutement import Recrutement
-from domain.recruteur.value_objects.roles import AgentRecrutementRole
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
 from domain.recruteur.value_objects.statut_recrutement import StatutRecrutement
 from infrastructure.django_apps.recruteur.models.etape import EtapeModel
 from infrastructure.django_apps.recruteur.models.recrutement import (
@@ -97,6 +100,7 @@ class RecrutementFactory:
         offre_id: UUID | None = None,
         offre_archivee: bool = False,
         organisme_id: UUID | None = None,
+        organisme_role: AgentOrganismeRole | None = None,
         etapes: tuple[EtapeRecrutement, ...] | None = None,
         ordre_etapes: list[str] | None = None,
         agent_id: UUID | None = None,
@@ -105,8 +109,12 @@ class RecrutementFactory:
         if offre_id is None:
             archived_at = datetime(2024, 1, 1) if offre_archivee else None
             offre_id = OfferFactory.create_model(archived_at=archived_at).id
+        if agent_id is None:
+            agent_id = UUID(AgentFactory.create_model().utilisateur_id)
         if organisme_id is None:
-            organisme_id = OrganismeFactory.create_model().id
+            organisme_id = OrganismeFactory.create_model(
+                agent_id=agent_id, role=organisme_role
+            ).id
         if etapes is None:
             etapes = EtapeRecrutementFactory.create_entities()
 
@@ -126,9 +134,6 @@ class RecrutementFactory:
                 ordre_candidatures=None,
             )
             model.save()
-
-        if agent_id is None:
-            agent_id = UUID(AgentFactory.create_model().utilisateur_id)
 
         RecrutementAgentModel(
             id=uuid4(),

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -286,29 +286,24 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # ------------------------------------------------------------------ #
     # 7. Recrutements (1 par offre active) : étapes + responsables         #
     # ------------------------------------------------------------------ #
-    # Doit précéder les candidatures car CandidatureFactory.create_model()
-    # crée désormais un recrutement lié.
-    # Marie est responsable de la première moitié des recrutements, Claire de
-    # l'autre (Claire n'est que membre de l'organisme : ça exerce l'accès par
-    # role recrutement seul, sans passer par le role organisme). Paul est
-    # recruteur sur la moitié de Marie, en plus d'elle. David (hors organisme)
-    # est contributeur sur le premier recrutement de Claire, et sur lui seul.
     marie_id = UUID(agents[0].utilisateur_id)
     paul_id = UUID(agents[1].utilisateur_id)
     claire_id = UUID(agents[2].utilisateur_id)
     david_id = UUID(agents[3].utilisateur_id)
-    moitie = len(offres_actives) // 2
-    responsables = [marie_id] * moitie + [claire_id] * (len(offres_actives) - moitie)
-    recrutements = []
-    for i, (offre, responsable_id) in enumerate(
-        zip(offres_actives, responsables, strict=True)
-    ):
-        extra_agent: tuple[UUID, AgentRecrutementRole] | None = None
-        if i < moitie:
-            extra_agent = (paul_id, AgentRecrutementRole.RECRUTEUR)
-        elif i == moitie:
-            extra_agent = (david_id, AgentRecrutementRole.CONTRIBUTEUR)
 
+    recrutements_specs: list[
+        tuple[OfferModel, UUID, tuple[UUID, AgentRecrutementRole] | None]
+    ] = [
+        (offres_actives[0], marie_id, (paul_id, AgentRecrutementRole.RECRUTEUR)),
+        (offres_actives[1], marie_id, (paul_id, AgentRecrutementRole.RECRUTEUR)),
+        (offres_actives[2], marie_id, (paul_id, AgentRecrutementRole.RECRUTEUR)),
+        (offres_actives[3], claire_id, (david_id, AgentRecrutementRole.CONTRIBUTEUR)),
+        (offres_actives[4], claire_id, None),
+        (offres_actives[5], claire_id, None),
+    ]
+
+    recrutements = []
+    for offre, responsable_id, extra_agent in recrutements_specs:
         recrutement = RecrutementFactory.create_model(
             offre_id=offre.id,
             organisme_id=_ORGANISME_UUID,

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -247,33 +247,35 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # ------------------------------------------------------------------ #
     # 5. Offres archivées (3)                                              #
     # ------------------------------------------------------------------ #
-    OfferFactory.create_model(
-        title="Directeur des systèmes d'information",
-        reference="REF-2024-A01",
-        external_id="SEED-ARCHIVE-001",
-        verse=Verse.FPE,
-        category=Category.A,
-        publication_date=datetime(2024, 12, 1, tzinfo=UTC),
-        archived_at=datetime(2025, 3, 1),
-    )
-    OfferFactory.create_model(
-        title="Chef de projet transformation numérique",
-        reference="REF-2024-A02",
-        external_id="SEED-ARCHIVE-002",
-        verse=Verse.FPE,
-        category=Category.A,
-        publication_date=datetime(2024, 11, 15, tzinfo=UTC),
-        archived_at=datetime(2025, 2, 15),
-    )
-    OfferFactory.create_model(
-        title="Conseiller en mobilité professionnelle",
-        reference="REF-2024-A03",
-        external_id="SEED-ARCHIVE-003",
-        verse=Verse.FPT,
-        category=Category.B,
-        publication_date=datetime(2024, 10, 1, tzinfo=UTC),
-        archived_at=datetime(2025, 1, 15),
-    )
+    offres_archivees = [
+        OfferFactory.create_model(
+            title="Directeur des systèmes d'information",
+            reference="REF-2024-A01",
+            external_id="SEED-ARCHIVE-001",
+            verse=Verse.FPE,
+            category=Category.A,
+            publication_date=datetime(2024, 12, 1, tzinfo=UTC),
+            archived_at=datetime(2025, 3, 1),
+        ),
+        OfferFactory.create_model(
+            title="Chef de projet transformation numérique",
+            reference="REF-2024-A02",
+            external_id="SEED-ARCHIVE-002",
+            verse=Verse.FPE,
+            category=Category.A,
+            publication_date=datetime(2024, 11, 15, tzinfo=UTC),
+            archived_at=datetime(2025, 2, 15),
+        ),
+        OfferFactory.create_model(
+            title="Conseiller en mobilité professionnelle",
+            reference="REF-2024-A03",
+            external_id="SEED-ARCHIVE-003",
+            verse=Verse.FPT,
+            category=Category.B,
+            publication_date=datetime(2024, 10, 1, tzinfo=UTC),
+            archived_at=datetime(2025, 1, 15),
+        ),
+    ]
 
     # ------------------------------------------------------------------ #
     # 6. Candidats (8)                                                     #
@@ -284,7 +286,7 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     ]
 
     # ------------------------------------------------------------------ #
-    # 7. Recrutements (1 par offre active) : étapes + responsables         #
+    # 7. Recrutements (1 par offre active et archivée) : étapes + responsables #
     # ------------------------------------------------------------------ #
     marie_id = UUID(agents[0].utilisateur_id)
     paul_id = UUID(agents[1].utilisateur_id)
@@ -300,6 +302,9 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         (offres_actives[3], claire_id, (david_id, AgentRecrutementRole.CONTRIBUTEUR)),
         (offres_actives[4], claire_id, None),
         (offres_actives[5], claire_id, None),
+        (offres_archivees[0], claire_id, None),
+        (offres_archivees[1], claire_id, None),
+        (offres_archivees[2], claire_id, None),
     ]
 
     recrutements = []

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -17,7 +17,10 @@ from infrastructure.django_apps.recruteur.models.organisme import (
     OrganismeAgentModel,
     OrganismeModel,
 )
-from infrastructure.django_apps.recruteur.models.recrutement import RecrutementModel
+from infrastructure.django_apps.recruteur.models.recrutement import (
+    RecrutementAgentModel,
+    RecrutementModel,
+)
 from infrastructure.django_apps.referentiel.models.metier import MetierModel
 from infrastructure.django_apps.referentiel.models.offer import OfferModel
 from infrastructure.django_apps.users.models import (
@@ -300,22 +303,27 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     for i, (offre, responsable_id) in enumerate(
         zip(offres_actives, responsables, strict=True)
     ):
-        agent_roles = {responsable_id: AgentRecrutementRole.RESPONSABLE}
-        agent_ids: tuple[UUID, ...] = (responsable_id,)
+        extra_agent: tuple[UUID, AgentRecrutementRole] | None = None
         if i < moitie:
-            agent_roles[paul_id] = AgentRecrutementRole.RECRUTEUR
-            agent_ids = (responsable_id, paul_id)
+            extra_agent = (paul_id, AgentRecrutementRole.RECRUTEUR)
         elif i == moitie:
-            agent_roles[david_id] = AgentRecrutementRole.CONTRIBUTEUR
-            agent_ids = (responsable_id, david_id)
-        recrutements.append(
-            RecrutementFactory.create_model(
-                offre_id=offre.id,
-                organisme_id=_ORGANISME_UUID,
-                agent_ids=agent_ids,
-                agent_roles=agent_roles,
-            )
+            extra_agent = (david_id, AgentRecrutementRole.CONTRIBUTEUR)
+
+        recrutement = RecrutementFactory.create_model(
+            offre_id=offre.id,
+            organisme_id=_ORGANISME_UUID,
+            agent_id=responsable_id,
+            agent_role=AgentRecrutementRole.RESPONSABLE,
         )
+        if extra_agent is not None:
+            extra_agent_id, extra_agent_role = extra_agent
+            RecrutementAgentModel(
+                id=uuid4(),
+                recrutement=recrutement,
+                agent_id=str(extra_agent_id),
+                role=extra_agent_role.value,
+            ).save()
+        recrutements.append(recrutement)
 
     # ------------------------------------------------------------------ #
     # 8. Candidatures                                                      #

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_kanban.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_kanban.py
@@ -45,10 +45,7 @@ class TestGetRecrutementKanbanRbac:
         ],
     )
     def test_authorized(self, usecase, role, assign_agent_to_recrutement):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=role
-        )
+        agent, organisme = OrganismeFactory.create_model_with_agent(role=role)
         agent_ids = (
             (UUID(agent.utilisateur_id),) if assign_agent_to_recrutement else None
         )
@@ -81,9 +78,8 @@ class TestGetRecrutementKanbanRbac:
         assert result.organisme_recruteur.siret == organisme.siret
 
     def test_forbidden_when_membre_not_assigned_to_recrutement(self, usecase):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.MEMBRE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.MEMBRE
         )
         recrutement = RecrutementFactory.create_model(organisme_id=organisme.id)
 
@@ -112,9 +108,8 @@ class TestGetRecrutementKanbanRbac:
             )
 
     def test_returns_none_for_unknown_recrutement(self, usecase):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE
         )
 
         result = usecase.execute(
@@ -128,9 +123,8 @@ class TestGetRecrutementKanbanRbac:
         assert result is None
 
     def test_returns_none_when_recrutement_belongs_to_another_organisme(self, usecase):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE
         )
         autre_organisme = OrganismeFactory.create_model()
         recrutement = RecrutementFactory.create_model(organisme_id=autre_organisme.id)

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_kanban.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_kanban.py
@@ -46,11 +46,9 @@ class TestGetRecrutementKanbanRbac:
     )
     def test_authorized(self, usecase, role, assign_agent_to_recrutement):
         agent, organisme = OrganismeFactory.create_model_with_agent(role=role)
-        agent_ids = (
-            (UUID(agent.utilisateur_id),) if assign_agent_to_recrutement else None
-        )
+        agent_id = UUID(agent.utilisateur_id) if assign_agent_to_recrutement else None
         recrutement = RecrutementFactory.create_model(
-            organisme_id=organisme.id, agent_ids=agent_ids
+            organisme_id=organisme.id, agent_id=agent_id
         )
         etape_entree = EtapeModel.objects.get(
             recrutement_id=recrutement.offre_id,

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
@@ -45,10 +45,7 @@ class TestGetRecrutementListeRbac:
         ],
     )
     def test_authorized(self, usecase, role, assign_agent_to_recrutement):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=role
-        )
+        agent, organisme = OrganismeFactory.create_model_with_agent(role=role)
         agent_ids = (
             (UUID(agent.utilisateur_id),) if assign_agent_to_recrutement else None
         )
@@ -81,9 +78,8 @@ class TestGetRecrutementListeRbac:
         assert item.etape.categorie == "ENTREE"
 
     def test_forbidden_when_membre_not_assigned_to_recrutement(self, usecase):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.MEMBRE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.MEMBRE
         )
         recrutement = RecrutementFactory.create_model(organisme_id=organisme.id)
 
@@ -112,9 +108,8 @@ class TestGetRecrutementListeRbac:
             )
 
     def test_returns_none_for_unknown_recrutement(self, usecase):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE
         )
 
         result = usecase.execute(
@@ -128,9 +123,8 @@ class TestGetRecrutementListeRbac:
         assert result is None
 
     def test_returns_none_when_recrutement_belongs_to_another_organisme(self, usecase):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE
         )
         autre_organisme = OrganismeFactory.create_model()
         recrutement = RecrutementFactory.create_model(organisme_id=autre_organisme.id)

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_liste.py
@@ -46,11 +46,9 @@ class TestGetRecrutementListeRbac:
     )
     def test_authorized(self, usecase, role, assign_agent_to_recrutement):
         agent, organisme = OrganismeFactory.create_model_with_agent(role=role)
-        agent_ids = (
-            (UUID(agent.utilisateur_id),) if assign_agent_to_recrutement else None
-        )
+        agent_id = UUID(agent.utilisateur_id) if assign_agent_to_recrutement else None
         recrutement = RecrutementFactory.create_model(
-            organisme_id=organisme.id, agent_ids=agent_ids
+            organisme_id=organisme.id, agent_id=agent_id
         )
         etape_entree = EtapeModel.objects.get(
             recrutement_id=recrutement.offre_id,

--- a/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
@@ -45,9 +45,8 @@ def usecase_fixture(recruteur_integration_container):
 
 class TestListerMesRecrutements:
     def _create_agent_responsable(self):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE
         )
         return agent.utilisateur_id, organisme
 
@@ -210,9 +209,8 @@ class TestListerMesRecrutementsRbac:
         )
 
     def test_responsable_organisme(self, usecase, statut):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE
         )
         (
             recrutement_in_org,
@@ -232,9 +230,8 @@ class TestListerMesRecrutementsRbac:
             assert recrutement not in results._qs
 
     def test_membre_organisme(self, usecase, statut):
-        agent = AgentFactory.create_model()
-        organisme = OrganismeFactory.create_model(
-            agent_id=agent.utilisateur_id, role=AgentOrganismeRole.MEMBRE
+        agent, organisme = OrganismeFactory.create_model_with_agent(
+            role=AgentOrganismeRole.MEMBRE
         )
         (
             recrutement_in_org,

--- a/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/infrastructure/recruteur/test_lister_mes_recrutements.py
@@ -63,13 +63,13 @@ class TestListerMesRecrutements:
         agent_id, organisme = self._create_agent_responsable()
         recrutement_actif = RecrutementFactory.create_model(
             organisme_id=organisme.id,
-            agent_ids=(agent_id,),
+            agent_id=agent_id,
             etapes=EtapeRecrutementFactory.create_entities(),
         )
         RecrutementFactory.create_model(
             offre_archivee=True,
             organisme_id=organisme.id,
-            agent_ids=(agent_id,),
+            agent_id=agent_id,
         )
         etape_entree = EtapeModel.objects.filter(
             recrutement_id=recrutement_actif.offre_id,
@@ -137,7 +137,7 @@ class TestListerMesRecrutements:
         recrutement_actif = RecrutementFactory.create_model(
             offre_id=offre.id,
             organisme_id=organisme.id,
-            agent_ids=(agent_id,),
+            agent_id=agent_id,
             etapes=EtapeRecrutementFactory.create_entities(),
         )
 
@@ -156,7 +156,7 @@ class TestListerMesRecrutements:
         recrutement_archive = RecrutementFactory.create_model(
             offre_archivee=True,
             organisme_id=organisme.id,
-            agent_ids=(agent_id,),
+            agent_id=agent_id,
         )
 
         result = self._lister_recrutements(
@@ -181,16 +181,16 @@ class TestListerMesRecrutementsRbac:
         recrutement_in_org_with_role = RecrutementFactory.create_model(
             offre_archivee=offre_archivee,
             organisme_id=organisme.id,
-            agent_ids=(agent.utilisateur_id,),
-            agent_roles={agent.utilisateur_id: AgentRecrutementRole.CONTRIBUTEUR},
+            agent_id=agent.utilisateur_id,
+            agent_role=AgentRecrutementRole.CONTRIBUTEUR,
         )
         recrutement_in_other_org = RecrutementFactory.create_model(
             offre_archivee=offre_archivee
         )
         recrutement_in_other_org_with_role = RecrutementFactory.create_model(
             offre_archivee=offre_archivee,
-            agent_ids=(agent.utilisateur_id,),
-            agent_roles={agent.utilisateur_id: AgentRecrutementRole.CONTRIBUTEUR},
+            agent_id=agent.utilisateur_id,
+            agent_role=AgentRecrutementRole.CONTRIBUTEUR,
         )
         return (
             recrutement_in_org,

--- a/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
@@ -14,9 +14,8 @@ def repository_fixture():
 
 
 def test_get_role_returns_responsable(db, repository):
-    agent = AgentFactory.create_model()
-    organisme_model = OrganismeFactory.create_model(
-        agent_id=agent.utilisateur_id, role=AgentOrganismeRole.RESPONSABLE
+    agent, organisme_model = OrganismeFactory.create_model_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
     )
 
     role = repository.get_role(
@@ -27,8 +26,9 @@ def test_get_role_returns_responsable(db, repository):
 
 
 def test_get_role_returns_membre(db, repository):
-    agent = AgentFactory.create_model()
-    organisme_model = OrganismeFactory.create_model(agent_id=agent.utilisateur_id)
+    agent, organisme_model = OrganismeFactory.create_model_with_agent(
+        role=AgentOrganismeRole.MEMBRE
+    )
 
     role = repository.get_role(
         organisme_id=organisme_model.id, agent_id=agent.utilisateur_id

--- a/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_steps.py
@@ -1,5 +1,4 @@
 from unittest.mock import MagicMock
-from uuid import UUID
 
 import pytest
 
@@ -17,7 +16,6 @@ from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
-from infrastructure.factories.identite.agent_factory import AgentFactory
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory
 from infrastructure.factories.recruteur.etapes_recrutement_factory import (
     EtapeRecrutementFactory,
@@ -25,17 +23,6 @@ from infrastructure.factories.recruteur.etapes_recrutement_factory import (
 from infrastructure.gateways.shared.logger import LoggerService
 
 NB_ETAPES_PAR_DEFAUT = 6
-
-
-def _create_agent(role: AgentOrganismeRole | None = None, **organisme_kwargs):
-    agent = AgentFactory.create_model()
-    if role is not None:
-        organisme = OrganismeFactory.create_model(
-            agent_id=UUID(agent.utilisateur_id), role=role, **organisme_kwargs
-        )
-    else:
-        organisme = OrganismeFactory.create_model(**organisme_kwargs)
-    return agent, organisme
 
 
 @pytest.fixture(name="recruteur_integration_container")
@@ -50,7 +37,9 @@ def recruteur_integration_container_fixture(db):
 
 
 def test_get_organisme_steps(recruteur_integration_container):
-    agent, organisme_model = _create_agent(AgentOrganismeRole.RESPONSABLE)
+    agent, organisme_model = OrganismeFactory.create_model_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
     usecase = recruteur_integration_container.get_organisme_recruteur_usecase()
 
     organisme = usecase.execute(
@@ -64,7 +53,9 @@ def test_get_organisme_steps(recruteur_integration_container):
 
 
 def test_initialize_organisme_steps(recruteur_integration_container):
-    agent, organisme_model = _create_agent(AgentOrganismeRole.RESPONSABLE)
+    agent, organisme_model = OrganismeFactory.create_model_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
     usecase = recruteur_integration_container.initialize_organisme_steps_usecase()
 
     organisme = usecase.execute(
@@ -82,7 +73,7 @@ def test_initialize_organisme_steps(recruteur_integration_container):
 def test_update_organisme_steps(recruteur_integration_container):
     etapes = EtapeRecrutementFactory.create_entities()
 
-    agent, organisme_model = _create_agent(
+    agent, organisme_model = OrganismeFactory.create_model_with_agent(
         AgentOrganismeRole.RESPONSABLE, etapes=etapes
     )
 
@@ -110,7 +101,7 @@ class TestGetOrganismeRecruteurRbac:
         ids=["responsable", "staff"],
     )
     def test_role_grants_access(self, recruteur_integration_container, role, est_staff):
-        agent, organisme = _create_agent(role)
+        agent, organisme = OrganismeFactory.create_model_with_agent(role)
         usecase = recruteur_integration_container.get_organisme_recruteur_usecase()
 
         result = usecase.execute(
@@ -127,7 +118,7 @@ class TestGetOrganismeRecruteurRbac:
         "role", [AgentOrganismeRole.MEMBRE, None], ids=["membre", "non_membre"]
     )
     def test_role_refuse_access(self, recruteur_integration_container, role):
-        agent, organisme = _create_agent(role)
+        agent, organisme = OrganismeFactory.create_model_with_agent(role)
         usecase = recruteur_integration_container.get_organisme_recruteur_usecase()
 
         with pytest.raises(AccesOrganismeRefuse):
@@ -145,7 +136,7 @@ class TestInitializeOrganismeStepsRbac:
         ids=["responsable", "staff"],
     )
     def test_role_grants_access(self, recruteur_integration_container, role, est_staff):
-        agent, organisme = _create_agent(role)
+        agent, organisme = OrganismeFactory.create_model_with_agent(role)
         usecase = recruteur_integration_container.initialize_organisme_steps_usecase()
 
         result = usecase.execute(
@@ -163,7 +154,7 @@ class TestInitializeOrganismeStepsRbac:
         "role", [AgentOrganismeRole.MEMBRE, None], ids=["membre", "non_membre"]
     )
     def test_role_refuse_access(self, recruteur_integration_container, role):
-        agent, organisme = _create_agent(role)
+        agent, organisme = OrganismeFactory.create_model_with_agent(role)
         usecase = recruteur_integration_container.initialize_organisme_steps_usecase()
 
         with pytest.raises(AccesOrganismeRefuse):
@@ -191,7 +182,7 @@ class TestUpdateOrganismeStepsRbac:
         ids=["responsable", "staff"],
     )
     def test_role_grants_access(self, recruteur_integration_container, role, est_staff):
-        agent, organisme = _create_agent(role)
+        agent, organisme = OrganismeFactory.create_model_with_agent(role)
         usecase = recruteur_integration_container.update_organisme_steps_usecase()
 
         result = usecase.execute(self._command(organisme, agent, est_staff=est_staff))
@@ -202,7 +193,7 @@ class TestUpdateOrganismeStepsRbac:
         "role", [AgentOrganismeRole.MEMBRE, None], ids=["membre", "non_membre"]
     )
     def test_role_refuse_access(self, recruteur_integration_container, role):
-        agent, organisme = _create_agent(role)
+        agent, organisme = OrganismeFactory.create_model_with_agent(role)
         usecase = recruteur_integration_container.update_organisme_steps_usecase()
 
         with pytest.raises(AccesOrganismeRefuse):

--- a/src/web/tests/infrastructure/recruteur/test_recrutement_agent_repository.py
+++ b/src/web/tests/infrastructure/recruteur/test_recrutement_agent_repository.py
@@ -19,8 +19,8 @@ def test_get_role_returns_assigned_role(db, repository):
     agent = AgentFactory.create_model()
     agent_id = UUID(agent.utilisateur_id)
     recrutement = RecrutementFactory.create_model(
-        agent_ids=(agent_id,),
-        agent_roles={agent_id: AgentRecrutementRole.RECRUTEUR},
+        agent_id=agent_id,
+        agent_role=AgentRecrutementRole.RECRUTEUR,
     )
 
     role = repository.get_role(recrutement_id=recrutement.offre_id, agent_id=agent_id)


### PR DESCRIPTION
📢 requiert #1064 

## 📝 Description
🎸 Simplifie et enrichit les factories de test `recruteur`/`identite` pour attacher un agent avec un rôle à un `Organisme` ou un `Recrutement` en un seul appel
🎸 Simplifie et enrichit le seed de données de démo (`seed_recruteur_datas`) en réutilisant ces factories, et ajoute les recrutements sur les offres archivées.

## 🏷️ Type de changement
- [x] ♻️ Refactorisation

## 🏝️ Comment tester (si applicable)
* `bin/manage seed_recruteur_datas --force`

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
