### PR TITLE
✨(api) ajouter des filtres category/verse/contractType/experienceLevel à /api/v1/offres

### DIFF
--- a/src/web/presentation/commons/pagination.py
+++ b/src/web/presentation/commons/pagination.py
@@ -9,11 +9,12 @@ from rest_framework.settings import api_settings
 
 class WebPagination(BasePagination):
     page_size = api_settings.PAGE_SIZE
+    min_page_size = 1
 
     def paginate(self, page: IPage, request) -> list[Any]:
         self.request = request
         self.count = page.count()
-        self.page_size = int(self.request.query_params.get("size", self.page_size))
+        self.page_size = int(self.request.query_params.get("taille", self.page_size))
         self.page_num = int(self.request.query_params.get("page", 1))
 
         offset = (self.page_num - 1) * self.page_size
@@ -38,14 +39,18 @@ class WebPagination(BasePagination):
                 "required": False,
                 "in": "query",
                 "description": "Numéro de la page.",
-                "schema": {"type": "integer"},
+                "schema": {"type": "integer", "default": 1, "minimum": 1},
             },
             {
-                "name": "size",
+                "name": "taille",
                 "required": False,
                 "in": "query",
                 "description": "Nombre d'éléments par page.",
-                "schema": {"type": "integer"},
+                "schema": {
+                    "type": "integer",
+                    "default": self.page_size,
+                    "minimum": self.min_page_size,
+                },
             },
         ]
 
@@ -87,7 +92,7 @@ class WebPagination(BasePagination):
         parsed = urlparse(url)
         params = parse_qs(parsed.query, keep_blank_values=True)
         params["page"] = [page_num]
