### PR TITLE
🐛(ingestion) autoriser un champ mission vide dans DescriptionInputSerializer

### DIFF
--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -173,7 +173,7 @@ class ProfessionInputSerializer(serializers.Serializer):
 
 
 class DescriptionInputSerializer(serializers.Serializer):
-    mission = serializers.CharField(max_length=10000)
+    mission = serializers.CharField(max_length=10000, allow_blank=True)
     profil = serializers.CharField(max_length=10000, allow_blank=True)
     employeur = serializers.CharField(max_length=3000)
     complements = serializers.CharField(max_length=5000, allow_blank=True)

--- a/src/web/tests/presentation/ingestion/test_serializers.py
+++ b/src/web/tests/presentation/ingestion/test_serializers.py
@@ -1,5 +1,8 @@
 from infrastructure.factories.ingestion.offer_payload_factory import PayloadOfferFactory
-from presentation.ingestion.serializers import OffersInputSerializer
+from presentation.ingestion.serializers import (
+    DescriptionInputSerializer,
+    OffersInputSerializer,
+)
 
 
 def test_offers_input_serializer_never_exposes_archived_at():
@@ -12,3 +15,20 @@ def test_offers_input_serializer_never_exposes_archived_at():
     serializer = OffersInputSerializer(data=payload)
     assert serializer.is_valid(), serializer.errors
     assert "archived_at" not in serializer.validated_data
+
+
+def test_description_input_serializer_allows_blanks():
+    payload = {
+        "mission": "",
+        "profil": "",
+        "employeur": "Employeur",
+        "complements": "",
+    }
+
+    serializer = DescriptionInputSerializer(data=payload)
+
+    assert serializer.is_valid(), serializer.errors
+
+    assert serializer.validated_data["mission"] == ""
+    assert serializer.validated_data["profil"] == ""
+    assert serializer.validated_data["complements"] == ""

--- a/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
@@ -58,7 +58,7 @@ COMPLETE_VALID_OFFER = PayloadOfferFactory.create(
     categories=["A", "B"],
     forme_contrat=["CDD"],
     vacance_poste="OUI",
-    description={"profil": ""},
+    description={"profil": "", "mission": ""},
     localisation=[
         {
             "zone_geographique": "EU",


### PR DESCRIPTION
## 📝 Description

Autorise le champ `mission` vide, similaire à https://github.com/betagouv/csplab/issues/1066

Ceci survient pour plusieurs offres du MENJ. [Voir exemple](https://sentry.incubateur.net/organizations/betagouv/issues/299174/events/29e8781b75bf4d6a9efe53c6eb86e40b/)

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
