### PR TITLE
✨(api) ajouter l'endpoint /api/fake-ts/offersummaries au format Talentsoft

### DIFF
--- a/src/web/config/urls.py
+++ b/src/web/config/urls.py
@@ -9,6 +9,7 @@ from presentation.ats import urls as ats_urls
 from presentation.candidate import urls as candidate_urls
 from presentation.identite import urls as identite_urls
 from presentation.ingestion import urls as ingestion_urls
+from presentation.ingestion import urls_v2 as ingestion_v2_urls
 from presentation.pages import urls as pages_urls
 from presentation.pages.views import security_txt
 from presentation.recruteur import urls as recruteur_urls
@@ -28,6 +29,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("admin/", admin.site.urls),
     path("candidate/", include(candidate_urls)),
     path("api/v1/", include(ingestion_urls)),
+    path("api/v2/", include(ingestion_v2_urls)),
     path("ats/", include(ats_urls)),
     path("utilisateur/", include(identite_urls)),
     path("recruteur/", include(recruteur_urls)),

--- a/src/web/config/urls.py
+++ b/src/web/config/urls.py
@@ -9,7 +9,7 @@ from presentation.ats import urls as ats_urls
 from presentation.candidate import urls as candidate_urls
 from presentation.identite import urls as identite_urls
 from presentation.ingestion import urls as ingestion_urls
-from presentation.ingestion import urls_v2 as ingestion_v2_urls
+from presentation.ingestion import urls_fake_ts as ingestion_fake_ts_urls
 from presentation.pages import urls as pages_urls
 from presentation.pages.views import security_txt
 from presentation.recruteur import urls as recruteur_urls
@@ -29,7 +29,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("admin/", admin.site.urls),
     path("candidate/", include(candidate_urls)),
     path("api/v1/", include(ingestion_urls)),
-    path("api/v2/", include(ingestion_v2_urls)),
+    path("api/fake-ts/", include(ingestion_fake_ts_urls)),
     path("ats/", include(ats_urls)),
     path("utilisateur/", include(identite_urls)),
     path("recruteur/", include(recruteur_urls)),

--- a/src/web/presentation/commons/pagination.py
+++ b/src/web/presentation/commons/pagination.py
@@ -90,3 +90,67 @@ class WebPagination(BasePagination):
         params["size"] = [self.page_size]
         new_query = urlencode({k: v[0] for k, v in params.items()})
         return urlunparse(parsed._replace(query=new_query))
+
+
+class TalentsoftPagination(BasePagination):
+    start_default = 0
+    count_default = 100
+
+    def paginate(self, page: IPage, request) -> list[Any]:
+        self.start = int(request.query_params.get("start", self.start_default))
+        self.count = int(request.query_params.get("count", self.count_default))
+        self.total = page.count()
+        self.results = list(page.slice(self.start, self.count))
+
+        return self.results
+
+    def get_paginated_response(self, data: list[Any]) -> Response:
+        return Response(
+            {
+                "data": data,
+                "_pagination": {
+                    "start": self.start,
+                    "count": len(self.results),
+                    "total": self.total,
+                    "resultsPerPage": self.count,
+                    "hasMore": self.start + len(self.results) < self.total,
+                },
+            }
+        )
+
+    def get_schema_operation_parameters(self, view) -> list[dict]:
+        return [
+            {
+                "name": "start",
+                "required": False,
+                "in": "query",
+                "description": "Index de début de la pagination.",
+                "schema": {"type": "integer"},
+            },
+            {
+                "name": "count",
+                "required": False,
+                "in": "query",
+                "description": "Nombre d'éléments par page.",
+                "schema": {"type": "integer"},
+            },
+        ]
+
+    def get_paginated_response_schema(self, schema: dict) -> dict:
+        return {
+            "type": "object",
+            "required": ["data", "_pagination"],
+            "properties": {
+                "data": schema,
+                "_pagination": {
+                    "type": "object",
+                    "properties": {
+                        "start": {"type": "integer", "example": 0},
+                        "count": {"type": "integer", "example": 1},
+                        "total": {"type": "integer", "example": 1},
+                        "resultsPerPage": {"type": "integer", "example": 100},
+                        "hasMore": {"type": "boolean", "example": False},
+                    },
+                },
+            },
+        }