-        params["size"] = [self.page_size]
+        params["taille"] = [self.page_size]
         new_query = urlencode({k: v[0] for k, v in params.items()})
         return urlunparse(parsed._replace(query=new_query))
 

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -1061,7 +1061,7 @@ export interface operations {
                 /** @description Numéro de la page. */
                 page?: number;
                 /** @description Nombre d'éléments par page. */
-                size?: number;
+                taille?: number;
             };
             header?: never;
             path: {
@@ -1127,7 +1127,7 @@ export interface operations {
                 /** @description Numéro de la page. */
                 page?: number;
                 /** @description Nombre d'éléments par page. */
-                size?: number;
+                taille?: number;
             };
             header?: never;
             path: {
@@ -1483,7 +1483,7 @@ export interface operations {
                 /** @description Numéro de la page. */
                 page?: number;
                 /** @description Nombre d'éléments par page. */
-                size?: number;
+                taille?: number;
             };
             header?: never;
             path: {

--- a/src/web/presentation/ingestion/openapi.py
+++ b/src/web/presentation/ingestion/openapi.py
@@ -264,11 +264,17 @@ LIST_OFFERS_DESCRIPTION = (
     """
 # API de consultation des offres d'emploi de la Fonction Publique
 
-Cette API retourne la liste des offres correspondant à une recherche selon les 2
+Cette API retourne la liste des offres correspondant à une recherche selon les
 critères suivants :
 
-- Candidature active / archivée
-- Référence externe de la candidature contient une chaîne de caractère spécifique
+- `actif` — candidature active / archivée
+- `categorie` — une ou plusieurs catégories (ex. `A,B`)
+- `versant` — un ou plusieurs versants (ex. `FPE,FPT`)
+- `type_contrat` — un ou plusieurs types de contrat (ex. `TITULAIRE_CONTRACTUEL`)
+- `niveau_experience` — un ou plusieurs niveaux d'expérience (ex. `DEBUTANT,EXPERT`)
+
+Les filtres à valeurs multiples acceptent une liste de valeurs séparées par une
+virgule. Une valeur invalide pour l'un de ces filtres renvoie une erreur `400`.
 
 """
     + _API_COMMON_FOOTER

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -35,6 +35,21 @@ def _parse_enum_list(value, enum_cls, error_label, excluded=frozenset()):
     return [enum_cls[part] for part in requested]
 
 
+class _CommaSeparatedEnumField(serializers.MultipleChoiceField):
+    def __init__(self, enum_cls, error_label, excluded=frozenset(), **kwargs):
+        self.enum_cls = enum_cls
+        self.error_label = error_label
+        self.excluded = excluded
+        choices = [(e.name, e.value) for e in enum_cls if e not in excluded]
+        kwargs.setdefault("default", None)
+        super().__init__(choices=choices, **kwargs)
+
+    def to_internal_value(self, data):
+        if isinstance(data, (list, tuple)):
+            data = ",".join(data)
+        return _parse_enum_list(data, self.enum_cls, self.error_label, self.excluded)
+
+
 class ValidationErrorSerializer(GenericErrorSerializer):
     row = serializers.IntegerField()
 
@@ -68,8 +83,32 @@ class ListOffersResponseSerializer(serializers.Serializer):
 
 
 class ListOffersFiltersSerializer(serializers.Serializer):
-    active = serializers.BooleanField(default=True)
-    external_id_contains = serializers.CharField(default=None)
+    actif = serializers.BooleanField(default=True, source="active")
+    categorie = _CommaSeparatedEnumField(
+        Category,
+        "catégorie",
+        excluded={Category.HORS_CATEGORIE},
+        help_text="Valeurs séparées par une virgule (ex. `A,B`).",
+        source="category",
+    )
+    versant = _CommaSeparatedEnumField(
+        Verse,
+        "versant",
+        help_text="Valeurs séparées par une virgule (ex. `FPE,FPT`).",
+        source="verse",
+    )
+    type_contrat = _CommaSeparatedEnumField(
+        ContractType,
+        "type de contrat",
+        help_text="Valeurs séparées par une virgule (ex. `TITULAIRE_CONTRACTUEL`).",
+        source="contract_type",
+    )
+    niveau_experience = _CommaSeparatedEnumField(
+        ExperienceLevel,
+        "niveau d'expérience",
+        help_text="Valeurs séparées par une virgule (ex. `DEBUTANT,EXPERT`).",
+        source="experience_level",
+    )
 
 
 class OfferSummariesQuerySerializer(serializers.Serializer):
@@ -77,28 +116,16 @@ class OfferSummariesQuerySerializer(serializers.Serializer):
     count = serializers.IntegerField(
         required=False, min_value=1, max_value=1_000, default=100
     )
-    category = serializers.CharField(required=False, allow_blank=True, default=None)
-    verse = serializers.CharField(required=False, allow_blank=True, default=None)
-    contractType = serializers.CharField(
-        required=False, allow_blank=True, default=None, source="contract_type"
+    category = _CommaSeparatedEnumField(
+        Category, "catégorie", excluded={Category.HORS_CATEGORIE}
     )
-    experienceLevel = serializers.CharField(
-        required=False, allow_blank=True, default=None, source="experience_level"
+    verse = _CommaSeparatedEnumField(Verse, "versant")
+    contractType = _CommaSeparatedEnumField(
+        ContractType, "type de contrat", source="contract_type"
     )
-
-    def validate_category(self, value):
-        return _parse_enum_list(
-            value, Category, "catégorie", excluded={Category.HORS_CATEGORIE}
-        )
-
-    def validate_verse(self, value):
-        return _parse_enum_list(value, Verse, "versant")
-
-    def validate_contractType(self, value):
-        return _parse_enum_list(value, ContractType, "type de contrat")
-
-    def validate_experienceLevel(self, value):
-        return _parse_enum_list(value, ExperienceLevel, "niveau d'expérience")
+    experienceLevel = _CommaSeparatedEnumField(
+        ExperienceLevel, "niveau d'expérience", source="experience_level"
+    )
 
 
 class LocalisationInputSerializer(LocalisationSerializer):

--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -9,6 +9,7 @@ from drf_spectacular.utils import (
 from referentiel.exceptions.offer_errors import OfferDoesNotExist
 from rest_framework import serializers, status
 from rest_framework import serializers as drf_serializers
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -58,6 +59,7 @@ from presentation.ingestion.serializers import (
     description=LIST_OFFERS_DESCRIPTION,
     examples=LIST_OFFERS_EXAMPLES,
     tags=["offres"],
+    parameters=[ListOffersFiltersSerializer],
     responses={
         200: ListOffersResponseSerializer(many=True),
         400: GenericErrorSerializer,
@@ -82,7 +84,9 @@ class OffersListView(APIView):
         try:
             filters = ListOffersFiltersSerializer(data=self.request.query_params)
             filters.is_valid(raise_exception=True)
-            input_data = GetFilteredOffersInput(**filters.validated_data)
+            input_data = GetFilteredOffersInput(
+                external_id_contains=None, **filters.validated_data
+            )
 
             result = self.usecase.execute(input_data)
 
@@ -90,6 +94,12 @@ class OffersListView(APIView):
             items = paginator.paginate(result, request)
             return paginator.get_paginated_response(
                 ListOffersResponseSerializer(items, many=True).data
+            )
+        except DRFValidationError as e:
+            serializer = GenericErrorSerializer({"error": str(e)})
+            return Response(
+                serializer.data,
+                status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as e:
             self.logger.error("Unexpected error in OffersListView: %s", str(e))

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -433,12 +433,16 @@ paths:
         description: Numéro de la page.
         schema:
           type: integer
-      - name: size
+          default: 1
+          minimum: 1
+      - name: taille
         required: false
         in: query
         description: Nombre d'éléments par page.
         schema:
           type: integer
+          default: 100
+          minimum: 1
       tags:
       - recruteur
       security:
@@ -499,12 +503,16 @@ paths:
         description: Numéro de la page.
         schema:
           type: integer
-      - name: size
+          default: 1
+          minimum: 1
+      - name: taille
         required: false
         in: query
         description: Nombre d'éléments par page.
         schema:
           type: integer
+          default: 100
+          minimum: 1
       tags:
       - recruteur
       security:
@@ -869,18 +877,22 @@ paths:
         description: Numéro de la page.
         schema:
           type: integer
+          default: 1
+          minimum: 1
       - in: path
         name: recrutement_uuid
         schema:
           type: string
           format: uuid
         required: true
-      - name: size
+      - name: taille
         required: false
         in: query
         description: Nombre d'éléments par page.
         schema:
           type: integer
+          default: 100
+          minimum: 1
       tags:
       - recruteur
       security:

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -259,12 +259,16 @@ paths:
         description: Numéro de la page.
         schema:
           type: integer
-      - name: size
+          default: 1
+          minimum: 1
+      - name: taille
         required: false
         in: query
         description: Nombre d'éléments par page.
         schema:
           type: integer
+          default: 100
+          minimum: 1
       tags:
       - metiers
       security:
@@ -376,11 +380,17 @@ paths:
 
         # API de consultation des offres d'emploi de la Fonction Publique
 
-        Cette API retourne la liste des offres correspondant à une recherche selon les 2
+        Cette API retourne la liste des offres correspondant à une recherche selon les
         critères suivants :
 
-        - Candidature active / archivée
-        - Référence externe de la candidature contient une chaîne de caractère spécifique
+        - `actif` — candidature active / archivée
+        - `categorie` — une ou plusieurs catégories (ex. `A,B`)
+        - `versant` — un ou plusieurs versants (ex. `FPE,FPT`)
+        - `type_contrat` — un ou plusieurs types de contrat (ex. `TITULAIRE_CONTRACTUEL`)
+        - `niveau_experience` — un ou plusieurs niveaux d'expérience (ex. `DEBUTANT,EXPERT`)
+
+        Les filtres à valeurs multiples acceptent une liste de valeurs séparées par une
+        virgule. Une valeur invalide pour l'un de ces filtres renvoie une erreur `400`.
 
 
         Cette API est à l'usage exclusif des personnes autorisées.
@@ -395,18 +405,89 @@ paths:
         L'interrogation de cette API est limitée à 120 appels par minute et par utilisateur.
       summary: Liste des offres
       parameters:
+      - in: query
+        name: actif
+        schema:
+          type: boolean
+          default: true
+      - in: query
+        name: categorie
+        schema:
+          type: array
+          items:
+            enum:
+            - APLUS
+            - A
+            - B
+            - C
+            type: string
+            description: |-
+              * `APLUS` - APLUS
+              * `A` - A
+              * `B` - B
+              * `C` - C
+        description: Valeurs séparées par une virgule (ex. `A,B`).
+      - in: query
+        name: niveau_experience
+        schema:
+          type: array
+          items:
+            enum:
+            - DEBUTANT
+            - CONFIRME
+            - EXPERT
+            type: string
+            description: |-
+              * `DEBUTANT` - Débutant
+              * `CONFIRME` - Confirmé
+              * `EXPERT` - Expert
+        description: Valeurs séparées par une virgule (ex. `DEBUTANT,EXPERT`).
       - name: page
         required: false
         in: query
         description: Numéro de la page.
         schema:
           type: integer
-      - name: size
+          default: 1
+          minimum: 1
+      - name: taille
         required: false
         in: query
         description: Nombre d'éléments par page.
         schema:
           type: integer
+          default: 100
+          minimum: 1
+      - in: query
+        name: type_contrat
+        schema:
+          type: array
+          items:
+            enum:
+            - TITULAIRE_CONTRACTUEL
+            - CONTRACTUELS
+            - TERRITORIAL
+            type: string
+            description: |-
+              * `TITULAIRE_CONTRACTUEL` - TITULAIRE_CONTRACTUEL
+              * `CONTRACTUELS` - CONTRACTUELS
+              * `TERRITORIAL` - TERRITORIAL
+        description: Valeurs séparées par une virgule (ex. `TITULAIRE_CONTRACTUEL`).
+      - in: query
+        name: versant
+        schema:
+          type: array
+          items:
+            enum:
+            - FPT
+            - FPE
+            - FPH
+            type: string
+            description: |-
+              * `FPT` - FPT
+              * `FPE` - FPE
+              * `FPH` - FPH
+        description: Valeurs séparées par une virgule (ex. `FPE,FPT`).
       tags:
       - offres
       security:
@@ -690,18 +771,22 @@ paths:
         description: Numéro de la page.
         schema:
           type: integer
-      - name: size
-        required: false
-        in: query
-        description: Nombre d'éléments par page.
-        schema:
-          type: integer
+          default: 1
+          minimum: 1
       - in: path
         name: source_id
         schema:
           type: string
           format: uuid
         required: true
+      - name: taille
+        required: false
+        in: query
+        description: Nombre d'éléments par page.
+        schema:
+          type: integer
+          default: 100
+          minimum: 1
       tags:
       - offres
       security:

--- a/src/web/tests/presentation/commons/test_pagination.py
+++ b/src/web/tests/presentation/commons/test_pagination.py
@@ -10,14 +10,18 @@ def test_get_schema_operation_parameters_exposes_page_and_size():
             "required": False,
             "in": "query",
             "description": "Numéro de la page.",
-            "schema": {"type": "integer"},
+            "schema": {"type": "integer", "default": 1, "minimum": 1},
         },
         {
-            "name": "size",
+            "name": "taille",
             "required": False,
             "in": "query",
             "description": "Nombre d'éléments par page.",
-            "schema": {"type": "integer"},
+            "schema": {
+                "type": "integer",
+                "default": WebPagination.page_size,
+                "minimum": WebPagination.min_page_size,
+            },
         },
     ]
 

--- a/src/web/tests/presentation/ingestion/views/test_list_metiers.py
+++ b/src/web/tests/presentation/ingestion/views/test_list_metiers.py
@@ -119,7 +119,7 @@ def test_pagination_page_arg(mock_metiers_container, authenticated_client):
     assert parse_qs(parsed_previous.query) == {
         "page": ["1"],
         "dummy": ["arg"],
-        "size": ["2"],
+        "taille": ["2"],
     }
 
     parsed_next = urlparse(data["next"])
@@ -127,7 +127,7 @@ def test_pagination_page_arg(mock_metiers_container, authenticated_client):
     assert parse_qs(parsed_next.query) == {
         "page": ["3"],
         "dummy": ["arg"],
-        "size": ["2"],
+        "taille": ["2"],
     }
 
 
@@ -151,7 +151,7 @@ def test_pagination_out_of_bond(mock_metiers_container, authenticated_client):
     assert parsed.path == URL
     assert parse_qs(parsed.query) == {
         "page": ["2"],
-        "size": ["2"],
+        "taille": ["2"],
     }
 
     assert data["next"] is None

--- a/src/web/tests/presentation/ingestion/views/test_list_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_list_offers.py
@@ -5,7 +5,10 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from django.urls import reverse
 from faker import Faker
+from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
+from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.verse import Verse
 from rest_framework import status
 
 from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
@@ -117,21 +120,135 @@ def test_call_without_arg(mock_offers_container, authenticated_client):
             assert result["archived_at"] is None
 
 
-@pytest.mark.parametrize("active,external_id_contains", [(True, None), (False, "123")])
-def test_call_with_args(
-    mock_offers_container, authenticated_client, active, external_id_contains
+@pytest.mark.parametrize("active", [True, False])
+def test_call_with_args(mock_offers_container, authenticated_client, active):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"actif": active})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(active=active, external_id_contains=None)
+    )
+
+
+def test_external_id_contains_is_not_accepted(
+    mock_offers_container, authenticated_client
 ):
     _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
 
-    params = {"active": active}
-    if external_id_contains is not None:
-        params["external_id_contains"] = external_id_contains
-
-    authenticated_client.get(URL, params)
+    authenticated_client.get(URL, {"external_id_contains": "123"})
 
     mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
-        GetFilteredOffersInput(active=active, external_id_contains=external_id_contains)
+        GetFilteredOffersInput(active=True, external_id_contains=None)
     )
+
+
+def test_category_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"categorie": "A,B"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            category=[Category.A, Category.B],
+        )
+    )
+
+
+def test_invalid_category_returns_400(mock_offers_container, authenticated_client):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"categorie": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+    assert "A, APLUS, B, C" in response.json()["error"]
+
+
+def test_verse_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"versant": "FPE,FPT"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            verse=[Verse.FPE, Verse.FPT],
+        )
+    )
+
+
+def test_invalid_verse_returns_400(mock_offers_container, authenticated_client):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"versant": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+    assert "FPE, FPH, FPT" in response.json()["error"]
+
+
+def test_contract_type_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"type_contrat": "CONTRACTUELS,TERRITORIAL"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            contract_type=[ContractType.CONTRACTUELS, ContractType.TERRITORIAL],
+        )
+    )
+
+
+def test_invalid_contract_type_returns_400(mock_offers_container, authenticated_client):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"type_contrat": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+    assert (
+        "CONTRACTUELS, TERRITORIAL, TITULAIRE_CONTRACTUEL" in response.json()["error"]
+    )
+
+
+def test_experience_level_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"niveau_experience": "DEBUTANT,EXPERT"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            experience_level=[ExperienceLevel.DEBUTANT, ExperienceLevel.EXPERT],
+        )
+    )
+
+
+def test_invalid_experience_level_returns_400(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"niveau_experience": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+    assert "CONFIRME, DEBUTANT, EXPERT" in response.json()["error"]
 
 
 def test_returns_error_500(mock_offers_container, authenticated_client):
@@ -152,7 +269,7 @@ def test_pagination_page_arg(mock_offers_container, authenticated_client):
         mock_offers_container, num_offers=len(offers), offers_slice=offers[2:4]
     )
 
