### PR TITLE
✨(api) ajouter des filtres management/workingPlace à OfferSummariesQuerySerializer

### DIFF
--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.1.20"
+version = "0.1.21"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/repositories/offers_repository_interface.py
+++ b/libs/referentiel/repositories/offers_repository_interface.py
@@ -7,6 +7,7 @@ from referentiel.entities.offer import Offer
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.verse import Verse
 
 
@@ -33,6 +34,8 @@ class IOffersRepository(Protocol):
         verse: Optional[List[Verse]] = None,
         contract_type: Optional[List[ContractType]] = None,
         experience_level: Optional[List[ExperienceLevel]] = None,
+        management: Optional[List[Management]] = None,
+        working_place: Optional[List[WorkingPlace]] = None,
     ) -> IPage[Offer]: ...
 
     def get_by_source_id(self, source_id: UUID) -> IPage[Offer]: ...

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1226,7 +1226,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/application/ingestion/interfaces/list_offers_input.py
+++ b/src/web/application/ingestion/interfaces/list_offers_input.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.verse import Verse
 
 
@@ -15,3 +16,5 @@ class GetFilteredOffersInput:
     verse: Optional[List[Verse]] = None
     contract_type: Optional[List[ContractType]] = None
     experience_level: Optional[List[ExperienceLevel]] = None
+    management: Optional[List[Management]] = None
+    working_place: Optional[List[WorkingPlace]] = None

--- a/src/web/application/ingestion/usecases/list_offers.py
+++ b/src/web/application/ingestion/usecases/list_offers.py
@@ -24,4 +24,6 @@ class ListOffersUseCase(IUseCase[GetFilteredOffersInput, IPage[Offer]]):
             verse=input_data.verse,
             contract_type=input_data.contract_type,
             experience_level=input_data.experience_level,
+            management=input_data.management,
+            working_place=input_data.working_place,
         )

--- a/src/web/infrastructure/factories/referentiel/offer_factory.py
+++ b/src/web/infrastructure/factories/referentiel/offer_factory.py
@@ -47,6 +47,7 @@ class OfferFactory:
         beginning_date: LimitDate | None = None,
         archived_at: datetime | None = None,
         criteria: dict | None = None,
+        conditions: dict | None = None,
     ) -> Offer:
         if archived_at:
             archived_at = timezone.make_aware(archived_at)
@@ -86,6 +87,7 @@ class OfferFactory:
             family_code=family_code,
             source_id=source_id or uuid4(),
             criteria=criteria,
+            conditions=conditions,
         )
 
     @staticmethod
@@ -110,6 +112,7 @@ class OfferFactory:
         processed_at: Optional[datetime] = None,
         archived_at: Optional[datetime] = None,
         criteria: Optional[dict] = None,
+        conditions: Optional[dict] = None,
     ) -> OfferModel:
         if processed_at:
             processed_at = timezone.make_aware(processed_at)
@@ -137,6 +140,7 @@ class OfferFactory:
             beginning_date=beginning_date,
             archived_at=archived_at,
             criteria=criteria,
+            conditions=conditions,
         )
 
         offer_model = _mapper.from_domain(offer)

--- a/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
+++ b/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
@@ -13,6 +13,7 @@ from referentiel.types import IUpsertResult
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.verse import Verse
 
 from domain.ingestion.repositories.ingestion_offers_repository_interface import (
@@ -160,6 +161,8 @@ class PostgresOffersRepository(IIngestionOffersRepository):
         verse: List[Verse] | None = None,
         contract_type: List[ContractType] | None = None,
         experience_level: List[ExperienceLevel] | None = None,
+        management: List[Management] | None = None,
+        working_place: List[WorkingPlace] | None = None,
     ) -> IPage[Offer]:
         qs = OfferModel.objects.filter(archived_at__isnull=active)
 
@@ -177,6 +180,14 @@ class PostgresOffersRepository(IIngestionOffersRepository):
 
         if experience_level:
             qs = qs.filter(criteria__experience__in=[e.name for e in experience_level])
+
+        if management:
+            qs = qs.filter(conditions__management__in=[m.name for m in management])
+
+        if working_place:
+            qs = qs.filter(
+                conditions__lieu_de_travail__in=[w.name for w in working_place]
+            )
 
         return QuerySetPage(qs.order_by("-updated_at"), self.mapper.to_domain)
 

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -126,6 +126,10 @@ class OfferSummariesQuerySerializer(serializers.Serializer):
     experienceLevel = _CommaSeparatedEnumField(
         ExperienceLevel, "niveau d'expérience", source="experience_level"
     )
+    management = _CommaSeparatedEnumField(Management, "management")
+    workingPlace = _CommaSeparatedEnumField(
+        WorkingPlace, "lieu de travail", source="working_place"
+    )
 
 
 class LocalisationInputSerializer(LocalisationSerializer):

