### PR TITLE
🐛(api) exclure les requêtes API key du throttle UserRateThrottle

### DIFF
--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -338,7 +338,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_THROTTLE_CLASSES": [
         "rest_framework.throttling.AnonRateThrottle",
-        "rest_framework.throttling.UserRateThrottle",
+        "infrastructure.authentication.api_key_authentication.NonApiKeyUserRateThrottle",
         "infrastructure.authentication.api_key_authentication.ApiKeyRateThrottle",
         "infrastructure.authentication.api_key_authentication.ApiKeyRateThrottleDaily",
     ],

--- a/src/web/infrastructure/authentication/api_key_authentication.py
+++ b/src/web/infrastructure/authentication/api_key_authentication.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.throttling import SimpleRateThrottle
+from rest_framework.throttling import SimpleRateThrottle, UserRateThrottle
 
 
 class _IngestionApiKeyUser:
@@ -79,3 +79,15 @@ class ApiKeyRateThrottle(SimpleRateThrottle):
 
 class ApiKeyRateThrottleDaily(ApiKeyRateThrottle):
     scope = "api_key_daily"
+
+
+class NonApiKeyUserRateThrottle(UserRateThrottle):
+    """
+    UserRateThrottle that skips ingestion API key requests, which are rate-limited
+    by ApiKeyRateThrottle / ApiKeyRateThrottleDaily instead.
+    """
+
+    def get_cache_key(self, request, view):
+        if isinstance(request.user, _IngestionApiKeyUser):
+            return None
+        return super().get_cache_key(request, view)

--- a/src/web/tests/infrastructure/authentification/test_api_key_authentication.py
+++ b/src/web/tests/infrastructure/authentification/test_api_key_authentication.py
@@ -9,6 +9,7 @@ from infrastructure.authentication.api_key_authentication import (
     ApiKeyAuthentication,
     ApiKeyRateThrottle,
     ApiKeyRateThrottleDaily,
+    NonApiKeyUserRateThrottle,
     _IngestionApiKeyUser,
     _ip_is_allowed,
 )
@@ -239,3 +240,28 @@ class TestApiKeyRateThrottleAndDailyBothTrack:
 
         assert hourly.allow_request(request, view=None) is False
         assert daily.allow_request(request, view=None) is True
+
+
+class TestNonApiKeyUserRateThrottle:
+    def test_returns_none_for_api_key_user(self, rf):
+        request = rf.get("/")
+        request.user = API_KEY_USER
+        throttle = NonApiKeyUserRateThrottle()
+        assert throttle.get_cache_key(request, view=None) is None
+
+    @patch.object(NonApiKeyUserRateThrottle, "THROTTLE_RATES", {"user": "2/minute"})
+    def test_does_not_throttle_api_key_user(self, rf):
+        cache.clear()
+        request = rf.get("/")
+        request.user = API_KEY_USER
+        for _ in range(10):
+            assert NonApiKeyUserRateThrottle().allow_request(request, view=None) is True
+
+    @patch.object(NonApiKeyUserRateThrottle, "THROTTLE_RATES", {"user": "2/minute"})
+    def test_still_throttles_regular_authenticated_user(self, rf):
+        cache.clear()
+        request = rf.get("/")
+        request.user = type("User", (), {"is_authenticated": True, "pk": 1})()
+        for _ in range(2):
+            assert NonApiKeyUserRateThrottle().allow_request(request, view=None) is True
+        assert NonApiKeyUserRateThrottle().allow_request(request, view=None) is False


### PR DESCRIPTION
## 📝 Description

Les requêtes authentifiées via la clé API d'ingestion partageaient toutes le même throttle "user" (120/minute), causant des 429 inattendus lors de bursts d'ingestion alors que les limites api_key (70000/heure et 100000/jour) prévues pour cet usage n'étaient pas atteintes.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