-    response = authenticated_client.get(URL, {"page": 2, "dummy": "arg", "active": 1})
+    response = authenticated_client.get(URL, {"page": 2, "dummy": "arg", "actif": 1})
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
@@ -165,8 +282,8 @@ def test_pagination_page_arg(mock_offers_container, authenticated_client):
     assert parse_qs(parsed_previous.query) == {
         "page": ["1"],
         "dummy": ["arg"],
-        "active": ["1"],
-        "size": ["2"],
+        "actif": ["1"],
+        "taille": ["2"],
     }
 
     parsed_next = urlparse(data["next"])
@@ -174,8 +291,8 @@ def test_pagination_page_arg(mock_offers_container, authenticated_client):
     assert parse_qs(parsed_next.query) == {
         "page": ["3"],
         "dummy": ["arg"],
-        "active": ["1"],
-        "size": ["2"],
+        "actif": ["1"],
+        "taille": ["2"],
     }
 
 
@@ -197,7 +314,7 @@ def test_pagination_out_of_bond(mock_offers_container, authenticated_client):
     assert parsed.path == URL
     assert parse_qs(parsed.query) == {
         "page": ["2"],
-        "size": ["2"],
+        "taille": ["2"],
     }
 
     assert data["next"] is None

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_detail.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_detail.py
@@ -294,7 +294,7 @@ class TestRecrutementListeView:
             _candidature_liste_read_models(5)
         )
 
