### PR TITLE
✨(api) valider domaine et metier RMFP sur ProfessionInputSerializer

### DIFF
--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.1.24"
+version = "0.1.25"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.17"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },

--- a/libs/referentiel/value_objects/domaine_fonctionnel.py
+++ b/libs/referentiel/value_objects/domaine_fonctionnel.py
@@ -1,0 +1,54 @@
+from enum import Enum
+
+
+class DomaineFonctionnel(Enum):
+    ACHAT = ("ACH", "Achat")
+    AGRICULTURE = ("AGR", "Agriculture")
+    AMENAGEMENT_DEVELOPPEMENT_DURABLE_TERRITOIRE = (
+        "AMT",
+        "Aménagement et développement durable du territoire",
+    )
+    ANIMATION_JEUNESSE_SPORTS = ("ASP", "Animation, jeunesse et sports")
+    BATIMENT = ("BAT", "Bâtiment")
+    COMMUNICATION = ("COM", "Communication")
+    ORGANISATION_CONTROLE_EVALUATION = ("CTL", "Organisation, contrôle et évaluation")
+    CULTURE_PATRIMOINE = ("CUL", "Culture et Patrimoine")
+    DEFENSE = ("DEF", "Défense")
+    DIRECTION_PILOTAGE_POLITIQUES_PUBLIQUES = (
+        "DIR",
+        "Direction et pilotage des politiques publiques",
+    )
+    LECTURE_PUBLIQUE_DOCUMENTATION = ("DOC", "Lecture publique et Documentation")
+    ENSEIGNEMENT_FORMATION = ("ENS", "Enseignement et Formation")
+    ENVIRONNEMENT = ("ENV", "Environnement")
+    FINANCES_PUBLIQUES = ("FIP", "Finances publiques")
+    GESTION_BUDGETAIRE_FINANCIERE = ("GBF", "Gestion budgétaire et financière")
+    RESSOURCES_HUMAINES = ("GRH", "Ressources humaines")
+    INTERNATIONAL = ("INT", "International")
+    AFFAIRES_JURIDIQUES = ("JUR", "Affaires juridiques")
+    JUSTICE = ("JUS", "Justice")
+    INTERVENTIONS_TECHNIQUES_LOGISTIQUES = (
+        "LOG",
+        "Interventions techniques et logistiques",
+    )
+    MEDICAL_PARAMEDICAL = ("MED", "Médical et paramédical")
+    NUMERIQUE = ("NUM", "Numérique")
+    RECHERCHE = ("RCH", "Recherche")
+    RENSEIGNEMENT = ("REN", "Renseignement")
+    PREVENTION_CONSEIL_PILOTAGE_SANTE = (
+        "SAN",
+        "Prévention, conseil et pilotage en santé",
+    )
+    SECURITE = ("SEC", "Sécurité")
+    SOCIAL_ENFANCE_FAMILLE = ("SOC", "Social, enfance et famille")
+    TRANSPORTS = ("TRA", "Transports")
+    RELATION_USAGER = ("USA", "Relation à l'usager")
+
+    def __new__(cls, code: str, label: str):
+        obj = object.__new__(cls)
+        obj._value_ = code
+        obj.label = label
+        return obj
+
+    def __str__(self):
+        return self.value

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1226,7 +1226,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/infrastructure/factories/ingestion/offer_payload_factory.py
+++ b/src/web/infrastructure/factories/ingestion/offer_payload_factory.py
@@ -36,8 +36,8 @@ class PayloadOfferFactory:
             "url_offre": None,
             "url_candidature": None,
             "profession": {
-                "domaine": "INF",
-                "metier": "INF001",
+                "domaine": "NUM",
+                "metier": "ERNUM001",
                 "referentiel": "RMFPv2",
             },
             "categories": [],

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -2,6 +2,7 @@ from drf_spectacular.utils import extend_schema_field
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractKind, ContractType
 from referentiel.value_objects.diploma import Diploma
+from referentiel.value_objects.domaine_fonctionnel import DomaineFonctionnel
 from referentiel.value_objects.experience_level import ExperienceLevel
 from referentiel.value_objects.job_family_referential import JobFamilyReferential
 from referentiel.value_objects.language_level import LanguageLevel
@@ -261,11 +262,38 @@ class ProfessionInputSerializer(serializers.Serializer):
         choices=[e.value for e in JobFamilyReferential],
         default=JobFamilyReferential.RMFPV2.value,
     )
-    domaine = serializers.CharField(max_length=3)  # code domaine fonctionnel
+    domaine = serializers.CharField(
+        max_length=3,
+        help_text="Code domaine fonctionnel RMFP, vérifié uniquement si "
+        f"referentiel={JobFamilyReferential.RMFPV2.value}. Valeurs possibles : "
+        + ", ".join(f"{e.value} ({e.label})" for e in DomaineFonctionnel)
+        + ".",
+    )
     metier = serializers.CharField(max_length=8)
     code_emploi_local = serializers.CharField(
         max_length=50, required=False, allow_null=True
     )
