### PR TITLE
♻️(recrutement-domain) Refacto des Repositories Organisme

### DIFF
--- a/src/web/application/recruteur/usecases/changer_etape_candidatures.py
+++ b/src/web/application/recruteur/usecases/changer_etape_candidatures.py
@@ -3,8 +3,8 @@ from uuid import UUID
 
 from ddd.usecase_interface import IUseCase
 
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
+from domain.recruteur.repositories.organisme_repository_interface import (
+    IOrganismeRecruteurRepository,
 )
 
 
@@ -37,11 +37,11 @@ class ChangerEtapeResultat:
 class ChangerEtapeCandidaturesUsecase(
     IUseCase[ChangerEtapeCandidaturesCommand, ChangerEtapeResultat]
 ):
-    def __init__(self, organisme_repository: IOrganismeRepository):
-        self.organisme_repository = organisme_repository
+    def __init__(self, organisme_recruteur_repository: IOrganismeRecruteurRepository):
+        self.organisme_recruteur_repository = organisme_recruteur_repository
 
     def execute(self, command: ChangerEtapeCandidaturesCommand) -> ChangerEtapeResultat:
-        self.organisme_repository.get_by_id(command.organisme_id)
+        self.organisme_recruteur_repository.get_by_id(command.organisme_id)
         return ChangerEtapeResultat(
             reussites=[c.candidature_id for c in command.candidatures],
             echecs=[],

--- a/src/web/application/recruteur/usecases/get_organisme_recruteur.py
+++ b/src/web/application/recruteur/usecases/get_organisme_recruteur.py
@@ -25,10 +25,10 @@ class GetOrganismeRecruteurUsecase(
 ):
     def __init__(
         self,
-        organisme_repository: IOrganismeRecruteurRepository,
+        organisme_recruteur_repository: IOrganismeRecruteurRepository,
         organisme_permission_service: OrganismePermissionService,
     ):
-        self.organisme_repository = organisme_repository
+        self.organisme_recruteur_repository = organisme_recruteur_repository
         self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: GetOrganismeRecruteurQuery) -> OrganismeRecruteur:
@@ -38,4 +38,4 @@ class GetOrganismeRecruteurUsecase(
             agent_id=command.utilisateur_id,
             est_staff=command.est_staff,
         )
-        return self.organisme_repository.get_by_id(command.organisme_id)
+        return self.organisme_recruteur_repository.get_by_id(command.organisme_id)

--- a/src/web/application/recruteur/usecases/get_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_etapes.py
@@ -4,9 +4,6 @@ from ddd.usecase_interface import IUseCase
 
 from application.recruteur.dtos.etape_data import EtapeData, etapes_par_defaut
 from application.recruteur.dtos.recrutement_request import RecrutementRequest
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
-)
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
@@ -24,14 +21,11 @@ class GetRecrutementEtapesQuery(RecrutementRequest):
 class GetRecrutementEtapesUsecase(IUseCase[GetRecrutementEtapesQuery, list[EtapeData]]):
     def __init__(
         self,
-        organisme_repository: IOrganismeRepository,
         organisme_permission_service: OrganismePermissionService,
     ):
-        self.organisme_repository = organisme_repository
         self.organisme_permission_service = organisme_permission_service
 
     def execute(self, query: GetRecrutementEtapesQuery) -> list[EtapeData]:
-        self.organisme_repository.get_by_id(query.organisme_id)
         self.organisme_permission_service.est_autorise(
             action=OrganismeAction.GET_RECRUTEMENT_ETAPES,
             organisme_id=query.organisme_id,

--- a/src/web/application/recruteur/usecases/get_recrutement_kanban.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_kanban.py
@@ -9,9 +9,6 @@ from application.recruteur.dtos.recrutement_request import RecrutementRequest
 from application.recruteur.services.recrutement_query_service_interface import (
     IRecrutementQueryService,
 )
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
-)
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
@@ -28,11 +25,9 @@ class GetRecrutementKanbanUsecase(
 ):
     def __init__(
         self,
-        organisme_repository: IOrganismeRepository,
         organisme_permission_service: OrganismePermissionService,
         recrutement_query_service: IRecrutementQueryService,
     ):
-        self.organisme_repository = organisme_repository
         self.organisme_permission_service = organisme_permission_service
         self.recrutement_query_service = recrutement_query_service
 
@@ -46,7 +41,6 @@ class GetRecrutementKanbanUsecase(
             recrutement_id=query.recrutement_id,
             est_staff=query.est_staff,
         )
-        self.organisme_repository.get_by_id(query.organisme_id)
 
         return self.recrutement_query_service.get_kanban_by_recrutement(
             organisme_id=query.organisme_id, recrutement_id=query.recrutement_id

--- a/src/web/application/recruteur/usecases/get_recrutement_liste.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_liste.py
@@ -10,9 +10,6 @@ from application.recruteur.dtos.recrutement_request import RecrutementRequest
 from application.recruteur.services.recrutement_query_service_interface import (
     IRecrutementQueryService,
 )
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
-)
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
@@ -29,11 +26,9 @@ class GetRecrutementListeUsecase(
 ):
     def __init__(
         self,
-        organisme_repository: IOrganismeRepository,
         organisme_permission_service: OrganismePermissionService,
         recrutement_query_service: IRecrutementQueryService,
     ):
-        self.organisme_repository = organisme_repository
         self.organisme_permission_service = organisme_permission_service
         self.recrutement_query_service = recrutement_query_service
 
@@ -47,7 +42,6 @@ class GetRecrutementListeUsecase(
             recrutement_id=query.recrutement_id,
             est_staff=query.est_staff,
         )
-        self.organisme_repository.get_by_id(query.organisme_id)
 
         return self.recrutement_query_service.get_candidatures_by_recrutement(
             organisme_id=query.organisme_id, recrutement_id=query.recrutement_id

--- a/src/web/application/recruteur/usecases/init_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/init_recrutement_etapes.py
@@ -4,9 +4,6 @@ from ddd.usecase_interface import IUseCase
 
 from application.recruteur.dtos.etape_data import EtapeData, etapes_par_defaut
 from application.recruteur.dtos.recrutement_request import RecrutementRequest
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
-)
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
@@ -26,14 +23,11 @@ class InitRecrutementEtapesUsecase(
 ):
     def __init__(
         self,
-        organisme_repository: IOrganismeRepository,
         organisme_permission_service: OrganismePermissionService,
     ):
-        self.organisme_repository = organisme_repository
         self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: InitRecrutementEtapesCommand) -> list[EtapeData]:
-        self.organisme_repository.get_by_id(command.organisme_id)
         self.organisme_permission_service.est_autorise(
             action=OrganismeAction.INIT_RECRUTEMENT_ETAPES,
             organisme_id=command.organisme_id,

--- a/src/web/application/recruteur/usecases/initialize_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/initialize_organisme_steps.py
@@ -25,10 +25,10 @@ class InitializeOrganismeStepsUsecase(
 ):
     def __init__(
         self,
-        organisme_repository: IOrganismeRecruteurRepository,
+        organisme_recruteur_repository: IOrganismeRecruteurRepository,
         organisme_permission_service: OrganismePermissionService,
     ):
-        self.organisme_repository = organisme_repository
+        self.organisme_recruteur_repository = organisme_recruteur_repository
         self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: InitializeOrganismeStepsCommand) -> OrganismeRecruteur:
@@ -38,7 +38,7 @@ class InitializeOrganismeStepsUsecase(
             agent_id=command.utilisateur_id,
             est_staff=command.est_staff,
         )
-        organisme = self.organisme_repository.get_by_id(command.organisme_id)
+        organisme = self.organisme_recruteur_repository.get_by_id(command.organisme_id)
         organisme.initialiser_etapes()
-        self.organisme_repository.save(organisme)
+        self.organisme_recruteur_repository.save(organisme)
         return organisme