-        response = authenticated_client.get(RECRUTEMENT_LISTE_URL + "?page=2&size=5")
+        response = authenticated_client.get(RECRUTEMENT_LISTE_URL + "?page=2&taille=5")
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert len(data["results"]) == 5  # noqa
@@ -302,7 +302,7 @@ class TestRecrutementListeView:
         assert data["previous"] is not None
 
     def test_no_next_on_last_page(self, authenticated_client):
-        data = authenticated_client.get(RECRUTEMENT_LISTE_URL + "?size=20").json()
+        data = authenticated_client.get(RECRUTEMENT_LISTE_URL + "?taille=20").json()
         assert data["next"] is None
         assert data["previous"] is None
 

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_listes.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_listes.py
@@ -51,7 +51,9 @@ class TestRecrutementsActifsView:
             RecrutementFactory.create_actif_read_model() for _ in range(2)
         ]
 
-        response = authenticated_client.get(RECRUTEMENTS_ACTIFS_URL + "?size=2&page=2")
+        response = authenticated_client.get(
+            RECRUTEMENTS_ACTIFS_URL + "?taille=2&page=2"
+        )
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert len(data["results"]) == 2  # noqa
@@ -156,7 +158,7 @@ class TestRecrutementsArchivesView:
         ]
 
         response = authenticated_client.get(
-            RECRUTEMENTS_ARCHIVES_URL + "?size=2&page=1"
+            RECRUTEMENTS_ARCHIVES_URL + "?taille=2&page=1"
         )
         assert response.status_code == status.HTTP_200_OK
         data = response.json()


