### PR TITLE
♻️(api) renommer le paramètre domain en domaine sur ListMetiersFiltersSerializer

### DIFF
--- a/src/web/presentation/ingestion/openapi.py
+++ b/src/web/presentation/ingestion/openapi.py
@@ -336,7 +336,7 @@ LIST_METIERS_DESCRIPTION = (
 # API de consultation des métiers de la Fonction Publique
 
 Cette API retourne la liste paginée des métiers. Les métiers peuvent être filtrés
-selon leur code de domaine fonctionnel (`domain`).
+selon leur code de domaine fonctionnel (`domaine`).
 
 """
     + _API_COMMON_FOOTER

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -243,7 +243,7 @@ class ListMetiersResponseSerializer(serializers.Serializer):
 
 
 class ListMetiersFiltersSerializer(serializers.Serializer):
-    domain = serializers.CharField(default=None, max_length=3)
+    domaine = serializers.CharField(default=None, max_length=3, source="domain")
 
 
 class IdentityInputSerializer(serializers.Serializer):

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -232,7 +232,7 @@ paths:
         # API de consultation des métiers de la Fonction Publique
 
         Cette API retourne la liste paginée des métiers. Les métiers peuvent être filtrés
-        selon leur code de domaine fonctionnel (`domain`).
+        selon leur code de domaine fonctionnel (`domaine`).
 
 
         Cette API est à l'usage exclusif des personnes autorisées.
@@ -248,7 +248,7 @@ paths:
       summary: Liste des métiers
       parameters:
       - in: query
-        name: domain
+        name: domaine
         schema:
           type: string
           maxLength: 3

--- a/src/web/tests/presentation/ingestion/views/test_list_metiers.py
+++ b/src/web/tests/presentation/ingestion/views/test_list_metiers.py
@@ -80,7 +80,7 @@ def test_call_without_arg(mock_metiers_container, authenticated_client):
 def test_call_with_args(mock_metiers_container, authenticated_client, domain):
     _make_paginated_mock(mock_metiers_container, num_metiers=0, metiers_slice=[])
 
-    params = {"domain": domain} if domain else {}
+    params = {"domaine": domain} if domain else {}
     authenticated_client.get(URL, params)
 
     mock_metiers_container.list_metiers_usecase.return_value.execute.assert_called_once_with(
@@ -160,7 +160,7 @@ def test_pagination_out_of_bond(mock_metiers_container, authenticated_client):
 def test_invalid_payload(mock_metiers_container, authenticated_client):
     _make_paginated_mock(mock_metiers_container, num_metiers=0, metiers_slice=[])
 
-    response = authenticated_client.get(URL, {"domain": "ABCD"})
+    response = authenticated_client.get(URL, {"domaine": "ABCD"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "error" in response.json().keys()


### PR DESCRIPTION
## 📝 Description

Avoir un paramètre en français pour l'API métiers.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