--- a/src/web/presentation/ingestion/mappers.py
+++ b/src/web/presentation/ingestion/mappers.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
@@ -77,3 +78,97 @@ class OfferInputMapper(IToDomainMapper[dict, Offer]):
             conditions=conditions,
             contacts=list(data["contacts"]) if data.get("contacts") else None,
         )
+
+
+class OfferSummaryOutputMapper:
+    def to_dict(self, offer: Offer) -> dict:
+        return {
+            "reference": offer.reference,
+            "isTopOffer": False,
+            "title": offer.title,
+            "location": offer.localisation.label if offer.localisation else None,
+            "modificationDate": self._isoformat(
+                offer.processed_at or offer.publication_date
+            ),
+            "contractType": self._coded_object(
+                offer.contract_type.name, offer.contract_type.value, "contractType"
+            )
+            if offer.contract_type
+            else None,
+            "offerFamilyCategory": self._coded_object(
+                offer.category.name, offer.category.value, "offerFamilyCategory"
+            )
+            if offer.category
+            else None,
+            "organisationName": offer.organization,
+            "organisationDescription": offer.employer,
+            "organisationLogoUrl": None,
+            "contractDuration": None,
+            "contractTypeCountry": None,
+            "description1": offer.mission,
+            "description2": offer.profile,
+            "description1Formatted": None,
+            "description2Formatted": None,
+            "salaryRange": None,
+            "geographicalLocation": [],
+            "country": [
+                self._coded_object(
+                    str(offer.localisation.country),
+                    offer.localisation.country.short_name,
+                    "country",
+                )
+            ]
+            if offer.localisation
+            else [],
+            "region": [
+                self._coded_object(
+                    offer.localisation.region.code,
+                    offer.localisation.region.name,
+                    "region",
+                )
+            ]
+            if offer.localisation
+            else [],
+            "department": [
+                self._coded_object(
+                    offer.localisation.department.code,
+                    offer.localisation.department.name,
+                    "department",
+                )
+            ]
+            if offer.localisation
+            else [],
+            "latitude": offer.localisation.latitude if offer.localisation else None,
+            "longitude": offer.localisation.longitude if offer.localisation else None,
+            "professionalCategory": None,
+            "_links": [],
+            "offerUrl": str(offer.offer_url) if offer.offer_url else None,
+            "_format": None,
+            "_metadata": None,
+            "urlRedirectionEmployee": None,
+            "urlRedirectionApplicant": str(offer.application_url)
+            if offer.application_url
+            else None,
+            "startPublicationDate": self._isoformat(offer.publication_date),
+            "beginningDate": self._isoformat(offer.beginning_date.value)
+            if offer.beginning_date
+            else None,
+            "locations": [],
+        }
+
+    @staticmethod
+    def _isoformat(value: Optional[datetime]) -> Optional[str]:
+        return value.isoformat() if value else None
+
+    @staticmethod
+    def _coded_object(client_code: str, label: str, type_name: str) -> dict:
+        return {
+            "code": None,
+            "clientCode": client_code,
+            "label": label,
+            "active": True,
+            "parentCode": None,
+            "type": type_name,
+            "parentType": "",
+            "hasChildren": False,
+        }

--- a/src/web/presentation/ingestion/mappers.py
+++ b/src/web/presentation/ingestion/mappers.py
@@ -158,7 +158,16 @@ class OfferSummaryOutputMapper:
 
     @staticmethod
     def _isoformat(value: Optional[datetime]) -> Optional[str]:
-        return value.isoformat() if value else None
+        if not value:
+            return None
+
+        naive_value = value.replace(tzinfo=None)
+        if not naive_value.microsecond:
+            return naive_value.isoformat()
+
+        date_part, _, frac = naive_value.isoformat().partition(".")
+        centiseconds = round(int(frac) / 10_000)
+        return f"{date_part}.{centiseconds:02d}"
 
     @staticmethod
     def _coded_object(client_code: str, label: str, type_name: str) -> dict:

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -55,6 +55,13 @@ class ListOffersFiltersSerializer(serializers.Serializer):
     external_id_contains = serializers.CharField(default=None)
 
 
+class OfferSummariesQuerySerializer(serializers.Serializer):
+    start = serializers.IntegerField(required=False, min_value=0, default=0)
+    count = serializers.IntegerField(
+        required=False, min_value=1, max_value=1_000, default=100
+    )
+
+
 class LocalisationInputSerializer(LocalisationSerializer):
     def validate(self, data):
         if data.get("pays") == "FRA" and not (

--- a/src/web/presentation/ingestion/urls_fake_ts.py
+++ b/src/web/presentation/ingestion/urls_fake_ts.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from presentation.ingestion.views.offer_summaries import OfferSummariesView
 
-app_name = "ingestion_v2"
+app_name = "ingestion_fake_ts"
 
 urlpatterns = [
     path("offersummaries", OfferSummariesView.as_view(), name="offer_summaries"),

--- a/src/web/presentation/ingestion/urls_v2.py
+++ b/src/web/presentation/ingestion/urls_v2.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from presentation.ingestion.views.offer_summaries import OfferSummariesView
+
+app_name = "ingestion_v2"
+
+urlpatterns = [
+    path("offersummaries", OfferSummariesView.as_view(), name="offer_summaries"),
+]

--- a/src/web/presentation/ingestion/views/offer_summaries.py
+++ b/src/web/presentation/ingestion/views/offer_summaries.py
@@ -1,0 +1,58 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
+from infrastructure.authentication.api_key_authentication import (
+    ApiKeyAuthentication,
+)
+from infrastructure.di.ingestion.ingestion_factory import create_ingestion_container
+from presentation.api.serializers import GenericErrorSerializer
+from presentation.ingestion.mappers import OfferSummaryOutputMapper
+from presentation.ingestion.serializers import OfferSummariesQuerySerializer
+
+
+@extend_schema(exclude=True)
+class OfferSummariesView(APIView):
+    authentication_classes = [JWTAuthentication, ApiKeyAuthentication]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.container = create_ingestion_container()
+        self.logger = self.container.logger_service()
+        self.usecase = self.container.list_offers_usecase()
+        self.mapper = OfferSummaryOutputMapper()
+
+    def get(self, request):
+        try:
+            query = OfferSummariesQuerySerializer(data=request.query_params)
+            query.is_valid(raise_exception=True)
+            start = query.validated_data["start"]
+            count = query.validated_data["count"]
+
+            page = self.usecase.execute(
+                GetFilteredOffersInput(active=True, external_id_contains=None)
+            )
+            total = page.count()
+            offers = list(page.slice(start, count))
+
+            return Response(
+                {
+                    "data": [self.mapper.to_dict(offer) for offer in offers],
+                    "_pagination": {
+                        "start": start,
+                        "count": len(offers),
+                        "total": total,
+                        "resultsPerPage": count,
+                        "hasMore": start + len(offers) < total,
+                    },
+                }
+            )
+        except Exception as e:
+            self.logger.error("Unexpected error in OfferSummariesView: %s", str(e))
+            serializer = GenericErrorSerializer({"error": "Unexpected error"})
+            return Response(
+                serializer.data, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )

--- a/src/web/presentation/ingestion/views/offer_summaries.py
+++ b/src/web/presentation/ingestion/views/offer_summaries.py
@@ -5,18 +5,17 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
-from infrastructure.authentication.api_key_authentication import (
-    ApiKeyAuthentication,
-)
 from infrastructure.di.ingestion.ingestion_factory import create_ingestion_container
 from presentation.api.serializers import GenericErrorSerializer
+from presentation.commons.pagination import TalentsoftPagination
 from presentation.ingestion.mappers import OfferSummaryOutputMapper
 from presentation.ingestion.serializers import OfferSummariesQuerySerializer
 
 
 @extend_schema(exclude=True)
 class OfferSummariesView(APIView):
-    authentication_classes = [JWTAuthentication, ApiKeyAuthentication]
+    authentication_classes = [JWTAuthentication]
+    pagination_class = TalentsoftPagination
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -29,26 +28,16 @@ class OfferSummariesView(APIView):
         try:
             query = OfferSummariesQuerySerializer(data=request.query_params)
             query.is_valid(raise_exception=True)
-            start = query.validated_data["start"]
-            count = query.validated_data["count"]
 
             page = self.usecase.execute(
                 GetFilteredOffersInput(active=True, external_id_contains=None)
             )
-            total = page.count()
-            offers = list(page.slice(start, count))
 
-            return Response(
-                {
-                    "data": [self.mapper.to_dict(offer) for offer in offers],
-                    "_pagination": {
-                        "start": start,
-                        "count": len(offers),
-                        "total": total,
-                        "resultsPerPage": count,
-                        "hasMore": start + len(offers) < total,
-                    },
-                }
+            paginator = TalentsoftPagination()
+            offers = paginator.paginate(page, request)
+
+            return paginator.get_paginated_response(
+                [self.mapper.to_dict(offer) for offer in offers]
             )
         except Exception as e:
             self.logger.error("Unexpected error in OfferSummariesView: %s", str(e))

--- a/src/web/tests/presentation/commons/test_pagination.py
+++ b/src/web/tests/presentation/commons/test_pagination.py
@@ -1,4 +1,4 @@
-from presentation.commons.pagination import WebPagination
+from presentation.commons.pagination import TalentsoftPagination, WebPagination
 
 
 def test_get_schema_operation_parameters_exposes_page_and_size():
@@ -45,5 +45,50 @@ def test_get_paginated_response_schema_wraps_results():
                 "example": None,
             },
             "results": results_schema,
+        },
+    }
+
+
+def test_talentsoft_get_schema_operation_parameters_exposes_start_and_count():
+    parameters = TalentsoftPagination().get_schema_operation_parameters(view=None)
+
+    assert parameters == [
+        {
+            "name": "start",
+            "required": False,
+            "in": "query",
+            "description": "Index de début de la pagination.",
+            "schema": {"type": "integer"},
+        },
+        {
+            "name": "count",
+            "required": False,
+            "in": "query",
+            "description": "Nombre d'éléments par page.",
+            "schema": {"type": "integer"},
+        },
+    ]
+
+
+def test_talentsoft_get_paginated_response_schema_wraps_results():
+    results_schema = {"type": "string"}
+
+    schema = TalentsoftPagination().get_paginated_response_schema(results_schema)
+
+    assert schema == {
+        "type": "object",
+        "required": ["data", "_pagination"],
+        "properties": {
+            "data": results_schema,
+            "_pagination": {
+                "type": "object",
+                "properties": {
+                    "start": {"type": "integer", "example": 0},
+                    "count": {"type": "integer", "example": 1},
+                    "total": {"type": "integer", "example": 1},
+                    "resultsPerPage": {"type": "integer", "example": 100},
+                    "hasMore": {"type": "boolean", "example": False},
+                },
+            },
         },
     }

