### PR TITLE
✨(ingestion) ajouter working_place et management sur les offres Talentsoft

### DIFF
--- a/src/ingestion/domain/entities/offer.py
+++ b/src/ingestion/domain/entities/offer.py
@@ -10,6 +10,7 @@ from referentiel.value_objects.experience_level import ExperienceLevel
 from referentiel.value_objects.language import Language
 from referentiel.value_objects.limit_date import LimitDate
 from referentiel.value_objects.localisation import Localisation
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.verse import Verse
 
 
@@ -38,4 +39,6 @@ class Offer:
     languages: list[Language] = field(default_factory=list)
     specialisations: list[str] = field(default_factory=list)
     family_code: Optional[str] = None
+    working_place: WorkingPlace = WorkingPlace.NON_DEFINI
+    management: Optional[Management] = None
     id: UUID = field(default_factory=uuid4)

--- a/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
+++ b/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from pydantic import BaseModel, HttpUrl, model_serializer
 from referentiel.value_objects.language import Language
+from referentiel.value_objects.offer_conditions import WorkingTime
 
 from domain.entities.offer import Offer
 
@@ -71,6 +72,16 @@ class CriteresPayload(BaseModel):
         return {k: v for k, v in self.__dict__.items() if v is not None and v != []}
 
 
+class ConditionsPayload(BaseModel):
+    temps_travail: str
+    lieu_de_travail: str
+    management: Optional[str] = None
+
+    @model_serializer
+    def serialize(self) -> dict:
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+
 class OfferUpsertPayload(BaseModel):
     identification: IdentificationPayload
     titre: str
@@ -86,7 +97,7 @@ class OfferUpsertPayload(BaseModel):
     description: DescriptionPayload
     localisation: Optional[list[LocalisationItemPayload]] = None
     criteres: Optional[CriteresPayload] = None
-    conditions: None = None
+    conditions: Optional[ConditionsPayload] = None
     contacts: None = None
     publication: PublicationPayload
 
@@ -156,7 +167,11 @@ class OfferUpsertPayload(BaseModel):
             or offer.specialisations
             or offer.languages
             else None,
-            conditions=None,
+            conditions=ConditionsPayload(
+                temps_travail=WorkingTime.NON_DEFINI.name,
+                lieu_de_travail=offer.working_place.name,
+                management=offer.management.name if offer.management else None,
+            ),
             contacts=None,
             publication=PublicationPayload(
                 debut_publication=offer.publication_date,

--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -16,6 +16,7 @@ from referentiel.value_objects.language import Language
 from referentiel.value_objects.language_level import LanguageLevel
 from referentiel.value_objects.limit_date import LimitDate
 from referentiel.value_objects.localisation import Localisation
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.region import Region
 from referentiel.value_objects.verse import Verse
 
@@ -131,6 +132,22 @@ class OffersCleaner:
             talentsoft_offer.diploma.clientCode if talentsoft_offer.diploma else None
         )
 
+        working_place = self._map_working_place(
+            talentsoft_offer.customFields.offerCustomBlock1.customCodeTable2.clientCode
+            if talentsoft_offer.customFields
+            and talentsoft_offer.customFields.offerCustomBlock1
+            and talentsoft_offer.customFields.offerCustomBlock1.customCodeTable2
+            else None
+        )
+
+        management = self._map_management(
+            talentsoft_offer.customFields.offerCustomBlock1.customCodeTable1.clientCode
+            if talentsoft_offer.customFields
+            and talentsoft_offer.customFields.offerCustomBlock1
+            and talentsoft_offer.customFields.offerCustomBlock1.customCodeTable1
+            else None
+        )
+
         return Offer(
             reference=raw_offer.reference,
             source_id=UUID(cast(str, raw_offer.source_id)),
@@ -157,6 +174,8 @@ class OffersCleaner:
             languages=languages,
             specialisations=specialisations,
             family_code=family_code_value,
+            working_place=working_place,
+            management=management,
         )
 
     def _map_verse(self, verse_str: Optional[str], reference: str) -> Optional[Verse]:
@@ -234,6 +253,30 @@ class OffersCleaner:
             return ContractKind.CDD
 
         return self._CONTRACT_KIND_MAPPING.get(contract_kind_upper)