### PR DESCRIPTION
## 📝 Description

## Nouveaux filtres sur `OffersListView`

Ajout de 4 filtres à valeurs multiples, alignés sur ceux déjà disponibles sur `/api/fake-ts/offersummaries`, avec des noms de paramètres en français :

| Paramètre URL | Champ interne | Enum |
|---|---|---|
| `actif` | `active` | booléen |
| `categorie` | `category` | `Category` |
| `versant` | `verse` | `Verse` |
| `type_contrat` | `contract_type` | `ContractType` |
| `niveau_experience` | `experience_level` | `ExperienceLevel` |

- Valeurs multiples séparées par une virgule (ex. `categorie=A,B`).
- Une valeur invalide renvoie désormais `400 Bad Request` (au lieu d'un `500` générique auparavant).
- `external_id_contains` a été retiré : ce filtre n'est plus accepté sur `/api/v1/offres`.

<img width="693" height="653" alt="Screenshot 2026-07-30 at 16 13 01" src="https://github.com/user-attachments/assets/3365c0d1-d3d4-45c7-b2e8-ef9ad15938a9" />


## Nouveau champ `_CommaSeparatedEnumField`

- Nouvelle classe dans `presentation/ingestion/serializers.py`, sous-classe de `MultipleChoiceField`.
- Accepte une chaîne CSV en entrée, valide contre les valeurs de l'enum, et restitue une liste ordonnée d'instances d'enum.
- Fait apparaître un vrai `enum: [...]` dans le schéma OpenAPI (au lieu d'une simple description texte).
- Réutilisée à la fois par `ListOffersFiltersSerializer` (noms FR) et `OfferSummariesQuerySerializer` (noms camelCase Talentsoft), éliminant la duplication des `validate_*` précédents.

## `WebPagination` (partagée par offres, sources, métiers, recruteur)

- Paramètre `size` renommé en `taille`.
- Le schéma OpenAPI documente désormais `default` et `minimum` pour `page` et `taille` (pas de changement de comportement à l'exécution).

## Documentation OpenAPI

- `LIST_OFFERS_DESCRIPTION` mise à jour pour lister les nouveaux filtres et leurs noms de paramètres.
- `schema.yaml` régénéré et validé (`spectacular --validate --fail-on-warn`).

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