--- a/src/web/tests/presentation/ingestion/test_mappers.py
+++ b/src/web/tests/presentation/ingestion/test_mappers.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from presentation.ingestion.mappers import OfferSummaryOutputMapper
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        (datetime(2024, 1, 15, tzinfo=timezone.utc), "2024-01-15T00:00:00"),
+        (
+            datetime(2026, 7, 30, 10, 8, 39, 230000, tzinfo=timezone.utc),
+            "2026-07-30T10:08:39.23",
+        ),
+    ],
+    ids=[
+        "none-value-returns-none",
+        "no-microsecond-has-no-fractional-part",
+        "microsecond-truncated-to-centiseconds-and-drops-timezone",
+    ],
+)
+def test_isoformat(value, expected):
+    assert OfferSummaryOutputMapper._isoformat(value) == expected

--- a/src/web/tests/presentation/ingestion/views/conftest.py
+++ b/src/web/tests/presentation/ingestion/views/conftest.py
@@ -30,3 +30,9 @@ def mock_sources_container():
 def mock_metiers_container():
     with patch_ingestion_container("metiers") as container:
         yield container
+
+
+@pytest.fixture
+def mock_offer_summaries_container():
+    with patch_ingestion_container("offer_summaries") as container:
+        yield container

--- a/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
+++ b/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
 from infrastructure.factories.referentiel.offer_factory import OfferFactory
 
