### PR TITLE
✨(ats-recrutement) Modification des étapes de recrutement au niveau d'une offre

### DIFF
--- a/src/web/presentation/frontend/src/app/icons.ts
+++ b/src/web/presentation/frontend/src/app/icons.ts
@@ -46,6 +46,7 @@ import riMapPin2Line from '@iconify-icons/ri/map-pin-2-line'
 import riMenuLine from '@iconify-icons/ri/menu-line'
 import riMoonLine from '@iconify-icons/ri/moon-line'
 import riMore2Fill from '@iconify-icons/ri/more-2-fill'
+import riMoreFill from '@iconify-icons/ri/more-fill'
 import riNotification3Line from '@iconify-icons/ri/notification-3-line'
 import riPriceTag3Line from '@iconify-icons/ri/price-tag-3-line'
 import riPushpin2Line from '@iconify-icons/ri/pushpin-2-line'
@@ -119,6 +120,7 @@ addIcon('ri:sidebar-unfold-line', {
   body: '<path fill="currentColor" d="M5 5h8v14H5zm14 14h-4V5h4zM4 3a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zm7 9L7 8.5v7z"/>',
 })
 addIcon('ri:more-2-fill', riMore2Fill)
+addIcon('ri:more-fill', riMoreFill)
 addIcon('ri:notification-3-line', riNotification3Line)
 addIcon('ri:price-tag-3-line', riPriceTag3Line)
 addIcon('ri:progress-4-line', {

--- a/src/web/presentation/frontend/src/components/layout/CspPageHeader/CspPageHeader.vue
+++ b/src/web/presentation/frontend/src/components/layout/CspPageHeader/CspPageHeader.vue
@@ -154,6 +154,7 @@ const hasBreadcrumb = computed(() => Boolean(props.breadcrumb?.length))
 .csp-page-header__actions {
   display: flex;
   align-items: center;
+  align-self: flex-start;
   gap: 0.5rem;
   flex-shrink: 0;
 }

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -2,8 +2,9 @@
 import type { CspBreadcrumbItem } from '@/components/base/CspBreadcrumb/CspBreadcrumb.vue'
 import type { CspTabItem } from '@/components/base/CspTabs/CspTabs.vue'
 import { computed, ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import CspButton from '@/components/base/CspButton/CspButton.vue'
+import CspDropdownMenu from '@/components/base/CspDropdownMenu/CspDropdownMenu.vue'
 import CspEmptyState from '@/components/base/CspEmptyState/CspEmptyState.vue'
 import CspErrorState from '@/components/base/CspErrorState/CspErrorState.vue'
 import CspInput from '@/components/base/CspInput/CspInput.vue'
@@ -18,6 +19,7 @@ import { useCandidatures } from '../composables/useCandidatures'
 import { formatRecrutementMeta } from '../format'
 
 const route = useRoute()
+const router = useRouter()
 const recrutementUuid = route.params.recrutementUuid as string
 
 const {
@@ -81,6 +83,17 @@ const currentView = computed(() => {
   return route.name === 'recrutement-candidatures-kanban' ? 'kanban' : 'liste'
 })
 
+const headerMenuSections = [{
+  items: [{
+    label: 'Personnaliser les étapes de recrutement',
+    icon: 'ri:table-line',
+    onSelect: () => router.push({
+      name: 'recrutement-etapes-recrutement',
+      params: { recrutementUuid },
+    }),
+  }],
+}]
+
 const TABS: CspTabItem[] = [
   { value: 'candidatures', label: 'Candidatures' },
   { value: 'activites-et-taches', label: 'Activités et tâches' },
@@ -96,6 +109,22 @@ const activeTab = ref<'candidatures' | 'activites-et-taches'>('candidatures')
     :show-title-skeleton="showTitleSkeleton"
     :show-subtitle-skeleton="showSubtitleSkeleton"
   >
+    <template #actions>
+      <CspDropdownMenu
+        :sections="headerMenuSections"
+        side="bottom"
+        align="end"
+      >
+        <template #trigger>
+          <CspButton
+            icon="ri:more-fill"
+            variant="tertiary"
+            size="sm"
+            aria-label="Actions sur l’offre"
+          />
+        </template>
+      </CspDropdownMenu>
+    </template>
     <template #subtitle>
       <CspMetaList :items="metaItems" />
     </template>

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/api.ts
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/api.ts
@@ -25,3 +25,59 @@ export async function initEtapesRecrutement(organismeUuid: string): Promise<Etap
   })
   return data!
 }
+
+export async function getEtapesOffre(
+  organismeUuid: string,
+  recrutementUuid: string,
+): Promise<EtapeRecrutement[]> {
+  const { data } = await api.GET(
+    '/recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes',
+    {
+      params: {
+        path: {
+          organisme_uuid: organismeUuid,
+          recrutement_uuid: recrutementUuid,
+        },
+      },
+    },
+  )
+  return data!
+}
+
+export async function updateEtapesOffre(
+  organismeUuid: string,
+  recrutementUuid: string,
+  etapes: UpdateEtapeRecrutement[],
+): Promise<EtapeRecrutement[]> {
+  const { data } = await api.PATCH(
+    '/recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes',
+    {
+      params: {
+        path: {
+          organisme_uuid: organismeUuid,
+          recrutement_uuid: recrutementUuid,
+        },
+      },
+      body: etapes,
+    },
+  )
+  return data!
+}
+
+export async function initEtapesOffre(
+  organismeUuid: string,
+  recrutementUuid: string,
+): Promise<EtapeRecrutement[]> {
+  const { data } = await api.POST(
+    '/recruteur/organisme/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes/init',
+    {
+      params: {
+        path: {
+          organisme_uuid: organismeUuid,
+          recrutement_uuid: recrutementUuid,
+        },
+      },
+    },
+  )
+  return data!
+}

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/components/EtapesRecrutementList.vue
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/components/EtapesRecrutementList.vue
@@ -28,7 +28,7 @@ const {
   renameEtape,
   removeEtape,
   resetEtapes,
-} = useEtapesRecrutement(TEMP_ORGANISME_UUID)
+} = useEtapesRecrutement({ type: 'organisme', organismeUuid: TEMP_ORGANISME_UUID })
 
 const showSkeleton = useMinimumPending(loading)
 

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/components/EtapesRecrutementList.vue
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/components/EtapesRecrutementList.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { EtapesRecrutementType } from '../composables/useEtapesRecrutement'
+import type { EtapesListeTexts } from '../constants/etape-recrutement'
 import type { EtapeRecrutement } from '../types'
 import { ref, watch } from 'vue'
 import CspAsyncSection from '@/components/base/CspAsyncSection/CspAsyncSection.vue'
@@ -12,9 +14,13 @@ import CspSkeletonSortableList from '@/components/base/CspSkeleton/CspSkeletonSo
 import CspSortableList from '@/components/base/CspSortableList/CspSortableList.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
 import { useToast } from '@/composables/ui/useToast'
-import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import { useEtapesRecrutement } from '../composables/useEtapesRecrutement'
 import { CATEGORIE_CONFIG } from '../constants/etape-recrutement'
+
+const props = defineProps<{
+  params: EtapesRecrutementType
+  texts: EtapesListeTexts
+}>()
 
 const {
   etapes,
@@ -28,7 +34,7 @@ const {
   renameEtape,
   removeEtape,
   resetEtapes,
-} = useEtapesRecrutement({ type: 'organisme', organismeUuid: TEMP_ORGANISME_UUID })
+} = useEtapesRecrutement(props.params)
 
 const showSkeleton = useMinimumPending(loading)
 
@@ -189,7 +195,7 @@ function getMenuSections(
     <div class="etapes-list__main">
       <header class="etapes-list__header">
         <h2 class="etapes-list__title">
-          Étapes de recrutement
+          {{ texts.title }}
         </h2>
         <div class="etapes-list__actions">
           <CspButton
@@ -266,8 +272,8 @@ function getMenuSections(
     <aside class="etapes-list__aside">
       <CspCallout
         variant="info"
-        title="Modification des étapes de recrutement"
-        description="Ce modèle d'étapes sera appliqué par défaut à tous les nouveaux recrutements. Les modifications apportées à ce modèle ne s'appliqueront qu'aux nouvelles offres."
+        :title="texts.calloutTitle"
+        :description="texts.calloutDescription"
       />
     </aside>
 
@@ -325,7 +331,7 @@ function getMenuSections(
     <CspDialog
       v-model:open="resetModalOpen"
       title="Réinitialiser les étapes"
-      description="Voulez-vous vraiment réinitialiser les étapes de recrutement ? Toutes vos personnalisations seront perdues et remplacées par la configuration par défaut."
+      :description="texts.resetDescription"
       size="sm"
     >
       <template #footer>

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/composables/useEtapesRecrutement.test.ts
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/composables/useEtapesRecrutement.test.ts
@@ -1,4 +1,5 @@
 import type { EtapeRecrutement, UpdateEtapeRecrutement } from '../types'
+import type { EtapesRecrutementType } from './useEtapesRecrutement'
 import { PiniaColada } from '@pinia/colada'
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
@@ -7,15 +8,22 @@ import { defineComponent, h } from 'vue'
 import { useEtapesRecrutement } from './useEtapesRecrutement'
 
 const ORGANISME_UUID = '00000000-0000-0000-0000-000000000001'
+const RECRUTEMENT_UUID = '00000000-0000-0000-0000-000000000002'
 
 const mockGetEtapesRecrutement = vi.fn()
 const mockUpdateEtapesRecrutement = vi.fn()
 const mockInitEtapesRecrutement = vi.fn()
+const mockGetEtapesOffre = vi.fn()
+const mockUpdateEtapesOffre = vi.fn()
+const mockInitEtapesOffre = vi.fn()
 
 vi.mock('../api', () => ({
   getEtapesRecrutement: (...args: unknown[]) => mockGetEtapesRecrutement(...args),
   updateEtapesRecrutement: (...args: unknown[]) => mockUpdateEtapesRecrutement(...args),
   initEtapesRecrutement: (...args: unknown[]) => mockInitEtapesRecrutement(...args),
+  getEtapesOffre: (...args: unknown[]) => mockGetEtapesOffre(...args),
+  updateEtapesOffre: (...args: unknown[]) => mockUpdateEtapesOffre(...args),
+  initEtapesOffre: (...args: unknown[]) => mockInitEtapesOffre(...args),
 }))
 
 const DEFAULT_ETAPES: EtapeRecrutement[] = [
@@ -26,12 +34,14 @@ const DEFAULT_ETAPES: EtapeRecrutement[] = [
   { etape_uuid: 'eeee', nom: 'Recrutement', categorie: 'ACCEPTE' },
 ]
 
-async function mountEtapes() {
+async function mountEtapes(
+  params: EtapesRecrutementType = { type: 'organisme', organismeUuid: ORGANISME_UUID },
+) {
   let result!: ReturnType<typeof useEtapesRecrutement>
 
   mount(defineComponent({
     setup() {
-      result = useEtapesRecrutement(ORGANISME_UUID)
+      result = useEtapesRecrutement(params)
       return () => h('div')
     },
   }), {
@@ -156,5 +166,49 @@ describe('useEtapesRecrutement', () => {
     const payload = lastUpdatePayload()
     expect(payload).toHaveLength(etapesSansFinales.length + 1)
     expect(payload.at(-1)).toEqual({ nom: 'Test technique', categorie: 'EN_COURS' })
+  })
+})
+
+describe('useEtapesRecrutement — type offre', () => {
+  const PARAMS_OFFRE: EtapesRecrutementType = {
+    type: 'offre',
+    organismeUuid: ORGANISME_UUID,
+    recrutementUuid: RECRUTEMENT_UUID,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetEtapesOffre.mockResolvedValue(DEFAULT_ETAPES)
+    mockUpdateEtapesOffre.mockResolvedValue(DEFAULT_ETAPES)
+  })
+
+  it('loads etapes from the offre endpoint', async () => {
+    const { etapes } = await mountEtapes(PARAMS_OFFRE)
+
+    expect(mockGetEtapesOffre).toHaveBeenCalledWith(ORGANISME_UUID, RECRUTEMENT_UUID)
+    expect(mockGetEtapesRecrutement).not.toHaveBeenCalled()
+    expect(etapes.value).toEqual(DEFAULT_ETAPES)
+  })
+
+  it('persists changes on the offre endpoint', async () => {
+    const { renameEtape } = await mountEtapes(PARAMS_OFFRE)
+    await renameEtape('bbbb', 'Présélection RH')
+
+    const [organismeUuid, recrutementUuid, payload] = mockUpdateEtapesOffre.mock.calls[0]!
+    expect(organismeUuid).toBe(ORGANISME_UUID)
+    expect(recrutementUuid).toBe(RECRUTEMENT_UUID)
+    expect((payload as UpdateEtapeRecrutement[]).find(p => p.etape_uuid === 'bbbb')?.nom)
+      .toBe('Présélection RH')
+    expect(mockUpdateEtapesRecrutement).not.toHaveBeenCalled()
+  })
+
+  it('resets etapes on the offre endpoint', async () => {
+    mockInitEtapesOffre.mockResolvedValue(DEFAULT_ETAPES)
+
+    const { etapes, resetEtapes } = await mountEtapes(PARAMS_OFFRE)
+    await resetEtapes()
+
+    expect(mockInitEtapesOffre).toHaveBeenCalledWith(ORGANISME_UUID, RECRUTEMENT_UUID)
+    expect(etapes.value).toEqual(DEFAULT_ETAPES)
   })
 })

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/composables/useEtapesRecrutement.ts
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/composables/useEtapesRecrutement.ts
@@ -1,8 +1,17 @@
 import type { EtapeRecrutement, UpdateEtapeRecrutement } from '../types'
 import { useMutation, useQuery, useQueryCache } from '@pinia/colada'
 import { computed } from 'vue'
-import { initEtapesRecrutement, updateEtapesRecrutement } from '../api'
-import { etapesRecrutementQuery } from '../queries'
+import {
+  initEtapesOffre,
+  initEtapesRecrutement,
+  updateEtapesOffre,
+  updateEtapesRecrutement,
+} from '../api'
+import { etapesOffreQuery, etapesRecrutementQuery } from '../queries'
+
+export type EtapesRecrutementType
+  = | { type: 'organisme', organismeUuid: string }
+    | { type: 'offre', organismeUuid: string, recrutementUuid: string }
 
 function toUpdatePayload(items: EtapeRecrutement[]): UpdateEtapeRecrutement[] {
   return items.map((etape) => {
@@ -36,9 +45,30 @@ function insertEtape(
   return [...etapes.slice(0, insertAt), nouvelle, ...etapes.slice(insertAt)]
 }
 
-export function useEtapesRecrutement(organismeUuid: string) {
+function resolveEtapesApi(params: EtapesRecrutementType) {
+  if (params.type === 'offre') {
+    const { organismeUuid, recrutementUuid } = params
+    return {
+      queryOptions: etapesOffreQuery({ organismeUuid, recrutementUuid }),
+      update: (payload: UpdateEtapeRecrutement[]) =>
+        updateEtapesOffre(organismeUuid, recrutementUuid, payload),
+      init: () => initEtapesOffre(organismeUuid, recrutementUuid),
+    }
+  }
+
+  const { organismeUuid } = params
+  return {
+    queryOptions: etapesRecrutementQuery({ organismeUuid }),
+    update: (payload: UpdateEtapeRecrutement[]) =>
+      updateEtapesRecrutement(organismeUuid, payload),
+    init: () => initEtapesRecrutement(organismeUuid),
+  }
+}
+
+export function useEtapesRecrutement(params: EtapesRecrutementType) {
   const queryCache = useQueryCache()
-  const queryOptions = etapesRecrutementQuery({ organismeUuid })
+  const etapesApi = resolveEtapesApi(params)
+  const queryOptions = etapesApi.queryOptions
   const query = useQuery(queryOptions)
 
   const etapes = computed(() => query.data.value ?? [])
@@ -48,13 +78,12 @@ export function useEtapesRecrutement(organismeUuid: string) {
   }
 
   const update = useMutation({
-    mutation: (payload: UpdateEtapeRecrutement[]) =>
-      updateEtapesRecrutement(organismeUuid, payload),
+    mutation: (payload: UpdateEtapeRecrutement[]) => etapesApi.update(payload),
     onSuccess: applyFreshEtapes,
   })
 
   const init = useMutation({
-    mutation: () => initEtapesRecrutement(organismeUuid),
+    mutation: () => etapesApi.init(),
     onSuccess: applyFreshEtapes,
   })
 

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/constants/etape-recrutement.ts
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/constants/etape-recrutement.ts
@@ -16,3 +16,24 @@ export const CATEGORIE_CONFIG: Record<Categorie, CategorieConfig> = {
   REFUS: { label: 'Refusée', icon: 'ri:close-circle-line', type: 'error', cssModifier: 'refus' },
   ACCEPTE: { label: 'Acceptée', icon: 'ri:checkbox-circle-line', type: 'success', cssModifier: 'accepte' },
 }
+
+export interface EtapesListeTexts {
+  title: string
+  calloutTitle: string
+  calloutDescription: string
+  resetDescription: string
+}
+
+export const ETAPES_TEXTS_ORGANISME: EtapesListeTexts = {
+  title: 'Étapes de recrutement',
+  calloutTitle: 'Modification des étapes de recrutement',
+  calloutDescription: 'Ce modèle d\'étapes sera appliqué par défaut à tous les nouveaux recrutements. Les modifications apportées à ce modèle ne s\'appliqueront qu\'aux nouvelles offres.',
+  resetDescription: 'Voulez-vous vraiment réinitialiser les étapes de recrutement ? Toutes vos personnalisations seront perdues et remplacées par la configuration par défaut.',
+}
+
+export const ETAPES_TEXTS_OFFRE: EtapesListeTexts = {
+  title: 'Étapes de recrutement',
+  calloutTitle: 'Modification des étapes de recrutement',
+  calloutDescription: 'Ces étapes ne s\'appliquent qu\'à cette offre et remplacent le modèle défini dans les paramètres de l\'organisme. Une étape ne doit pas contenir de candidature pour pouvoir être supprimée.',
+  resetDescription: 'Voulez-vous vraiment réinitialiser les étapes de cette offre ? Vos personnalisations seront perdues et remplacées par le modèle de l\'organisme.',
+}

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/queries.ts
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/queries.ts
@@ -1,15 +1,24 @@
 import { defineQueryOptions } from '@pinia/colada'
-import { getEtapesRecrutement } from './api'
+import { getEtapesOffre, getEtapesRecrutement } from './api'
 
 export const ETAPES_RECRUTEMENT_QUERY_KEYS = {
   root: ['etapes-recrutement'] as const,
   byOrganisme: (organismeUuid: string) =>
     [...ETAPES_RECRUTEMENT_QUERY_KEYS.root, organismeUuid] as const,
+  byOffre: (organismeUuid: string, recrutementUuid: string) =>
+    [...ETAPES_RECRUTEMENT_QUERY_KEYS.root, 'offre', organismeUuid, recrutementUuid] as const,
 }
 
 export const etapesRecrutementQuery = defineQueryOptions(
   ({ organismeUuid }: { organismeUuid: string }) => ({
     key: ETAPES_RECRUTEMENT_QUERY_KEYS.byOrganisme(organismeUuid),
     query: () => getEtapesRecrutement(organismeUuid),
+  }),
+)
+
+export const etapesOffreQuery = defineQueryOptions(
+  ({ organismeUuid, recrutementUuid }: { organismeUuid: string, recrutementUuid: string }) => ({
+    key: ETAPES_RECRUTEMENT_QUERY_KEYS.byOffre(organismeUuid, recrutementUuid),
+    query: () => getEtapesOffre(organismeUuid, recrutementUuid),
   }),
 )

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/routes.ts
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/routes.ts
@@ -1,0 +1,9 @@
+import type { RouteRecordRaw } from 'vue-router'
+
+export const etapesRecrutementRoutes: RouteRecordRaw[] = [
+  {
+    path: '/mes-recrutements/:recrutementUuid/etapes-recrutement',
+    name: 'recrutement-etapes-recrutement',
+    component: () => import('./views/OffreEtapesRecrutementView.vue'),
+  },
+]

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/views/OffreEtapesRecrutementView.vue
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/views/OffreEtapesRecrutementView.vue
@@ -8,6 +8,8 @@ import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import { recrutementKanbanQuery } from '@/features/candidatures/queries'
 import { peekRecrutementIntitule } from '@/features/recrutements/queries'
+import EtapesRecrutementList from '../components/EtapesRecrutementList.vue'
+import { ETAPES_TEXTS_OFFRE } from '../constants/etape-recrutement'
 
 const route = useRoute()
 const recrutementUuid = route.params.recrutementUuid as string
@@ -40,11 +42,13 @@ const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
 <template>
   <CspPageHeader
     :breadcrumb="breadcrumb"
-    title="Personnaliser les étapes de recrutement"
+    title="Personnaliser les étapes de recrutement de l'offre"
     :back-link="{ to: candidaturesRoute, label: 'Retour à l’offre' }"
   />
-  <CspPageContainer
-    fill
-    width="full"
-  />
+  <CspPageContainer width="reading">
+    <EtapesRecrutementList
+      :params="{ type: 'offre', organismeUuid: TEMP_ORGANISME_UUID, recrutementUuid }"
+      :texts="ETAPES_TEXTS_OFFRE"
+    />
+  </CspPageContainer>
 </template>

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/views/OffreEtapesRecrutementView.vue
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/views/OffreEtapesRecrutementView.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { CspBreadcrumbItem } from '@/components/base/CspBreadcrumb/CspBreadcrumb.vue'
+import { useQuery, useQueryCache } from '@pinia/colada'
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContainer.vue'
+import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
+import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
+import { recrutementKanbanQuery } from '@/features/candidatures/queries'
+import { peekRecrutementIntitule } from '@/features/recrutements/queries'
+
+const route = useRoute()
+const recrutementUuid = route.params.recrutementUuid as string
+
+const queryCache = useQueryCache()
+
+const { data: recrutementDetail } = useQuery(() => recrutementKanbanQuery({
+  organismeUuid: TEMP_ORGANISME_UUID,
+  recrutementUuid,
+}))
+
+const intitule = computed<string | null>(() =>
+  recrutementDetail.value?.intitule
+  ?? peekRecrutementIntitule(queryCache, TEMP_ORGANISME_UUID, recrutementUuid),
+)
+
+const candidaturesRoute = computed(() => ({
+  name: 'recrutement-candidatures-kanban',
+  params: { recrutementUuid },
+}))
+
+const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
+  { label: 'Accueil', to: { name: 'home' } },
+  { label: 'Mes recrutements', to: { name: 'mes-recrutements' } },
+  ...(intitule.value ? [{ label: intitule.value, to: candidaturesRoute.value }] : []),
+  { label: 'Étapes de recrutement' },
+])
+</script>
+
+<template>
+  <CspPageHeader
+    :breadcrumb="breadcrumb"
+    title="Personnaliser les étapes de recrutement"
+    :back-link="{ to: candidaturesRoute, label: 'Retour à l’offre' }"
+  />
+  <CspPageContainer
+    fill
+    width="full"
+  />
+</template>

--- a/src/web/presentation/frontend/src/router/index.ts
+++ b/src/web/presentation/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { candidaturesRoutes } from '@/features/candidatures/routes'
+import { etapesRecrutementRoutes } from '@/features/etapes-recrutement/routes'
 import { recrutementsRoutes } from '@/features/recrutements/routes'
 
 const appRoutes: RouteRecordRaw[] = [
@@ -15,4 +16,9 @@ const appRoutes: RouteRecordRaw[] = [
   },
 ]
 
-export const routes: RouteRecordRaw[] = [...appRoutes, ...recrutementsRoutes, ...candidaturesRoutes]
+export const routes: RouteRecordRaw[] = [
+  ...appRoutes,
+  ...recrutementsRoutes,
+  ...candidaturesRoutes,
+  ...etapesRecrutementRoutes,
+]

--- a/src/web/presentation/frontend/src/views/ParametresView.vue
+++ b/src/web/presentation/frontend/src/views/ParametresView.vue
@@ -5,7 +5,9 @@ import { ref } from 'vue'
 import CspMetaList from '@/components/base/CspMeta/CspMetaList.vue'
 import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContainer.vue'
 import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
+import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import EtapesRecrutementList from '@/features/etapes-recrutement/components/EtapesRecrutementList.vue'
+import { ETAPES_TEXTS_ORGANISME } from '@/features/etapes-recrutement/constants/etape-recrutement'
 
 const BREADCRUMB: CspBreadcrumbItem[] = [
   { label: 'Accueil', to: { name: 'home' } },
@@ -40,7 +42,10 @@ const metaItem: CspMetaItem = {
     :tabs="tabs"
   >
     <template #tab-etapes>
-      <EtapesRecrutementList />
+      <EtapesRecrutementList
+        :params="{ type: 'organisme', organismeUuid: TEMP_ORGANISME_UUID }"
+        :texts="ETAPES_TEXTS_ORGANISME"
+      />
     </template>
   </CspPageContainer>
 </template>


### PR DESCRIPTION
## 📝 Description
Création de la vue pour modifier les étapes de recrutement au niveau d'une offre

useEtapesRecrutement.ts accepte désormais { type: 'organisme', organismeUuid } ou { type: 'offre', organismeUuid, recrutementUuid }, résolution de la bonne query/mutation via resolveEtapesApi, logique métier partagée.

EtapesRecrutementList.vue prend params + texts en props (au lieu d'être câblé en dur sur l'organisme)

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)
<img width="1511" height="835" alt="Capture d’écran 2026-08-04 à 11 33 24" src="https://github.com/user-attachments/assets/9f19fe9f-9945-44e7-9b4e-6b7bfb61dd5d" />
<img width="1509" height="833" alt="Capture d’écran 2026-08-04 à 11 33 34" src="https://github.com/user-attachments/assets/0374e98c-4a9d-4be2-80cd-124544b93d20" />

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