+
+    _WORKING_PLACE_MAPPING: dict[str, WorkingPlace] = {
+        "reponse_oui": WorkingPlace.TELETRAVAIL,
+        "reponse_non": WorkingPlace.SUR_SITE,
+    }
+
+    def _map_working_place(self, client_code: Optional[str]) -> WorkingPlace:
+        if not client_code:
+            return WorkingPlace.NON_DEFINI
+
+        return self._WORKING_PLACE_MAPPING.get(
+            client_code.lower(), WorkingPlace.NON_DEFINI
+        )
+
+    _MANAGEMENT_MAPPING: dict[str, Management] = {
+        "reponse_non": Management.SANS,
+        "reponse_oui": Management.AVEC,
+    }
+
+    def _map_management(self, client_code: Optional[str]) -> Optional[Management]:
+        if not client_code:
+            return None
+
+        return self._MANAGEMENT_MAPPING.get(client_code.lower())
 
     def _extract_coordinates(
         self, talentsoft_offer: TalentsoftDetailOffer

--- a/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
+++ b/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
@@ -7,11 +7,13 @@ from referentiel.value_objects.contract_type import ContractKind, ContractType
 from referentiel.value_objects.experience_level import ExperienceLevel
 from referentiel.value_objects.language import Language
 from referentiel.value_objects.language_level import LanguageLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.verse import Verse
 
 from domain.entities.raw_offer import RawOffer
 from infrastructure.external_gateways.dtos.talentsoft_dtos import (
     TalentsoftLanguage,
+    TalentsoftOfferCustomBlock,
     TalentsoftOfferCustomFields,
 )
 from infrastructure.gateways.offers_cleaner import OffersCleaner
@@ -352,6 +354,62 @@ def test_clean_maps_contract_kind(cleaner, contract_kind_code, expected):
     offer = cleaner.clean(raw_offer)
 
     assert offer.contract_kind == expected
+
+
+@pytest.mark.parametrize(
+    "working_place_code, expected",
+    [
+        ("reponse_oui", WorkingPlace.TELETRAVAIL),
+        ("reponse_non", WorkingPlace.SUR_SITE),
+        ("UNKNOWN_CODE", WorkingPlace.NON_DEFINI),
+        (None, WorkingPlace.NON_DEFINI),
+    ],
+)
+def test_clean_maps_working_place(cleaner, working_place_code, expected):
+    offer_dto_kwargs = {
+        "customFields": TalentsoftCustomFieldsFactory.build(
+            offerCustomBlock1=TalentsoftOfferCustomBlock(
+                customCodeTable2=TalentsoftCustomCodeTableFactory.build(
+                    clientCode=working_place_code
+                )
+                if working_place_code
+                else None
+            )
+        )
+    }
+    raw_offer = _make_raw_offer(**offer_dto_kwargs)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.working_place == expected
+
+
+@pytest.mark.parametrize(
+    "management_code, expected",
+    [
+        ("reponse_oui", Management.AVEC),
+        ("reponse_non", Management.SANS),
+        ("UNKNOWN_CODE", None),
+        (None, None),
+    ],
+)
+def test_clean_maps_management(cleaner, management_code, expected):
+    offer_dto_kwargs = {
+        "customFields": TalentsoftCustomFieldsFactory.build(
+            offerCustomBlock1=TalentsoftOfferCustomBlock(
+                customCodeTable1=TalentsoftCustomCodeTableFactory.build(
+                    clientCode=management_code
+                )
+                if management_code
+                else None
+            )
+        )
+    }
+    raw_offer = _make_raw_offer(**offer_dto_kwargs)
+
+    offer = cleaner.clean(raw_offer)
+
+    assert offer.management == expected
 
 
 def test_clean_returns_none_url_on_invalid_offer_url(cleaner):

--- a/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
+++ b/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
@@ -16,6 +16,7 @@ from referentiel.value_objects.language import Language
 from referentiel.value_objects.language_level import LanguageLevel
 from referentiel.value_objects.limit_date import LimitDate
 from referentiel.value_objects.localisation import Localisation
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.region import Region
 from referentiel.value_objects.verse import Verse
 
@@ -137,7 +138,10 @@ async def test_publish_serializes_minimal_offer(gateway, httpx_mock: HTTPXMock):
     assert offer["description"]["complements"] == ""
     assert offer["localisation"] is None
     assert offer["criteres"] is None
-    assert offer["conditions"] is None
+    assert offer["conditions"] == {
+        "temps_travail": "NON_DEFINI",
+        "lieu_de_travail": "NON_DEFINI",
+    }
     assert offer["contacts"] is None
     assert offer["publication"]["debut_publication"] == "2024-01-15T00:00:00Z"
 
@@ -151,6 +155,37 @@ async def test_publish_serializes_contract_kind(gateway, httpx_mock: HTTPXMock):
 
     body = json.loads(httpx_mock.get_requests()[0].content)
     assert body["offres"][0]["forme_contrat"] == ["CDD"]
+
+
+@pytest.mark.asyncio
+async def test_publish_serializes_working_place(gateway, httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
+    offer = Offer(
+        **{**MINIMAL_OFFER.__dict__, "working_place": WorkingPlace.TELETRAVAIL}
+    )
+
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=offer))
+
+    body = json.loads(httpx_mock.get_requests()[0].content)
+    assert body["offres"][0]["conditions"] == {
+        "temps_travail": "NON_DEFINI",
+        "lieu_de_travail": "TELETRAVAIL",
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_serializes_management(gateway, httpx_mock: HTTPXMock):
+    httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
+    offer = Offer(**{**MINIMAL_OFFER.__dict__, "management": Management.AVEC})
+
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=offer))
+
+    body = json.loads(httpx_mock.get_requests()[0].content)
+    assert body["offres"][0]["conditions"] == {
+        "temps_travail": "NON_DEFINI",
+        "lieu_de_travail": "NON_DEFINI",
+        "management": "AVEC",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 📝 Description

Mappe `customFields.offerCustomBlock1.customCodeTable2/1` vers `Offer.working_place` et `Offer.management`, publiés dans `conditions.lieu_de_travail` et `conditions.management`.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