-URL = reverse("ingestion_v2:offer_summaries")
+URL = reverse("ingestion_fake_ts:offer_summaries")
 
 
 def _make_paginated_mock(mock_container, total, offers_slice):
@@ -170,4 +170,4 @@ def test_returns_error_500(mock_offer_summaries_container, authenticated_client)
 def test_is_excluded_from_openapi_schema():
     generator = SchemaGenerator()
     schema = generator.get_schema(request=None, public=True)
-    assert "/api/v2/offersummaries" not in schema["paths"]
+    assert "/api/fake-ts/offersummaries" not in schema["paths"]

--- a/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
+++ b/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
@@ -30,16 +30,9 @@ def test_unauthenticated_access(api_client):
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-def test_invalid_api_key_returns_401(api_client):
-    api_client.credentials(HTTP_AUTHORIZATION="Api-Key wrong-key")
-    response = api_client.get(URL)
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-
-def test_api_key_authentication_access(mock_offer_summaries_container, api_key_client):
-    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+def test_valid_api_key_no_longer_grants_access(api_key_client):
     response = api_key_client.get(URL)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_post_not_allowed(authenticated_client):
@@ -107,7 +100,7 @@ def test_call_without_arg(mock_offer_summaries_container, authenticated_client):
     assert result["contractType"]["label"] == offer.contract_type.value
     assert result["offerFamilyCategory"]["clientCode"] == offer.category.name
     assert result["offerFamilyCategory"]["label"] == offer.category.value