--- a/src/web/application/recruteur/usecases/lister_mes_recrutements.py
+++ b/src/web/application/recruteur/usecases/lister_mes_recrutements.py
@@ -10,9 +10,6 @@ from application.recruteur.services.recrutement_query_service_interface import (
     RecrutementActifsReadModel,
     RecrutementArchivesReadModel,
 )
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
-)
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
@@ -38,13 +35,11 @@ class ListerMesRecrutementsUsecase(
     def __init__(
         self,
         recrutement_query_service: IRecrutementQueryService,
-        organisme_repository: IOrganismeRepository,
         organisme_permission_service: OrganismePermissionService,
         logger: ILogger,
     ):
         self.logger = logger
         self.recrutement_query_service = recrutement_query_service
-        self.organisme_repository = organisme_repository
         self.organisme_permission_service = organisme_permission_service
 
     def execute(
@@ -60,7 +55,6 @@ class ListerMesRecrutementsUsecase(
             agent_id=query.utilisateur_id,
             est_staff=query.est_staff,
         )
-        self.organisme_repository.get_by_id(query.organisme_id)
 
         agent_id_filtre = (
             None if role == AgentOrganismeRole.RESPONSABLE else query.utilisateur_id

--- a/src/web/application/recruteur/usecases/update_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/update_organisme_steps.py
@@ -4,9 +4,6 @@ from uuid import UUID
 from ddd.usecase_interface import IUseCase
 
 from domain.commons.services.audit_log_writer import AuditLogWriter
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
-)
 from domain.recruteur.entities.etape_recrutement import EtapeRecrutement
 from domain.recruteur.entities.organisme_recruteur import OrganismeRecruteur
 from domain.recruteur.repositories.organisme_repository_interface import (
@@ -41,12 +38,10 @@ class UpdateOrganismeStepsUsecase(
 ):
     def __init__(
         self,
-        organisme_repository: IOrganismeRepository,
         organisme_recruteur_repository: IOrganismeRecruteurRepository,
         audit_log_writer: AuditLogWriter,
         organisme_permission_service: OrganismePermissionService,
     ):
-        self.organisme_repository = organisme_repository
         self.organisme_recruteur_repository = organisme_recruteur_repository
         self.audit_log_writer = audit_log_writer
         self.organisme_permission_service = organisme_permission_service
@@ -58,8 +53,6 @@ class UpdateOrganismeStepsUsecase(
             agent_id=command.utilisateur_id,
             est_staff=command.est_staff,
         )
-        # guard, raise OrganismeInexistant if not found
-        self.organisme_repository.get_by_id(command.organisme_id)
         organisme_recruteur = self.organisme_recruteur_repository.get_by_id(
             command.organisme_id
         )

--- a/src/web/application/recruteur/usecases/update_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/update_recrutement_etapes.py
@@ -4,9 +4,6 @@ from ddd.usecase_interface import IUseCase
 
 from application.recruteur.dtos.etape_data import EtapeData
 from application.recruteur.dtos.recrutement_request import RecrutementRequest
-from domain.identite.repositories.organisme_repository_interface import (
-    IOrganismeRepository,
-)
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
@@ -27,14 +24,11 @@ class UpdateRecrutementEtapesUsecase(
 ):
     def __init__(
         self,
-        organisme_repository: IOrganismeRepository,
         organisme_permission_service: OrganismePermissionService,
     ):
-        self.organisme_repository = organisme_repository
         self.organisme_permission_service = organisme_permission_service
 
     def execute(self, command: UpdateRecrutementEtapesCommand) -> list[EtapeData]:
-        self.organisme_repository.get_by_id(command.organisme_id)
         self.organisme_permission_service.est_autorise(
             action=OrganismeAction.UPDATE_RECRUTEMENT_ETAPES,
             organisme_id=command.organisme_id,

--- a/src/web/domain/commons/errors/organisme_errors.py
+++ b/src/web/domain/commons/errors/organisme_errors.py
@@ -1,0 +1,7 @@
+from ddd.domain_errors import DomainError
+
+
+class OrganismeNexistePas(DomainError):
+    def __init__(self, identifier: str):
+        super().__init__(f"Organisme introuvable : {identifier}")
+        self.identifier = identifier

--- a/src/web/domain/identite/errors/organisme_errors.py
+++ b/src/web/domain/identite/errors/organisme_errors.py
@@ -9,9 +9,3 @@ class SiretInvalide(OrganismeError):
     def __init__(self, siret_str: str):
         super().__init__(f"Invalid SIRET: {siret_str}")
         self.siret_str = siret_str
-
-
-class OrganismeNexistePas(OrganismeError):
-    def __init__(self, identifier: str):
-        super().__init__(f"Organisme introuvable : {identifier}")
-        self.identifier = identifier

--- a/src/web/domain/recruteur/services/organisme_permission_service.py
+++ b/src/web/domain/recruteur/services/organisme_permission_service.py
@@ -8,6 +8,9 @@ from domain.recruteur.errors.organisme_permission_errors import (
 from domain.recruteur.repositories.organisme_agent_repository_interface import (
     IOrganismeAgentRepository,
 )
+from domain.recruteur.repositories.organisme_repository_interface import (
+    IOrganismeRecruteurRepository,
+)
 from domain.recruteur.repositories.recrutement_agent_repository_interface import (
     IRecrutementAgentRepository,
 )
@@ -84,9 +87,11 @@ _ROLES_RECRUTEMENT_REQUIS: dict[OrganismeAction, frozenset[AgentRecrutementRole]
 class OrganismePermissionService:
     def __init__(
         self,
+        organisme_recruteur_repository: IOrganismeRecruteurRepository,
         organisme_agent_repository: IOrganismeAgentRepository,
         recrutement_agent_repository: IRecrutementAgentRepository,
     ) -> None:
+        self._organisme_recruteur_repository = organisme_recruteur_repository
         self._organisme_agent_repository = organisme_agent_repository
         self._recrutement_agent_repository = recrutement_agent_repository
 
@@ -99,6 +104,8 @@ class OrganismePermissionService:
         est_staff: bool,
         recrutement_id: UUID | None = None,
     ) -> AgentOrganismeRole | None:
+        self._organisme_recruteur_repository.get_by_id(organisme_id)
+
         if est_staff and action in _AUTORISE_POUR_STAFF:
             return None
 

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -83,7 +83,6 @@ class RecruteurContainer(containers.DeclarativeContainer):
         AuditLogWriter,
         repository=postgres_audit_log_repository,
     )
-    postgres_organisme_repository = providers.Singleton(PostgresOrganismeRepository)
     postgres_organisme_recruteur_repository = providers.Singleton(
         PostgresOrganismeRecruteurRepository
     )
@@ -95,6 +94,7 @@ class RecruteurContainer(containers.DeclarativeContainer):
     )
     organisme_permission_service = providers.Factory(
         OrganismePermissionService,
+        organisme_recruteur_repository=postgres_organisme_recruteur_repository,
         organisme_agent_repository=postgres_organisme_agent_repository,
         recrutement_agent_repository=postgres_recrutement_agent_repository,
     )
@@ -149,7 +149,6 @@ class RecruteurContainer(containers.DeclarativeContainer):
 
     update_organisme_steps_usecase = providers.Factory(
         UpdateOrganismeStepsUsecase,
-        organisme_repository=postgres_organisme_repository,
         organisme_recruteur_repository=postgres_organisme_recruteur_repository,
         audit_log_writer=audit_log_writer,
         organisme_permission_service=organisme_permission_service,
@@ -158,21 +157,18 @@ class RecruteurContainer(containers.DeclarativeContainer):
     lister_mes_recrutements_usecase = providers.Factory(
         ListerMesRecrutementsUsecase,
         recrutement_query_service=postgres_recrutement_query_service,
-        organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
         logger=logger_service,
     )
 
     get_recrutement_kanban_usecase = providers.Factory(
         GetRecrutementKanbanUsecase,
-        organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
         recrutement_query_service=postgres_recrutement_query_service,
     )
 
     get_recrutement_liste_usecase = providers.Factory(
         GetRecrutementListeUsecase,
-        organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
         recrutement_query_service=postgres_recrutement_query_service,
     )
@@ -184,18 +180,15 @@ class RecruteurContainer(containers.DeclarativeContainer):
 
     get_recrutement_etapes_usecase = providers.Factory(
         GetRecrutementEtapesUsecase,
-        organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
     )
 
     update_recrutement_etapes_usecase = providers.Factory(
         UpdateRecrutementEtapesUsecase,
-        organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
     )
 
     init_recrutement_etapes_usecase = providers.Factory(
         InitRecrutementEtapesUsecase,
-        organisme_repository=postgres_organisme_repository,
         organisme_permission_service=organisme_permission_service,
     )

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -175,7 +175,7 @@ class RecruteurContainer(containers.DeclarativeContainer):
 
     changer_etape_candidatures_usecase = providers.Factory(
         ChangerEtapeCandidaturesUsecase,
-        organisme_repository=postgres_organisme_repository,
+        organisme_recruteur_repository=postgres_organisme_recruteur_repository,
     )
 
     get_recrutement_etapes_usecase = providers.Factory(

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -50,9 +50,6 @@ from infrastructure.repositories.commons.postgres_audit_log_repository import (
 from infrastructure.repositories.identite.postgres_agent_repository import (
     PostgresAgentRepository,
 )
-from infrastructure.repositories.identite.postgres_organisme_repository import (
-    PostgresOrganismeRepository,
-)
 from infrastructure.repositories.recruteur.postgres_note_query_service import (
     PostgresNoteQueryService,
 )

--- a/src/web/infrastructure/di/recruteur/recruteur_container.py
+++ b/src/web/infrastructure/di/recruteur/recruteur_container.py
@@ -137,13 +137,13 @@ class RecruteurContainer(containers.DeclarativeContainer):
 
     get_organisme_recruteur_usecase = providers.Factory(
         GetOrganismeRecruteurUsecase,
-        organisme_repository=postgres_organisme_recruteur_repository,
+        organisme_recruteur_repository=postgres_organisme_recruteur_repository,
         organisme_permission_service=organisme_permission_service,
     )
 
     initialize_organisme_steps_usecase = providers.Factory(
         InitializeOrganismeStepsUsecase,
-        organisme_repository=postgres_organisme_recruteur_repository,
+        organisme_recruteur_repository=postgres_organisme_recruteur_repository,
         organisme_permission_service=organisme_permission_service,
     )
 

--- a/src/web/infrastructure/repositories/identite/postgres_organisme_repository.py
+++ b/src/web/infrastructure/repositories/identite/postgres_organisme_repository.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.identite.entities.organisme import Organisme
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.identite.repositories.organisme_repository_interface import (
     IOrganismeRepository as IOrganismeIdentiteRepository,
 )

--- a/src/web/infrastructure/repositories/recruteur/postgres_organisme_repository.py
+++ b/src/web/infrastructure/repositories/recruteur/postgres_organisme_repository.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.entities.organisme_recruteur import OrganismeRecruteur
 from domain.recruteur.repositories.organisme_repository_interface import (
     IOrganismeRecruteurRepository,

--- a/src/web/presentation/recruteur/views/organismes.py
+++ b/src/web/presentation/recruteur/views/organismes.py
@@ -17,7 +17,7 @@ from application.recruteur.usecases.update_organisme_steps import (
     EtapeData,
     UpdateOrganismeStepsCommand,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.erreur_recrutement import (
     ConfigurationEtapesInvalide,
     ErreurRecruteur,

--- a/src/web/presentation/recruteur/views/recrutement_detail.py
+++ b/src/web/presentation/recruteur/views/recrutement_detail.py
@@ -17,7 +17,7 @@ from application.recruteur.usecases.get_recrutement_kanban import (
 from application.recruteur.usecases.get_recrutement_liste import (
     GetRecrutementListeQuery,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import (
     OrganismePermissionError,
 )

--- a/src/web/presentation/recruteur/views/recrutement_listes.py
+++ b/src/web/presentation/recruteur/views/recrutement_listes.py
@@ -10,7 +10,7 @@ from rest_framework.views import APIView
 from application.recruteur.usecases.lister_mes_recrutements import (
     ListerMesRecrutementsQuery,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.statut_recrutement import StatutRecrutement
 from infrastructure.di.recruteur.recruteur_factory import recruteur_container

--- a/src/web/presentation/recruteur/views/recrutement_params.py
+++ b/src/web/presentation/recruteur/views/recrutement_params.py
@@ -17,7 +17,7 @@ from application.recruteur.usecases.init_recrutement_etapes import (
 from application.recruteur.usecases.update_recrutement_etapes import (
     UpdateRecrutementEtapesCommand,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import (
     OrganismePermissionError,
 )

--- a/src/web/tests/application/recruteur/test_changer_etape_candidatures.py
+++ b/src/web/tests/application/recruteur/test_changer_etape_candidatures.py
@@ -8,7 +8,7 @@ from application.recruteur.usecases.changer_etape_candidatures import (
     ChangerEtapeCandidaturesCommand,
     ChangerEtapeCandidaturesUsecase,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 
 
 @pytest.fixture(name="organisme_repository")

--- a/src/web/tests/application/recruteur/test_changer_etape_candidatures.py
+++ b/src/web/tests/application/recruteur/test_changer_etape_candidatures.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
@@ -9,23 +9,30 @@ from application.recruteur.usecases.changer_etape_candidatures import (
     ChangerEtapeCandidaturesUsecase,
 )
 from domain.commons.errors.organisme_errors import OrganismeNexistePas
+from domain.recruteur.repositories.organisme_repository_interface import (
+    IOrganismeRecruteurRepository,
+)
 
 
-@pytest.fixture(name="organisme_repository")
-def organisme_repository_fixture():
-    repo = MagicMock()
-    repo.get_by_id.return_value = MagicMock()
+@pytest.fixture(name="organisme_recruteur_repository")
+def organisme_recruteur_repository_fixture():
+    repo = Mock(spec=IOrganismeRecruteurRepository)
+    repo.get_by_id.return_value = Mock()
     return repo
 
 
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository):
-    return ChangerEtapeCandidaturesUsecase(organisme_repository=organisme_repository)
+def usecase_fixture(organisme_recruteur_repository):
+    return ChangerEtapeCandidaturesUsecase(
+        organisme_recruteur_repository=organisme_recruteur_repository
+    )
 
 
 class TestChangerEtapeCandidaturesUsecase:
     # TODO : failed updates are not yet tested, waiting for their implementation
-    def test_echoes_all_candidatures_as_reussites(self, organisme_repository, usecase):
+    def test_echoes_all_candidatures_as_reussites(
+        self, organisme_recruteur_repository, usecase
+    ):
         organisme_id = uuid4()
         candidature_ids = [uuid4(), uuid4()]
         command = ChangerEtapeCandidaturesCommand(
@@ -42,7 +49,7 @@ class TestChangerEtapeCandidaturesUsecase:
 
         assert resultat.reussites == candidature_ids
         assert resultat.echecs == []
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
+        organisme_recruteur_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_empty_batch_returns_empty_result(self, usecase):
         command = ChangerEtapeCandidaturesCommand(
@@ -57,9 +64,11 @@ class TestChangerEtapeCandidaturesUsecase:
         assert resultat.reussites == []
         assert resultat.echecs == []
 
-    def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
+    def test_raises_when_organisme_not_found(
+        self, organisme_recruteur_repository, usecase
+    ):
         organisme_id = uuid4()
-        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
+        organisme_recruteur_repository.get_by_id.side_effect = OrganismeNexistePas(
             str(organisme_id)
         )
 

--- a/src/web/tests/application/recruteur/test_get_recrutement_etapes.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_etapes.py
@@ -7,19 +7,11 @@ from application.recruteur.usecases.get_recrutement_etapes import (
     GetRecrutementEtapesQuery,
     GetRecrutementEtapesUsecase,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
-
-
-@pytest.fixture(name="organisme_repository")
-def organisme_repository_fixture():
-    repo = MagicMock()
-    repo.get_by_id.return_value = MagicMock()
-    return repo
 
 
 @pytest.fixture(name="organisme_permission_service")
@@ -28,17 +20,14 @@ def organisme_permission_service_fixture():
 
 
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository, organisme_permission_service):
+def usecase_fixture(organisme_permission_service):
     return GetRecrutementEtapesUsecase(
-        organisme_repository=organisme_repository,
         organisme_permission_service=organisme_permission_service,
     )
 
 
 class TestGetRecrutementEtapesUsecase:
-    def test_returns_default_pipeline(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
+    def test_returns_default_pipeline(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
         recrutement_id = uuid4()
         utilisateur_id = uuid4()
@@ -66,26 +55,8 @@ class TestGetRecrutementEtapesUsecase:
             recrutement_id=recrutement_id,
             est_staff=False,
         )
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
-    def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
-        organisme_id = uuid4()
-        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
-            str(organisme_id)
-        )
-
-        with pytest.raises(OrganismeNexistePas):
-            usecase.execute(
-                GetRecrutementEtapesQuery(
-                    organisme_id=organisme_id,
-                    recrutement_id=uuid4(),
-                    utilisateur_id=uuid4(),
-                )
-            )
-
-    def test_raises_when_not_authorized(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
+    def test_raises_when_not_authorized(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
         organisme_permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
             organisme_id

--- a/src/web/tests/application/recruteur/test_get_recrutement_kanban.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_kanban.py
@@ -19,7 +19,6 @@ from application.recruteur.usecases.get_recrutement_kanban import (
     GetRecrutementKanbanQuery,
     GetRecrutementKanbanUsecase,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
@@ -66,13 +65,6 @@ def _recrutement_kanban_read_model() -> RecrutementKanbanReadModel:
     )
 
 
-@pytest.fixture(name="organisme_repository")
-def organisme_repository_fixture():
-    repo = MagicMock()
-    repo.get_by_id.return_value = MagicMock()
-    return repo
-
-
 @pytest.fixture(name="organisme_permission_service")
 def organisme_permission_service_fixture():
     return MagicMock(spec=OrganismePermissionService)
@@ -84,11 +76,8 @@ def recrutement_query_service_fixture():
 
 
 @pytest.fixture(name="usecase")
-def usecase_fixture(
-    organisme_repository, organisme_permission_service, recrutement_query_service
-):
+def usecase_fixture(organisme_permission_service, recrutement_query_service):
     return GetRecrutementKanbanUsecase(
-        organisme_repository=organisme_repository,
         organisme_permission_service=organisme_permission_service,
         recrutement_query_service=recrutement_query_service,
     )
@@ -104,7 +93,6 @@ class TestGetRecrutementKanban:
     )
     def test_returns_detail_when_authorized(
         self,
-        organisme_repository,
         organisme_permission_service,
         recrutement_query_service,
         usecase,
@@ -133,14 +121,12 @@ class TestGetRecrutementKanban:
             est_staff=False,
             recrutement_id=recrutement_id,
         )
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
         recrutement_query_service.get_kanban_by_recrutement.assert_called_once_with(
             organisme_id=organisme_id, recrutement_id=recrutement_id
         )
 
     def test_returns_none_for_unknown_recrutement(
         self,
-        organisme_repository,
         organisme_permission_service,
         recrutement_query_service,
         usecase,
@@ -160,7 +146,6 @@ class TestGetRecrutementKanban:
         )
 
         assert result is None
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_raises_when_not_authorized(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
@@ -169,26 +154,6 @@ class TestGetRecrutementKanban:
         )
 
         with pytest.raises(AccesOrganismeRefuse):
-            usecase.execute(
-                GetRecrutementKanbanQuery(
-                    organisme_id=organisme_id,
-                    recrutement_id=uuid4(),
-                    utilisateur_id=uuid4(),
-                )
-            )
-
-    def test_raises_when_organisme_not_found(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
-        organisme_permission_service.est_autorise.return_value = (
-            AgentOrganismeRole.RESPONSABLE
-        )
-        organisme_id = uuid4()
-        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
-            str(organisme_id)
-        )
-
-        with pytest.raises(OrganismeNexistePas):
             usecase.execute(
                 GetRecrutementKanbanQuery(
                     organisme_id=organisme_id,

--- a/src/web/tests/application/recruteur/test_get_recrutement_liste.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_liste.py
@@ -16,7 +16,6 @@ from application.recruteur.usecases.get_recrutement_liste import (
     GetRecrutementListeQuery,
     GetRecrutementListeUsecase,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
@@ -35,13 +34,6 @@ def _candidature_liste_read_model() -> CandidatureListeReadModel:
     )
 
 
-@pytest.fixture(name="organisme_repository")
-def organisme_repository_fixture():
-    repo = MagicMock()
-    repo.get_by_id.return_value = MagicMock()
-    return repo
-
-
 @pytest.fixture(name="organisme_permission_service")
 def organisme_permission_service_fixture():
     return MagicMock(spec=OrganismePermissionService)
@@ -53,11 +45,8 @@ def recrutement_query_service_fixture():
 
 
 @pytest.fixture(name="usecase")
-def usecase_fixture(
-    organisme_repository, organisme_permission_service, recrutement_query_service
-):
+def usecase_fixture(organisme_permission_service, recrutement_query_service):
     return GetRecrutementListeUsecase(
-        organisme_repository=organisme_repository,
         organisme_permission_service=organisme_permission_service,
         recrutement_query_service=recrutement_query_service,
     )
@@ -73,7 +62,6 @@ class TestGetRecrutementListe:
     )
     def test_returns_detail_when_authorized(
         self,
-        organisme_repository,
         organisme_permission_service,
         recrutement_query_service,
         usecase,
@@ -104,14 +92,12 @@ class TestGetRecrutementListe:
             est_staff=False,
             recrutement_id=recrutement_id,
         )
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
         recrutement_query_service.get_candidatures_by_recrutement.assert_called_once_with(
             organisme_id=organisme_id, recrutement_id=recrutement_id
         )
 
     def test_returns_none_for_unknown_recrutement(
         self,
-        organisme_repository,
         organisme_permission_service,
         recrutement_query_service,
         usecase,
@@ -131,7 +117,6 @@ class TestGetRecrutementListe:
         )
 
         assert result is None
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_raises_when_not_authorized(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
@@ -140,26 +125,6 @@ class TestGetRecrutementListe:
         )
 
         with pytest.raises(AccesOrganismeRefuse):
-            usecase.execute(
-                GetRecrutementListeQuery(
-                    organisme_id=organisme_id,
-                    recrutement_id=uuid4(),
-                    utilisateur_id=uuid4(),
-                )
-            )
-
-    def test_raises_when_organisme_not_found(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
-        organisme_permission_service.est_autorise.return_value = (
-            AgentOrganismeRole.RESPONSABLE
-        )
-        organisme_id = uuid4()
-        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
-            str(organisme_id)
-        )
-
-        with pytest.raises(OrganismeNexistePas):
             usecase.execute(
                 GetRecrutementListeQuery(
                     organisme_id=organisme_id,

--- a/src/web/tests/application/recruteur/test_init_recrutement_etapes.py
+++ b/src/web/tests/application/recruteur/test_init_recrutement_etapes.py
@@ -7,19 +7,11 @@ from application.recruteur.usecases.init_recrutement_etapes import (
     InitRecrutementEtapesCommand,
     InitRecrutementEtapesUsecase,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
 )
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
-
-
-@pytest.fixture(name="organisme_repository")
-def organisme_repository_fixture():
-    repo = MagicMock()
-    repo.get_by_id.return_value = MagicMock()
-    return repo
 
 
 @pytest.fixture(name="organisme_permission_service")
@@ -28,17 +20,14 @@ def organisme_permission_service_fixture():
 
 
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository, organisme_permission_service):
+def usecase_fixture(organisme_permission_service):
     return InitRecrutementEtapesUsecase(
-        organisme_repository=organisme_repository,
         organisme_permission_service=organisme_permission_service,
     )
 
 
 class TestInitRecrutementEtapesUsecase:
-    def test_returns_default_pipeline(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
+    def test_returns_default_pipeline(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
         recrutement_id = uuid4()
         utilisateur_id = uuid4()
@@ -66,26 +55,8 @@ class TestInitRecrutementEtapesUsecase:
             recrutement_id=recrutement_id,
             est_staff=False,
         )
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
-    def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
-        organisme_id = uuid4()
-        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
-            str(organisme_id)
-        )
-
-        with pytest.raises(OrganismeNexistePas):
-            usecase.execute(
-                InitRecrutementEtapesCommand(
-                    organisme_id=organisme_id,
-                    recrutement_id=uuid4(),
-                    utilisateur_id=uuid4(),
-                )
-            )
-
-    def test_raises_when_not_authorized(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
+    def test_raises_when_not_authorized(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
         organisme_permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
             organisme_id

--- a/src/web/tests/application/recruteur/test_lister_mes_recrutements.py
+++ b/src/web/tests/application/recruteur/test_lister_mes_recrutements.py
@@ -12,7 +12,6 @@ from application.recruteur.usecases.lister_mes_recrutements import (
     ListerMesRecrutementsQuery,
     ListerMesRecrutementsUsecase,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
@@ -30,13 +29,6 @@ def service_fixture() -> IRecrutementQueryService:
     )
 
 
-@pytest.fixture(name="organisme_repository")
-def organisme_repository_fixture():
-    repo = MagicMock()
-    repo.get_by_id.return_value = MagicMock()
-    return repo
-
-
 @pytest.fixture(name="organisme_permission_service")
 def organisme_permission_service_fixture():
     service = MagicMock(spec=OrganismePermissionService)
@@ -45,19 +37,16 @@ def organisme_permission_service_fixture():
 
 
 @pytest.fixture(name="usecase")
-def usecase_fixture(service, organisme_repository, organisme_permission_service):
+def usecase_fixture(service, organisme_permission_service):
     return ListerMesRecrutementsUsecase(
         recrutement_query_service=service,
-        organisme_repository=organisme_repository,
         organisme_permission_service=organisme_permission_service,
         logger=MagicMock(),
     )
 
 
 class TestListerMesRecrutements:
-    def test_lister_mes_recrutements_actifs(
-        self, service, organisme_repository, usecase
-    ):
+    def test_lister_mes_recrutements_actifs(self, service, usecase):
         organisme_id = uuid4()
         recrutements_actifs = [
             RecrutementFactory.create_actif_read_model(
@@ -76,11 +65,8 @@ class TestListerMesRecrutements:
 
         assert result == recrutements_actifs
         service.get_actifs_by_organisme.assert_called_once_with(organisme_id, None)
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
-    def test_lister_mes_recrutements_archives(
-        self, service, organisme_repository, usecase
-    ):
+    def test_lister_mes_recrutements_archives(self, service, usecase):
         organisme_id = uuid4()
         recrutements_archives = [RecrutementFactory.create_archive_read_model()]
         service.get_archives_by_organisme = MagicMock(
@@ -97,10 +83,9 @@ class TestListerMesRecrutements:
 
         assert result == recrutements_archives
         service.get_archives_by_organisme.assert_called_once_with(organisme_id, None)
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_lister_mes_recrutements_actifs_filtre_par_agent_quand_membre(
-        self, service, organisme_repository, organisme_permission_service, usecase
+        self, service, organisme_permission_service, usecase
     ):
         organisme_id = uuid4()
         utilisateur_id = uuid4()
@@ -124,7 +109,7 @@ class TestListerMesRecrutements:
         )
 
     def test_lister_mes_recrutements_archives_filtre_par_agent_quand_membre(
-        self, service, organisme_repository, organisme_permission_service, usecase
+        self, service, organisme_permission_service, usecase
     ):
         organisme_id = uuid4()
         utilisateur_id = uuid4()
@@ -148,21 +133,6 @@ class TestListerMesRecrutements:
         service.get_archives_by_organisme.assert_called_once_with(
             organisme_id, utilisateur_id
         )
-
-    def test_raise_organisme_not_found(self, service, organisme_repository, usecase):
-        organisme_id = uuid4()
-        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
-            str(organisme_id)
-        )
-
-        with pytest.raises(OrganismeNexistePas):
-            usecase.execute(
-                ListerMesRecrutementsQuery(
-                    organisme_id=organisme_id,
-                    statut=StatutRecrutement.ACTIF,
-                    utilisateur_id=uuid4(),
-                )
-            )
 
     def test_raises_when_not_responsable(self, organisme_permission_service, usecase):
         organisme_id = uuid4()

--- a/src/web/tests/application/recruteur/test_organisme_steps.py
+++ b/src/web/tests/application/recruteur/test_organisme_steps.py
@@ -22,7 +22,7 @@ from infrastructure.factories.recruteur.organisme_factory import (
 
 def test_get_organisme_steps(get_organisme_recruteur_usecase):
     organisme_before = OrganismeRecruteurFactory.create_entity()
-    get_organisme_recruteur_usecase.organisme_repository.save(organisme_before)
+    get_organisme_recruteur_usecase.organisme_recruteur_repository.save(organisme_before)
 
     organisme = get_organisme_recruteur_usecase.execute(
         command=InitializeOrganismeStepsCommand(
@@ -37,7 +37,9 @@ def test_get_organisme_steps(get_organisme_recruteur_usecase):
 
 def test_initialize_organisme_steps(initialize_organisme_steps_usecase):
     organisme_before = OrganismeRecruteurFactory.create_entity()
-    initialize_organisme_steps_usecase.organisme_repository.save(organisme_before)
+    initialize_organisme_steps_usecase.organisme_recruteur_repository.save(
+        organisme_before
+    )
 
     organisme = initialize_organisme_steps_usecase.execute(
         command=InitializeOrganismeStepsCommand(
@@ -80,7 +82,7 @@ def test_get_organisme_steps_raises_when_not_responsable(
     get_organisme_recruteur_usecase,
 ):
     organisme_before = OrganismeRecruteurFactory.create_entity()
-    get_organisme_recruteur_usecase.organisme_repository.save(organisme_before)
+    get_organisme_recruteur_usecase.organisme_recruteur_repository.save(organisme_before)
     permission_service = get_organisme_recruteur_usecase.organisme_permission_service
     permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
         organisme_before.entity_id
@@ -98,7 +100,9 @@ def test_initialize_organisme_steps_raises_when_not_responsable(
     initialize_organisme_steps_usecase,
 ):
     organisme_before = OrganismeRecruteurFactory.create_entity()
-    initialize_organisme_steps_usecase.organisme_repository.save(organisme_before)
+    initialize_organisme_steps_usecase.organisme_recruteur_repository.save(
+        organisme_before
+    )
     permission_service = initialize_organisme_steps_usecase.organisme_permission_service
     permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
         organisme_before.entity_id

--- a/src/web/tests/application/recruteur/test_organisme_steps.py
+++ b/src/web/tests/application/recruteur/test_organisme_steps.py
@@ -22,7 +22,9 @@ from infrastructure.factories.recruteur.organisme_factory import (
 
 def test_get_organisme_steps(get_organisme_recruteur_usecase):
     organisme_before = OrganismeRecruteurFactory.create_entity()
-    get_organisme_recruteur_usecase.organisme_recruteur_repository.save(organisme_before)
+    get_organisme_recruteur_usecase.organisme_recruteur_repository.save(
+        organisme_before
+    )
 
     organisme = get_organisme_recruteur_usecase.execute(
         command=InitializeOrganismeStepsCommand(
@@ -82,7 +84,9 @@ def test_get_organisme_steps_raises_when_not_responsable(
     get_organisme_recruteur_usecase,
 ):
     organisme_before = OrganismeRecruteurFactory.create_entity()
-    get_organisme_recruteur_usecase.organisme_recruteur_repository.save(organisme_before)
+    get_organisme_recruteur_usecase.organisme_recruteur_repository.save(
+        organisme_before
+    )
     permission_service = get_organisme_recruteur_usecase.organisme_permission_service
     permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
         organisme_before.entity_id

--- a/src/web/tests/application/recruteur/test_update_recrutement_etapes.py
+++ b/src/web/tests/application/recruteur/test_update_recrutement_etapes.py
@@ -8,7 +8,6 @@ from application.recruteur.usecases.update_recrutement_etapes import (
     UpdateRecrutementEtapesCommand,
     UpdateRecrutementEtapesUsecase,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.services.organisme_permission_service import (
     OrganismePermissionService,
@@ -19,30 +18,20 @@ from domain.recruteur.value_objects.categorie_etapes_recrutement import (
 from domain.recruteur.value_objects.organisme_action import OrganismeAction
 
 
-@pytest.fixture(name="organisme_repository")
-def organisme_repository_fixture():
-    repo = MagicMock()
-    repo.get_by_id.return_value = MagicMock()
-    return repo
-
-
 @pytest.fixture(name="organisme_permission_service")
 def organisme_permission_service_fixture():
     return MagicMock(spec=OrganismePermissionService)
 
 
 @pytest.fixture(name="usecase")
-def usecase_fixture(organisme_repository, organisme_permission_service):
+def usecase_fixture(organisme_permission_service):
     return UpdateRecrutementEtapesUsecase(
-        organisme_repository=organisme_repository,
         organisme_permission_service=organisme_permission_service,
     )
 
 
 class TestUpdateRecrutementEtapesUsecase:
-    def test_echoes_etapes_back_unchanged(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
+    def test_echoes_etapes_back_unchanged(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
         recrutement_id = uuid4()
         utilisateur_id = uuid4()
@@ -76,7 +65,6 @@ class TestUpdateRecrutementEtapesUsecase:
             recrutement_id=recrutement_id,
             est_staff=False,
         )
-        organisme_repository.get_by_id.assert_called_once_with(organisme_id)
 
     def test_empty_etapes_returns_empty_result(self, usecase):
         resultat = usecase.execute(
@@ -90,25 +78,7 @@ class TestUpdateRecrutementEtapesUsecase:
 
         assert resultat == []
 
-    def test_raises_when_organisme_not_found(self, organisme_repository, usecase):
-        organisme_id = uuid4()
-        organisme_repository.get_by_id.side_effect = OrganismeNexistePas(
-            str(organisme_id)
-        )
-
-        with pytest.raises(OrganismeNexistePas):
-            usecase.execute(
-                UpdateRecrutementEtapesCommand(
-                    organisme_id=organisme_id,
-                    recrutement_id=uuid4(),
-                    utilisateur_id=uuid4(),
-                    etapes=[],
-                )
-            )
-
-    def test_raises_when_not_authorized(
-        self, organisme_repository, organisme_permission_service, usecase
-    ):
+    def test_raises_when_not_authorized(self, organisme_permission_service, usecase):
         organisme_id = uuid4()
         organisme_permission_service.est_autorise.side_effect = AccesOrganismeRefuse(
             organisme_id

--- a/src/web/tests/domain/recruteur/test_organisme_permission_service.py
+++ b/src/web/tests/domain/recruteur/test_organisme_permission_service.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import (
     AccesOrganismeRefuse,
     AccesRecrutementInconnu,
@@ -10,6 +11,9 @@ from domain.recruteur.errors.organisme_permission_errors import (
 )
 from domain.recruteur.repositories.organisme_agent_repository_interface import (
     IOrganismeAgentRepository,
+)
+from domain.recruteur.repositories.organisme_repository_interface import (
+    IOrganismeRecruteurRepository,
 )
 from domain.recruteur.repositories.recrutement_agent_repository_interface import (
     IRecrutementAgentRepository,
@@ -41,12 +45,16 @@ STAFF_BYPASS_ACTIONS = [
 def _service(
     role: AgentOrganismeRole | None,
     recrutement_role: AgentRecrutementRole | None = None,
+    organisme_recruteur_repository: Mock | None = None,
 ) -> tuple[OrganismePermissionService, Mock, Mock]:
+    if organisme_recruteur_repository is None:
+        organisme_recruteur_repository = Mock(spec=IOrganismeRecruteurRepository)
     repository = Mock(spec=IOrganismeAgentRepository)
     repository.get_role.return_value = role
     recrutement_repository = Mock(spec=IRecrutementAgentRepository)
     recrutement_repository.get_role.return_value = recrutement_role
     service = OrganismePermissionService(
+        organisme_recruteur_repository=organisme_recruteur_repository,
         organisme_agent_repository=repository,
         recrutement_agent_repository=recrutement_repository,
     )
@@ -290,6 +298,46 @@ class TestRecrutementEtapesRbac:
                 est_staff=True,
                 recrutement_id=uuid4(),
             )
+
+
+def test_raises_when_organisme_not_found() -> None:
+    organisme_id = uuid4()
+    organisme_recruteur_repository = Mock(spec=IOrganismeRecruteurRepository)
+    organisme_recruteur_repository.get_by_id.side_effect = OrganismeNexistePas(
+        str(organisme_id)
+    )
+    service, _, _ = _service(
+        AgentOrganismeRole.RESPONSABLE,
+        organisme_recruteur_repository=organisme_recruteur_repository,
+    )
+
+    with pytest.raises(OrganismeNexistePas):
+        service.est_autorise(
+            action=OrganismeAction.GET_ORGANISME,
+            organisme_id=organisme_id,
+            agent_id=uuid4(),
+            est_staff=False,
+        )
+
+
+def test_organisme_guard_runs_before_staff_bypass_and_role_check() -> None:
+    organisme_id = uuid4()
+    organisme_recruteur_repository = Mock(spec=IOrganismeRecruteurRepository)
+    organisme_recruteur_repository.get_by_id.side_effect = OrganismeNexistePas(
+        str(organisme_id)
+    )
+    service, repository, _ = _service(
+        None, organisme_recruteur_repository=organisme_recruteur_repository
+    )
+
+    with pytest.raises(OrganismeNexistePas):
+        service.est_autorise(
+            action=OrganismeAction.GET_ORGANISME,
+            organisme_id=organisme_id,
+            agent_id=uuid4(),
+            est_staff=True,
+        )
+    repository.get_role.assert_not_called()
 
 
 def test_toute_action_membre_est_classee() -> None:

--- a/src/web/tests/infrastructure/identite/test_create_organisme.py
+++ b/src/web/tests/infrastructure/identite/test_create_organisme.py
@@ -5,7 +5,7 @@ from referentiel.value_objects.verse import Verse
 
 from application.identite.usecases.create_organisme import CreateOrganismeCommand
 from config.app_config import AppConfig
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.identite.value_objects.siret import SIRET
 from infrastructure.di.identite.identite_container import IdentiteContainer
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory

--- a/src/web/tests/infrastructure/recruteur/test_changer_etape_candidatures.py
+++ b/src/web/tests/infrastructure/recruteur/test_changer_etape_candidatures.py
@@ -9,8 +9,8 @@ from application.recruteur.usecases.changer_etape_candidatures import (
     ChangerEtapeCandidaturesCommand,
 )
 from config.app_config import AppConfig
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.commons.services.audit_log_writer import AuditLogWriter
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
 from infrastructure.factories.candidate.candidature_factory import CandidatureFactory
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory

--- a/src/web/tests/infrastructure/recruteur/test_get_recrutement_etapes.py
+++ b/src/web/tests/infrastructure/recruteur/test_get_recrutement_etapes.py
@@ -7,8 +7,8 @@ from application.recruteur.usecases.get_recrutement_etapes import (
     GetRecrutementEtapesQuery,
 )
 from config.app_config import AppConfig
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.commons.services.audit_log_writer import AuditLogWriter
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import (
     AccesOrganismeRefuse,
     AccesRecrutementRefuse,

--- a/src/web/tests/infrastructure/recruteur/test_init_recrutement_etapes.py
+++ b/src/web/tests/infrastructure/recruteur/test_init_recrutement_etapes.py
@@ -7,8 +7,8 @@ from application.recruteur.usecases.init_recrutement_etapes import (
     InitRecrutementEtapesCommand,
 )
 from config.app_config import AppConfig
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.commons.services.audit_log_writer import AuditLogWriter
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import (
     AccesOrganismeRefuse,
     AccesRecrutementRefuse,

--- a/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
+++ b/src/web/tests/infrastructure/recruteur/test_organisme_agent_repository.py
@@ -1,16 +1,29 @@
 import pytest
 
+from config.app_config import AppConfig
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from infrastructure.di.recruteur.recruteur_container import RecruteurContainer
 from infrastructure.factories.identite.agent_factory import AgentFactory
 from infrastructure.factories.identite.organisme_factory import OrganismeFactory
+from infrastructure.gateways.shared.logger import LoggerService
 from infrastructure.repositories.recruteur.postgres_organisme_agent_repository import (
     PostgresOrganismeAgentRepository,
 )
 
 
+@pytest.fixture(name="recruteur_integration_container")
+def recruteur_integration_container_fixture(db) -> RecruteurContainer:
+    container = RecruteurContainer()
+    container.app_config.override(AppConfig.from_django_settings())
+    container.logger_service.override(LoggerService())
+    return container
+
+
 @pytest.fixture(name="repository")
-def repository_fixture():
-    return PostgresOrganismeAgentRepository()
+def repository_fixture(
+    recruteur_integration_container,
+) -> PostgresOrganismeAgentRepository:
+    return recruteur_integration_container.postgres_organisme_agent_repository()
 
 
 def test_get_role_returns_responsable(db, repository):

--- a/src/web/tests/infrastructure/recruteur/test_update_recrutement_etapes.py
+++ b/src/web/tests/infrastructure/recruteur/test_update_recrutement_etapes.py
@@ -8,8 +8,8 @@ from application.recruteur.usecases.update_recrutement_etapes import (
     UpdateRecrutementEtapesCommand,
 )
 from config.app_config import AppConfig
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.commons.services.audit_log_writer import AuditLogWriter
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import (
     AccesOrganismeRefuse,
     AccesRecrutementRefuse,

--- a/src/web/tests/presentation/recruteur/test_views_organismes.py
+++ b/src/web/tests/presentation/recruteur/test_views_organismes.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from faker import Faker
 from rest_framework import status
 
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.entities.etape_recrutement import EtapeRecrutement
 from domain.recruteur.errors.erreur_recrutement import (
     ConfigurationEtapesInvalide,

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_detail.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_detail.py
@@ -17,7 +17,7 @@ from application.recruteur.dtos.recrutement_read_models import (
     OrganismeRecruteurDto,
     RecrutementKanbanReadModel,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 
 fake = Faker()

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_listes.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_listes.py
@@ -10,7 +10,7 @@ from application.recruteur.dtos.recrutement_read_models import (
     AgentDto,
     CandidaturesCompteurDto,
 )
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
 

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_params.py
@@ -7,7 +7,7 @@ from faker import Faker
 from rest_framework import status
 
 from application.recruteur.dtos.etape_data import EtapeData
-from domain.identite.errors.organisme_errors import OrganismeNexistePas
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.recruteur.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -560,16 +560,11 @@ def calculate_daily_stats_usecase():
 
 @pytest.fixture
 def update_organisme_steps_usecase():
-    organisme_repo = cast(
-        IOrganismeRepository,
-        create_interface_aware_mock(IOrganismeRepository),
-    )
     organisme_recruteur_repo = cast(
         IOrganismeRecruteurRepository,
         create_interface_aware_mock(IOrganismeRecruteurRepository),
     )
     return UpdateOrganismeStepsUsecase(
-        organisme_repository=organisme_repo,
         organisme_recruteur_repository=organisme_recruteur_repo,
         audit_log_writer=MagicMock(spec=AuditLogWriter),
         organisme_permission_service=MagicMock(spec=OrganismePermissionService),

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -525,7 +525,7 @@ def get_organisme_recruteur_usecase():
         IOrganismeRecruteurRepository, create_interface_aware_mock(IOrganismeRepository)
     )
     return GetOrganismeRecruteurUsecase(
-        organisme_repository=organisme_repository,
+        organisme_recruteur_repository=organisme_recruteur_repository,
         organisme_permission_service=MagicMock(spec=OrganismePermissionService),
     )
 
@@ -537,7 +537,7 @@ def initialize_organisme_steps_usecase():
         create_interface_aware_mock(IOrganismeRecruteurRepository),
     )
     return InitializeOrganismeStepsUsecase(
-        organisme_repository=repository,
+        organisme_recruteur_repository=repository,
         organisme_permission_service=MagicMock(spec=OrganismePermissionService),
     )
 

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -521,8 +521,9 @@ def create_organisme_usecase():
 
 @pytest.fixture
 def get_organisme_recruteur_usecase():
-    organisme_repository = cast(
-        IOrganismeRecruteurRepository, create_interface_aware_mock(IOrganismeRepository)
+    organisme_recruteur_repository = cast(
+        IOrganismeRecruteurRepository,
+        create_interface_aware_mock(IOrganismeRecruteurRepository),
     )
     return GetOrganismeRecruteurUsecase(
         organisme_recruteur_repository=organisme_recruteur_repository,


### PR DESCRIPTION
## 📝 Description

🎸 Centralise le contrôle d'accès organisme/recrutement dans OrganismePermissionService
🎸 Unifie l'erreur OrganismeNexistePas dans un module partagé entre bounded contexts
🎸 Résout l'import d'un repository du contexte `identité` dans un conteneur du contexte `recruteur`

##🏷️ Type de changement
- [x] ♻️ Refactorisation

## 🔧 Modifications
- **Domain (organisme/commons)** : déplace OrganismeNexistePas de domain.identite.errors.organisme_errors vers domain.commons.errors.organisme_errors, partagée entre identite et recruteur.
- **Domain (recruteur)** : OrganismePermissionService.est_autorise vérifie désormais l'existence de l'organisme via IOrganismeRecruteurRepository avant tout contrôle de rôle (staff bypass compris)
- **Application (recruteur)** : retire la garde organisme_repository devenue redondante des use cases get_recrutement_etapes, get_recrutement_kanban, get_recrutement_liste, init_recrutement_etapes, lister_mes_recrutements, update_organisme_steps, update_recrutement_etapes — la garde vit désormais uniquement dans OrganismePermissionService
- **Application (recruteur)** : ChangerEtapeCandidaturesUsecase bascule du repository identite vers le repository recruteur (organisme_recruteur_repository / IOrganismeRecruteurRepository)
- **Infrastructure (recruteur)** : DI RecruteurContainer mis à jour (suppression de postgres_organisme_repository, renommage cohérent en organisme_recruteur_repository) ; les repositories postgres_organisme_repository (identite et recruteur) pointent vers la nouvelle erreur partagée.
- **Presentation (recruteur)** : mise à jour des imports d'OrganismeNexistePas dans les vues (organismes, recrutement_detail, recrutement_listes, recrutement_params).
- **Tests (infrastructure/recruteur)** : test_organisme_agent_repository utilise désormais le conteneur DI (RecruteurContainer) plutôt que d'instancier directement le repository.

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.