### PR TITLE
✨(api) utiliser Redis comme backend de cache pour le throttling

### DIFF
--- a/env.d/web-example
+++ b/env.d/web-example
@@ -18,6 +18,9 @@ WEB_DATABASE_URL=psql://web:pass@localhost:5432/web
 
 #redis
 WEB_REDIS_URL=redis://localhost:6379/0
+# DB used for Django's cache (API throttling), distinct from the Huey queue DB above (0)
+# and from the ingestion service's Celery broker DB (1) on the same shared Redis instance
+WEB_REDIS_CACHE_DB=2
 
 # Third-party integrations
 

--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -45,6 +45,7 @@ env = environ.Env(
     WEB_QDRANT_API_KEY=(str, ""),
     WEB_REDIS_URL=(str, "redis://localhost:6379"),
     WEB_REDIS_DB=(str, "0"),
+    WEB_REDIS_CACHE_DB=(str, "2"),
     WEB_ROBOTS_INDEXING=(bool, True),
 )
 env.prefix = "WEB_"
@@ -393,6 +394,15 @@ if _sentry_dsn:
         traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE"),
         profiles_sample_rate=env.float("SENTRY_PROFILES_SAMPLE_RATE"),
     )
+
+# Cache config (used for API throttling, see DEFAULT_THROTTLE_CLASSES above)
+REDIS_CACHE_DB = env.str("REDIS_CACHE_DB")
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"{env.str('REDIS_URL')}/?db={REDIS_CACHE_DB}",
+    },
+}
 
 # Huey config
 REDIS_URL = env.str("REDIS_URL")

--- a/src/web/config/settings/test.py
+++ b/src/web/config/settings/test.py
@@ -1,4 +1,18 @@
+import os
+
 from config.settings.base import *  # noqa E402 F403
+
+# Give each pytest-xdist worker its own Redis DB. Django's RedisCache.clear()
+# runs FLUSHDB, which ignores KEY_PREFIX and wipes the whole db, so a key
+# prefix alone isn't enough to keep parallel workers from clobbering each
+# other's throttle counters; a dedicated db per worker is.
+_xdist_worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+_worker_index = (
+    int(_xdist_worker.removeprefix("gw")) if _xdist_worker.startswith("gw") else 0
+)
+CACHES["default"]["LOCATION"] = (  # noqa: F405
+    f"{env.str('REDIS_URL')}/?db={int(REDIS_CACHE_DB) + 1 + _worker_index}"  # noqa: F405
+)
 
 STORAGES = {
     "staticfiles": {


### PR DESCRIPTION
## 📝 Description

Le cache par défaut de Django (LocMemCache, en mémoire par process) ne partage pas les compteurs de throttle DRF entre les workers de l'app, ce qui rend la limitation de débit inefficace en production. Utilise le backend Redis natif de Django sur une DB dédiée, distincte de celle de Huey et de celle du broker Celery de l'ingestion sur la même instance Redis partagée.

En test, chaque worker pytest-xdist reçoit sa propre DB Redis : le cache.clear() du backend Redis fait un FLUSHDB, qui ignore KEY_PREFIX et viderait la DB de tous les autres workers en parallèle.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