--- a/src/web/presentation/ingestion/views/offer_summaries.py
+++ b/src/web/presentation/ingestion/views/offer_summaries.py
@@ -38,6 +38,8 @@ class OfferSummariesView(APIView):
                     verse=query.validated_data.get("verse"),
                     contract_type=query.validated_data.get("contract_type"),
                     experience_level=query.validated_data.get("experience_level"),
+                    management=query.validated_data.get("management"),
+                    working_place=query.validated_data.get("working_place"),
                 )
             )
 

--- a/src/web/tests/infrastructure/ingestion/test_list_offers.py
+++ b/src/web/tests/infrastructure/ingestion/test_list_offers.py
@@ -5,6 +5,7 @@ import pytest
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.verse import Verse
 
 from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
@@ -247,6 +248,84 @@ def test_list_offers_filtered_by_experience_level(
 
     assert {offer.external_id for offer in result._qs} == {
         offers_by_experience_level[key].external_id for key in expected_keys
+    }
+
+
+@pytest.fixture(name="offers_by_management")
+def offers_by_management_fixture(db):
+    return {
+        "sans": OfferFactory.create_model(
+            external_id="test-sans",
+            conditions={"management": Management.SANS.name},
+        ),
+        "avec": OfferFactory.create_model(
+            external_id="test-avec",
+            conditions={"management": Management.AVEC.name},
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "management, expected_keys",
+    [
+        pytest.param(None, ["sans", "avec"], id="no_filter"),
+        pytest.param([Management.SANS], ["sans"], id="single_management"),
+        pytest.param(
+            [Management.SANS, Management.AVEC],
+            ["sans", "avec"],
+            id="multiple_managements",
+        ),
+    ],
+)
+def test_list_offers_filtered_by_management(
+    ingestion_container, offers_by_management, management, expected_keys
+):
+    input_data = GetFilteredOffersInput(
+        active=True, external_id_contains=None, management=management
+    )
+    result = ingestion_container.list_offers_usecase().execute(input_data=input_data)
+
+    assert {offer.external_id for offer in result._qs} == {
+        offers_by_management[key].external_id for key in expected_keys
+    }
+
+
+@pytest.fixture(name="offers_by_working_place")
+def offers_by_working_place_fixture(db):
+    return {
+        "sur_site": OfferFactory.create_model(
+            external_id="test-sur-site",
+            conditions={"lieu_de_travail": WorkingPlace.SUR_SITE.name},
+        ),
+        "teletravail": OfferFactory.create_model(
+            external_id="test-teletravail",
+            conditions={"lieu_de_travail": WorkingPlace.TELETRAVAIL.name},
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    "working_place, expected_keys",
+    [
+        pytest.param(None, ["sur_site", "teletravail"], id="no_filter"),
+        pytest.param([WorkingPlace.SUR_SITE], ["sur_site"], id="single_working_place"),
+        pytest.param(
+            [WorkingPlace.SUR_SITE, WorkingPlace.TELETRAVAIL],
+            ["sur_site", "teletravail"],
+            id="multiple_working_places",
+        ),
+    ],
+)
+def test_list_offers_filtered_by_working_place(
+    ingestion_container, offers_by_working_place, working_place, expected_keys
+):
+    input_data = GetFilteredOffersInput(
+        active=True, external_id_contains=None, working_place=working_place
+    )
+    result = ingestion_container.list_offers_usecase().execute(input_data=input_data)
+
+    assert {offer.external_id for offer in result._qs} == {
+        offers_by_working_place[key].external_id for key in expected_keys
     }
 
 

--- a/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
+++ b/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
@@ -6,6 +6,7 @@ from drf_spectacular.generators import SchemaGenerator
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.verse import Verse
 from rest_framework import status
 
@@ -265,6 +266,62 @@ def test_invalid_experience_level_returns_400(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "INVALID" in response.json()["error"]
     assert "CONFIRME, DEBUTANT, EXPERT" in response.json()["error"]
+
+
+def test_management_filter_is_forwarded_to_usecase(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"management": "SANS,AVEC"})
+
+    mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            management=[Management.SANS, Management.AVEC],
+        )
+    )
+
+
+def test_invalid_management_returns_400(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"management": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+    assert "AVEC, SANS" in response.json()["error"]
+
+
+def test_working_place_filter_is_forwarded_to_usecase(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"workingPlace": "SUR_SITE,TELETRAVAIL"})
+
+    mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            working_place=[WorkingPlace.SUR_SITE, WorkingPlace.TELETRAVAIL],
+        )
+    )
+
+
+def test_invalid_working_place_returns_400(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"workingPlace": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+    assert "NON_DEFINI, SUR_SITE, TELETRAVAIL" in response.json()["error"]
 
 
 def test_returns_error_500(mock_offer_summaries_container, authenticated_client):

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },


### PR DESCRIPTION
## 📝 Description
Permet de filtrer `/api/fake-ts/offersummaries` sur `conditions.management` et `conditions.lieu_de_travail`, sur le même modèle que les filtres `category/verse/contractType/experienceLevel` existants.

En lien avec https://github.com/betagouv/csplab/issues/941

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