+
+    def validate(self, data):
+        if data.get("referentiel") != JobFamilyReferential.RMFPV2.value:
+            return data
+
+        domaine = data.get("domaine")
+        if domaine not in {e.value for e in DomaineFonctionnel}:
+            raise serializers.ValidationError(
+                {"domaine": f"«\xa0{domaine}\xa0» n'est pas un choix valide."}
+            )
+
+        metier = data.get("metier")
+        metiers_repository = self.context.get("metiers_repository")
+        if metiers_repository is not None and not metiers_repository.get_filtered(
+            {"offer_family_code": metier}
+        ):
+            raise serializers.ValidationError(
+                {"metier": f"Code métier inconnu : {metier}."}
+            )
+
+        return data
 
 
 class DescriptionInputSerializer(serializers.Serializer):

--- a/src/web/presentation/ingestion/views/offers.py
+++ b/src/web/presentation/ingestion/views/offers.py
@@ -313,7 +313,10 @@ class OffersUpsertView(APIView):
         offer_mapper = OfferInputMapper()
 
         for _, offer_data in enumerate(request.data["offres"]):
-            serializer = OffersInputSerializer(data=offer_data)
+            serializer = OffersInputSerializer(
+                data=offer_data,
+                context={"metiers_repository": container.metiers_repository()},
+            )
             if not serializer.is_valid():
                 errors.append(
                     {

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -1793,6 +1793,19 @@ components:
           default: RMFPv2
         domaine:
           type: string
+          description: 'Code domaine fonctionnel RMFP, vérifié uniquement si referentiel=RMFPv2.
+            Valeurs possibles : ACH (Achat), AGR (Agriculture), AMT (Aménagement et
+            développement durable du territoire), ASP (Animation, jeunesse et sports),
+            BAT (Bâtiment), COM (Communication), CTL (Organisation, contrôle et évaluation),
+            CUL (Culture et Patrimoine), DEF (Défense), DIR (Direction et pilotage
+            des politiques publiques), DOC (Lecture publique et Documentation), ENS
+            (Enseignement et Formation), ENV (Environnement), FIP (Finances publiques),
+            GBF (Gestion budgétaire et financière), GRH (Ressources humaines), INT
+            (International), JUR (Affaires juridiques), JUS (Justice), LOG (Interventions
+            techniques et logistiques), MED (Médical et paramédical), NUM (Numérique),
+            RCH (Recherche), REN (Renseignement), SAN (Prévention, conseil et pilotage
+            en santé), SEC (Sécurité), SOC (Social, enfance et famille), TRA (Transports),
+            USA (Relation à l''usager).'
           maxLength: 3
         metier:
           type: string

--- a/src/web/tests/presentation/ingestion/test_mappers.py
+++ b/src/web/tests/presentation/ingestion/test_mappers.py
@@ -30,7 +30,7 @@ def test_isoformat(value, expected):
 def test_offer_input_mapper_maps_profession_referentiel_to_job_family_referential():
     payload = PayloadOfferFactory.create(
         identification={"reference": "REF-001", "versant": "FPT"},
-        profession={"domaine": "INF", "metier": "INF001", "referentiel": "RMFPv2"},
+        profession={"domaine": "NUM", "metier": "ERNUM001", "referentiel": "RMFPv2"},
     )
 
     offer = OfferInputMapper().to_domain(payload, source_id=uuid4())
@@ -41,9 +41,9 @@ def test_offer_input_mapper_maps_profession_referentiel_to_job_family_referentia
 def test_offer_input_mapper_maps_profession_domaine_to_functional_area_code():
     payload = PayloadOfferFactory.create(
         identification={"reference": "REF-001", "versant": "FPT"},
-        profession={"domaine": "INF", "metier": "INF001", "referentiel": "RMFPv2"},
+        profession={"domaine": "NUM", "metier": "ERNUM001", "referentiel": "RMFPv2"},
     )
 
     offer = OfferInputMapper().to_domain(payload, source_id=uuid4())
 
-    assert offer.functional_area_code == "INF"
+    assert offer.functional_area_code == "NUM"

--- a/src/web/tests/presentation/ingestion/test_serializers.py
+++ b/src/web/tests/presentation/ingestion/test_serializers.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from infrastructure.factories.ingestion.offer_payload_factory import PayloadOfferFactory
 from presentation.ingestion.serializers import (
     DescriptionInputSerializer,
@@ -36,7 +38,7 @@ def test_description_input_serializer_allows_blanks():
 
 
 def test_profession_input_serializer_defaults_referentiel_to_rmfpv2():
-    payload = {"domaine": "D01", "metier": "M0001"}
+    payload = {"domaine": "NUM", "metier": "ERNUM001"}
 
     serializer = ProfessionInputSerializer(data=payload)
 
@@ -45,7 +47,7 @@ def test_profession_input_serializer_defaults_referentiel_to_rmfpv2():
 
 
 def test_profession_input_serializer_rejects_null_referentiel():
-    payload = {"domaine": "D01", "metier": "M0001", "referentiel": None}
+    payload = {"domaine": "NUM", "metier": "ERNUM001", "referentiel": None}
 
     serializer = ProfessionInputSerializer(data=payload)
 
@@ -54,9 +56,71 @@ def test_profession_input_serializer_rejects_null_referentiel():
 
 
 def test_profession_input_serializer_rejects_invalid_referentiel():
-    payload = {"domaine": "D01", "metier": "M0001", "referentiel": "AUTRE"}
+    payload = {"domaine": "NUM", "metier": "ERNUM001", "referentiel": "AUTRE"}
 
     serializer = ProfessionInputSerializer(data=payload)
 
     assert not serializer.is_valid()
     assert "referentiel" in serializer.errors
+
+
+def test_profession_input_serializer_skips_metier_check_without_repository_in_context():
+    payload = {"domaine": "NUM", "metier": "INCONNU"}
+
+    serializer = ProfessionInputSerializer(data=payload)
+
+    assert serializer.is_valid(), serializer.errors
+
+
+def test_profession_input_serializer_accepts_metier_known_by_repository():
+    metiers_repository = MagicMock()
+    metiers_repository.get_filtered.return_value = [MagicMock()]
+    payload = {"domaine": "NUM", "metier": "ERNUM001"}
+
+    serializer = ProfessionInputSerializer(
+        data=payload, context={"metiers_repository": metiers_repository}
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    metiers_repository.get_filtered.assert_called_once_with(
+        {"offer_family_code": "ERNUM001"}
+    )
+
+
+def test_profession_input_serializer_rejects_metier_unknown_by_repository():
+    metiers_repository = MagicMock()
+    metiers_repository.get_filtered.return_value = []
+    payload = {"domaine": "NUM", "metier": "ERNUM999"}
+
+    serializer = ProfessionInputSerializer(
+        data=payload, context={"metiers_repository": metiers_repository}
+    )
+
+    assert not serializer.is_valid()
+    assert "metier" in serializer.errors
+
+
+def test_profession_input_serializer_rejects_invalid_domaine_for_rmfpv2():
+    payload = {"domaine": "ZZZ", "metier": "ERNUM001"}
+
+    serializer = ProfessionInputSerializer(data=payload)
+
+    assert not serializer.is_valid()
+    assert "domaine" in serializer.errors
+
+
+def test_profession_input_serializer_skips_checks_for_other_referentiel():
+    # JobFamilyReferential only exposes RMFPv2 today, so the "referentiel" field
+    # itself blocks any other value before reaching validate() through the public
+    # API. Calling validate() directly exercises the skip branch that protects
+    # future referentiels from being checked against RMFP-specific data.
+    metiers_repository = MagicMock()
+    serializer = ProfessionInputSerializer(
+        context={"metiers_repository": metiers_repository}
+    )
+    data = {"referentiel": "AUTRE", "domaine": "ZZZ", "metier": "INCONNU"}
+
+    validated = serializer.validate(data)
+
+    assert validated == data
+    metiers_repository.get_filtered.assert_not_called()

--- a/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_upsert_offers.py
@@ -330,6 +330,32 @@ def test_mixed_valid_invalid_offers_in_payload(
     ]
 
 
+def test_unknown_metier_returns_error_in_payload(
+    authenticated_client_with_source, use_case, mock_offers_container
+):
+    mock_offers_container.metiers_repository.return_value.get_filtered.return_value = []
+
+    use_case.execute.return_value = {"created": 0, "updated": 0, "errors": []}
+    response = authenticated_client_with_source.post(
+        URL,
+        data={"source_id": SOURCE_UUID, "offres": [MINIMAL_VALID_OFFER]},
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    errors = response.json()["errors"]
+    assert errors == [
+        {
+            "offer": {"reference": "REF-001", "versant": "FPT"},
+            "error": {
+                "profession": {
+                    "metier": ["Code métier inconnu : ERNUM001."],
+                }
+            },
+        }
+    ]
+
+
 def test_returns_error_500(authenticated_client_with_source, use_case):
     use_case.execute.side_effect = Exception("db error")
 

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },


### PR DESCRIPTION
## 📝 Description

Ajoute l'enum `DomaineFonctionnel` (référentiel officiel RMFP) et vérifie que `domaine`/`metier` correspondent à des valeurs connues, uniquement lorsque `referentiel=RMFPv2` (via le repository métiers injecté dans le context du serializer, pour rester compatible clean archi).

En lien avec https://github.com/betagouv/csplab/issues/780

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