-    assert result["startPublicationDate"] == "2024-01-15T00:00:00+00:00"
+    assert result["startPublicationDate"] == "2024-01-15T00:00:00"
     assert result["country"] == [
         {
             "code": None,

--- a/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
+++ b/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
@@ -1,0 +1,173 @@
+from unittest.mock import MagicMock
+
+import pytest
+from django.urls import reverse
+from drf_spectacular.generators import SchemaGenerator
+from referentiel.value_objects.category import Category
+from referentiel.value_objects.contract_type import ContractType
+from rest_framework import status
+
+from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
+from infrastructure.factories.referentiel.offer_factory import OfferFactory
+
+URL = reverse("ingestion_v2:offer_summaries")
+
+
+def _make_paginated_mock(mock_container, total, offers_slice):
+    mock_page = MagicMock()
+    mock_page.count.return_value = total
+    mock_page.slice.return_value = iter(offers_slice)
+
+    mock_usecase = MagicMock()
+    mock_usecase.execute.return_value = mock_page
+    mock_container.list_offers_usecase.return_value = mock_usecase
+
+    return mock_usecase
+
+
+def test_unauthenticated_access(api_client):
+    response = api_client.get(URL)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_invalid_api_key_returns_401(api_client):
+    api_client.credentials(HTTP_AUTHORIZATION="Api-Key wrong-key")
+    response = api_client.get(URL)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_api_key_authentication_access(mock_offer_summaries_container, api_key_client):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+    response = api_key_client.get(URL)
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_post_not_allowed(authenticated_client):
+    response = authenticated_client.post(URL)
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+def test_empty_result(mock_offer_summaries_container, authenticated_client):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    response = authenticated_client.get(URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "data": [],
+        "_pagination": {
+            "start": 0,
+            "count": 0,
+            "total": 0,
+            "resultsPerPage": 100,
+            "hasMore": False,
+        },
+    }
+
+
+def test_only_queries_non_archived_offers(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    authenticated_client.get(URL)
+
+    mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(active=True, external_id_contains=None)
+    )
+
+
+def test_call_without_arg(mock_offer_summaries_container, authenticated_client):
+    offer = OfferFactory.create_entity(
+        contract_type=ContractType.TERRITORIAL,
+        category=Category.A,
+    )
+    _make_paginated_mock(mock_offer_summaries_container, total=1, offers_slice=[offer])
+
+    response = authenticated_client.get(URL)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    assert data["_pagination"] == {
+        "start": 0,
+        "count": 1,
+        "total": 1,
+        "resultsPerPage": 100,
+        "hasMore": False,
+    }
+
+    result = data["data"][0]
+    assert result["reference"] == offer.reference
+    assert result["title"] == offer.title
+    assert result["organisationName"] == offer.organization
+    assert result["description1"] == offer.mission
+    assert result["description2"] == offer.profile
+    assert result["contractType"]["clientCode"] == offer.contract_type.name
+    assert result["contractType"]["label"] == offer.contract_type.value
+    assert result["offerFamilyCategory"]["clientCode"] == offer.category.name
+    assert result["offerFamilyCategory"]["label"] == offer.category.value
+    assert result["startPublicationDate"] == "2024-01-15T00:00:00+00:00"
+    assert result["country"] == [
+        {
+            "code": None,
+            "clientCode": str(offer.localisation.country),
+            "label": offer.localisation.country.short_name,
+            "active": True,
+            "parentCode": None,
+            "type": "country",
+            "parentType": "",
+            "hasChildren": False,
+        }
+    ]
+    assert result["region"][0]["clientCode"] == offer.localisation.region.code
+    assert result["region"][0]["label"] == offer.localisation.region.name
+    assert result["department"][0]["clientCode"] == offer.localisation.department.code
+    assert result["department"][0]["label"] == offer.localisation.department.name
+
+
+@pytest.mark.parametrize(
+    "start,count",
+    [(0, 10), (5, 20), (10, 1)],
+)
+def test_start_and_count_are_forwarded_to_pagination(
+    mock_offer_summaries_container, authenticated_client, start, count
+):
+    mock_usecase = _make_paginated_mock(
+        mock_offer_summaries_container, total=100, offers_slice=[]
+    )
+
+    response = authenticated_client.get(URL, {"start": start, "count": count})
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["_pagination"]["start"] == start
+    assert data["_pagination"]["resultsPerPage"] == count
+    mock_usecase.execute.return_value.slice.assert_called_once_with(start, count)
+
+
+def test_has_more_true_when_more_results_exist(
+    mock_offer_summaries_container, authenticated_client
+):
+    offers = [OfferFactory.create_entity() for _ in range(2)]
+    _make_paginated_mock(mock_offer_summaries_container, total=5, offers_slice=offers)
+
+    response = authenticated_client.get(URL, {"start": 0, "count": 2})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["_pagination"]["hasMore"] is True
+
+
+def test_returns_error_500(mock_offer_summaries_container, authenticated_client):
+    mock_usecase = MagicMock()
+    mock_usecase.execute.side_effect = Exception("db error")
+    mock_offer_summaries_container.list_offers_usecase.return_value = mock_usecase
+
+    response = authenticated_client.get(URL)
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+def test_is_excluded_from_openapi_schema():
+    generator = SchemaGenerator()
+    schema = generator.get_schema(request=None, public=True)
+    assert "/api/v2/offersummaries" not in schema["paths"]


### PR DESCRIPTION
## 📝 Description

Ajoute un endpoint Talensoft minimal, listant les offres, `/api/fake-ts/offersummaries`. Cet endpoint n'est pas documenté dans notre OpenAPI.

Seuls les paramètres GET `start` et `count` sont pris en charge.

En lien avec #941 

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
