### PR TITLE
✨(api) amélioration de la navigation

### DIFF
--- a/src/web/application/recruteur/dtos/recrutement_read_models.py
+++ b/src/web/application/recruteur/dtos/recrutement_read_models.py
@@ -99,6 +99,7 @@ class EtapeKanbanReadModel:
 class RecrutementKanbanReadModel:
     offer_id: UUID
     intitule: str
+    archive: bool
     date_publication: datetime
     localisation: LocalisationDto
     organisme_recruteur: OrganismeRecruteurDto

--- a/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
+++ b/src/web/infrastructure/repositories/recruteur/postgres_recrutement_query_service.py
@@ -253,6 +253,7 @@ class PostgresRecrutementQueryService(IRecrutementQueryService):
         return RecrutementKanbanReadModel(
             offer_id=recrutement.offre_id,
             intitule=offre.title,
+            archive=offre.archived_at is not None,
             date_publication=offre.publication_date,
             localisation=LocalisationDto(
                 zone_geographique=offre.area or "",

--- a/src/web/presentation/frontend/src/components/base/CspTabs/CspTabs.vue
+++ b/src/web/presentation/frontend/src/components/base/CspTabs/CspTabs.vue
@@ -1,25 +1,25 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends string = string">
 import { TabsRoot } from 'reka-ui'
 import CspTabsList from './CspTabsList.vue'
 import CspTabsPanels from './CspTabsPanels.vue'
 
-export interface CspTabItem {
-  value: string
+export interface CspTabItem<V extends string = string> {
+  value: V
   label: string
   icon?: string
   disabled?: boolean
 }
 
-export interface CspTabsProps {
+export interface CspTabsProps<V extends string = string> {
   /** When omitted, compose CspTabsList and CspTabsPanels in the default slot. */
-  tabs?: CspTabItem[]
-  defaultValue?: string
+  tabs?: CspTabItem<V>[]
+  defaultValue?: V
   orientation?: 'horizontal' | 'vertical'
   activationMode?: 'automatic' | 'manual'
   fill?: boolean
 }
 
-withDefaults(defineProps<CspTabsProps>(), {
+withDefaults(defineProps<CspTabsProps<T>>(), {
   tabs: undefined,
   defaultValue: undefined,
   orientation: 'horizontal',
@@ -27,7 +27,7 @@ withDefaults(defineProps<CspTabsProps>(), {
   fill: false,
 })
 
-const model = defineModel<string>()
+const model = defineModel<T>()
 </script>
 
 <template>

--- a/src/web/presentation/frontend/src/components/layout/CspPageContainer/CspPageContainer.vue
+++ b/src/web/presentation/frontend/src/components/layout/CspPageContainer/CspPageContainer.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends string = string">
 import type { CspTabItem } from '@/components/base/CspTabs/CspTabs.vue'
 import CspTabs from '@/components/base/CspTabs/CspTabs.vue'
 import CspTabsList from '@/components/base/CspTabs/CspTabsList.vue'
@@ -7,13 +7,13 @@ import CspTabsPanels from '@/components/base/CspTabs/CspTabsPanels.vue'
 withDefaults(defineProps<{
   fill?: boolean
   width?: 'reading' | 'wide' | 'full'
-  tabs?: CspTabItem[]
+  tabs?: CspTabItem<T>[]
 }>(), {
   fill: false,
   width: 'wide',
 })
 
-const activeTab = defineModel<string>('activeTab')
+const activeTab = defineModel<T>('activeTab')
 </script>
 
 <template>

--- a/src/web/presentation/frontend/src/composables/navigation/useRouteTab.test.ts
+++ b/src/web/presentation/frontend/src/composables/navigation/useRouteTab.test.ts
@@ -1,0 +1,76 @@
+import type { RouteRecordRaw } from 'vue-router'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { useRouteTab } from './useRouteTab'
+
+type Onglet = 'liste' | 'archives'
+
+const ROUTE_NAMES: Record<Onglet, string> = {
+  liste: 'demo-liste',
+  archives: 'demo-archives',
+}
+
+const stub = defineComponent({ setup: () => () => h('div') })
+
+const testRoutes: RouteRecordRaw[] = [
+  { path: '/demo', name: ROUTE_NAMES.liste, component: stub, meta: { tab: 'liste' } },
+  { path: '/demo/archives', name: ROUTE_NAMES.archives, component: stub, meta: { tab: 'archives' } },
+  { path: '/ailleurs', name: 'ailleurs', component: stub },
+  { path: '/mal-declare', name: 'mal-declare', component: stub, meta: { tab: 'onglet-inconnu' } },
+]
+
+async function mountRouteTab(path: string) {
+  const router = createRouter({ history: createMemoryHistory(), routes: testRoutes })
+  await router.push(path)
+
+  let tab!: ReturnType<typeof useRouteTab<Onglet>>
+
+  mount(defineComponent({
+    setup() {
+      tab = useRouteTab(ROUTE_NAMES, 'liste')
+      return () => h('div')
+    },
+  }), {
+    global: { plugins: [router] },
+  })
+
+  return { tab, router }
+}
+
+describe('useRouteTab', () => {
+  it('reads the tab from the current route', async () => {
+    const { tab } = await mountRouteTab('/demo/archives')
+    expect(tab.value).toBe('archives')
+  })
+
+  it('navigates when the tab is set', async () => {
+    const { tab, router } = await mountRouteTab('/demo')
+
+    tab.value = 'archives'
+    await vi.waitFor(() => expect(router.currentRoute.value.path).toBe('/demo/archives'))
+
+    expect(tab.value).toBe('archives')
+  })
+
+  it('restores the previous tab on browser back', async () => {
+    const { tab, router } = await mountRouteTab('/demo')
+
+    tab.value = 'archives'
+    await vi.waitFor(() => expect(tab.value).toBe('archives'))
+
+    router.back()
+    await vi.waitFor(() => expect(tab.value).toBe('liste'))
+
+    expect(router.currentRoute.value.path).toBe('/demo')
+  })
+
+  it.each([
+    ['the route declares no tab', '/ailleurs'],
+    ['the route declares an unknown tab', '/mal-declare'],
+  ])('falls back to the default tab when %s', async (_, path) => {
+    const { tab } = await mountRouteTab(path)
+    expect(tab.value).toBe('liste')
+  })
+})

--- a/src/web/presentation/frontend/src/composables/navigation/useRouteTab.ts
+++ b/src/web/presentation/frontend/src/composables/navigation/useRouteTab.ts
@@ -1,0 +1,28 @@
+import type { WritableComputedRef } from 'vue'
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    tab?: string
+  }
+}
+
+export function useRouteTab<T extends string>(
+  routeNames: Record<T, string>,
+  fallback: T,
+): WritableComputedRef<T> {
+  const route = useRoute()
+  const router = useRouter()
+
+  function isTab(value: unknown): value is T {
+    return typeof value === 'string' && Object.hasOwn(routeNames, value)
+  }
+
+  return computed<T>({
+    get: () => (isTab(route.meta.tab) ? route.meta.tab : fallback),
+    set: (tab) => {
+      void router.push({ name: routeNames[tab] })
+    },
+  })
+}

--- a/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/composables/useCandidatures.test.ts
@@ -24,6 +24,7 @@ const CANDIDATURE_ALICE = 'dddddddd-0001-0001-0001-000000000001'
 const MOCK_KANBAN: RecrutementDetailKanban = {
   offer_id: RECRUTEMENT_UUID,
   intitule: 'Chargé de mission numérique',
+  archive: false,
   date_publication: '2025-06-22T10:00:00Z',
   localisation: {
     zone_geographique: 'EU',

--- a/src/web/presentation/frontend/src/features/candidatures/routes.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/routes.ts
@@ -1,8 +1,9 @@
 import type { RouteRecordRaw } from 'vue-router'
+import { UUID_ROUTE_PARAM } from '@/router/params'
 
 export const candidaturesRoutes: RouteRecordRaw[] = [
   {
-    path: '/mes-recrutements/:recrutementUuid',
+    path: `/mes-recrutements/:recrutementUuid${UUID_ROUTE_PARAM}`,
     component: () => import('./views/CandidaturesView.vue'),
     children: [
       {

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -13,6 +13,7 @@ import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContai
 import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
 import { useDisclosure } from '@/composables/ui/useDisclosure'
+import { recrutementsListLocation } from '@/features/recrutements/routes'
 import CandidaturesFiltersDrawer from '../components/CandidaturesFiltersDrawer.vue'
 import CandidaturesViewSwitch from '../components/CandidaturesViewSwitch.vue'
 import { useCandidatures } from '../composables/useCandidatures'
@@ -61,11 +62,13 @@ function applyFilters() {
   closeFiltersDrawer()
 }
 
+const recrutementsListLink = recrutementsListLocation(router.options.history.state)
+
 const title = computed(() => intitule.value ?? 'Candidatures')
 
 const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
   { label: 'Accueil', to: { name: 'home' } },
-  { label: 'Mes recrutements', to: { name: 'mes-recrutements' } },
+  { label: 'Mes recrutements', to: recrutementsListLink },
   ...(intitule.value ? [{ label: intitule.value }] : []),
 ])
 
@@ -105,7 +108,7 @@ const activeTab = ref<'candidatures' | 'activites-et-taches'>('candidatures')
   <CspPageHeader
     :breadcrumb="breadcrumb"
     :title="title"
-    :back-link="{ to: { name: 'mes-recrutements' }, label: 'Retour à mes recrutements' }"
+    :back-link="{ to: recrutementsListLink, label: 'Retour à mes recrutements' }"
     :show-title-skeleton="showTitleSkeleton"
     :show-subtitle-skeleton="showSubtitleSkeleton"
   >

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -62,13 +62,13 @@ function applyFilters() {
   closeFiltersDrawer()
 }
 
-const recrutementsListLink = recrutementsListLocation(router.options.history.state)
+const recrutementsListLink = computed(() => recrutementsListLocation(recrutementDetail.value?.archive))
 
 const title = computed(() => intitule.value ?? 'Candidatures')
 
 const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
   { label: 'Accueil', to: { name: 'home' } },
-  { label: 'Mes recrutements', to: recrutementsListLink },
+  { label: 'Mes recrutements', to: recrutementsListLink.value },
   ...(intitule.value ? [{ label: intitule.value }] : []),
 ])
 

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/routes.ts
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/routes.ts
@@ -1,8 +1,9 @@
 import type { RouteRecordRaw } from 'vue-router'
+import { UUID_ROUTE_PARAM } from '@/router/params'
 
 export const etapesRecrutementRoutes: RouteRecordRaw[] = [
   {
-    path: '/mes-recrutements/:recrutementUuid/etapes-recrutement',
+    path: `/mes-recrutements/:recrutementUuid${UUID_ROUTE_PARAM}/etapes-recrutement`,
     name: 'recrutement-etapes-recrutement',
     component: () => import('./views/OffreEtapesRecrutementView.vue'),
   },

--- a/src/web/presentation/frontend/src/features/etapes-recrutement/views/OffreEtapesRecrutementView.vue
+++ b/src/web/presentation/frontend/src/features/etapes-recrutement/views/OffreEtapesRecrutementView.vue
@@ -8,6 +8,7 @@ import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import { recrutementKanbanQuery } from '@/features/candidatures/queries'
 import { peekRecrutementIntitule } from '@/features/recrutements/queries'
+import { recrutementsListLocation } from '@/features/recrutements/routes'
 import EtapesRecrutementList from '../components/EtapesRecrutementList.vue'
 import { ETAPES_TEXTS_OFFRE } from '../constants/etape-recrutement'
 
@@ -26,6 +27,10 @@ const intitule = computed<string | null>(() =>
   ?? peekRecrutementIntitule(queryCache, TEMP_ORGANISME_UUID, recrutementUuid),
 )
 
+const recrutementsListLink = computed(() =>
+  recrutementsListLocation(recrutementDetail.value?.archive),
+)
+
 const candidaturesRoute = computed(() => ({
   name: 'recrutement-candidatures-kanban',
   params: { recrutementUuid },
@@ -33,7 +38,7 @@ const candidaturesRoute = computed(() => ({
 
 const breadcrumb = computed<CspBreadcrumbItem[]>(() => [
   { label: 'Accueil', to: { name: 'home' } },
-  { label: 'Mes recrutements', to: { name: 'mes-recrutements' } },
+  { label: 'Mes recrutements', to: recrutementsListLink.value },
   ...(intitule.value ? [{ label: intitule.value, to: candidaturesRoute.value }] : []),
   { label: 'Étapes de recrutement' },
 ])

--- a/src/web/presentation/frontend/src/features/recrutements/routes.test.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/routes.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { recrutementsListLocation, recrutementsOriginState } from './routes'
+
+describe('recrutementsListLocation', () => {
+  it('points back to the tab the detail was opened from', () => {
+    expect(recrutementsListLocation(recrutementsOriginState('archives')))
+      .toEqual({ name: 'mes-recrutements-archives' })
+  })
+
+  it.each([
+    ['no state', undefined],
+    ['an unrelated state', { position: 3 }],
+    ['a malformed tab', { recrutementsTab: 'onglet-inconnu' }],
+  ])('falls back to the default tab with %s', (_, state) => {
+    expect(recrutementsListLocation(state)).toEqual({ name: 'mes-recrutements' })
+  })
+})

--- a/src/web/presentation/frontend/src/features/recrutements/routes.test.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/routes.test.ts
@@ -1,17 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { recrutementsListLocation, recrutementsOriginState } from './routes'
+import { recrutementsListLocation } from './routes'
 
 describe('recrutementsListLocation', () => {
-  it('points back to the tab the detail was opened from', () => {
-    expect(recrutementsListLocation(recrutementsOriginState('archives')))
-      .toEqual({ name: 'mes-recrutements-archives' })
+  it('points to the archives tab for an archived recrutement', () => {
+    expect(recrutementsListLocation(true)).toEqual({ name: 'mes-recrutements-archives' })
   })
 
-  it.each([
-    ['no state', undefined],
-    ['an unrelated state', { position: 3 }],
-    ['a malformed tab', { recrutementsTab: 'onglet-inconnu' }],
-  ])('falls back to the default tab with %s', (_, state) => {
-    expect(recrutementsListLocation(state)).toEqual({ name: 'mes-recrutements' })
+  it('points to the actifs tab for a live recrutement', () => {
+    expect(recrutementsListLocation(false)).toEqual({ name: 'mes-recrutements' })
+  })
+
+  it('points to the default tab while the detail is loading', () => {
+    expect(recrutementsListLocation(undefined)).toEqual({ name: 'mes-recrutements' })
   })
 })

--- a/src/web/presentation/frontend/src/features/recrutements/routes.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/routes.ts
@@ -1,9 +1,34 @@
 import type { RouteRecordRaw } from 'vue-router'
+import type { RecrutementKey } from './types'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    recrutementTab?: RecrutementKey
+  }
+}
+
+export const RECRUTEMENTS_TAB_ROUTE_NAMES = {
+  actifs: 'mes-recrutements',
+  archives: 'mes-recrutements-archives',
+} as const satisfies Record<RecrutementKey, string>
+
+export const DEFAULT_RECRUTEMENT_TAB: RecrutementKey = 'actifs'
+
+export function isRecrutementKey(value: string): value is RecrutementKey {
+  return Object.hasOwn(RECRUTEMENTS_TAB_ROUTE_NAMES, value)
+}
 
 export const recrutementsRoutes: RouteRecordRaw[] = [
   {
     path: '/mes-recrutements',
-    name: 'mes-recrutements',
+    name: RECRUTEMENTS_TAB_ROUTE_NAMES.actifs,
     component: () => import('./views/MesRecrutementsView.vue'),
+    meta: { recrutementTab: 'actifs' },
+  },
+  {
+    path: '/mes-recrutements/archives',
+    name: RECRUTEMENTS_TAB_ROUTE_NAMES.archives,
+    component: () => import('./views/MesRecrutementsView.vue'),
+    meta: { recrutementTab: 'archives' },
   },
 ]

--- a/src/web/presentation/frontend/src/features/recrutements/routes.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/routes.ts
@@ -1,11 +1,5 @@
-import type { RouteRecordRaw } from 'vue-router'
+import type { RouteLocationRaw, RouteRecordRaw } from 'vue-router'
 import type { RecrutementKey } from './types'
-
-declare module 'vue-router' {
-  interface RouteMeta {
-    recrutementTab?: RecrutementKey
-  }
-}
 
 export const RECRUTEMENTS_TAB_ROUTE_NAMES = {
   actifs: 'mes-recrutements',
@@ -14,17 +8,32 @@ export const RECRUTEMENTS_TAB_ROUTE_NAMES = {
 
 export const DEFAULT_RECRUTEMENT_TAB: RecrutementKey = 'actifs'
 
+const ORIGIN_TAB_STATE = 'recrutementsTab'
+
+function isRecrutementKey(value: unknown): value is RecrutementKey {
+  return typeof value === 'string' && Object.hasOwn(RECRUTEMENTS_TAB_ROUTE_NAMES, value)
+}
+
+export function recrutementsOriginState(tab: RecrutementKey) {
+  return { [ORIGIN_TAB_STATE]: tab }
+}
+
+export function recrutementsListLocation(historyState: unknown): RouteLocationRaw {
+  const tab = (historyState as Record<string, unknown> | null | undefined)?.[ORIGIN_TAB_STATE]
+  return { name: RECRUTEMENTS_TAB_ROUTE_NAMES[isRecrutementKey(tab) ? tab : DEFAULT_RECRUTEMENT_TAB] }
+}
+
 export const recrutementsRoutes: RouteRecordRaw[] = [
   {
     path: '/mes-recrutements',
     name: RECRUTEMENTS_TAB_ROUTE_NAMES.actifs,
     component: () => import('./views/MesRecrutementsView.vue'),
-    meta: { recrutementTab: 'actifs' },
+    meta: { tab: 'actifs' },
   },
   {
     path: '/mes-recrutements/archives',
     name: RECRUTEMENTS_TAB_ROUTE_NAMES.archives,
     component: () => import('./views/MesRecrutementsView.vue'),
-    meta: { recrutementTab: 'archives' },
+    meta: { tab: 'archives' },
   },
 ]

--- a/src/web/presentation/frontend/src/features/recrutements/routes.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/routes.ts
@@ -8,19 +8,8 @@ export const RECRUTEMENTS_TAB_ROUTE_NAMES = {
 
 export const DEFAULT_RECRUTEMENT_TAB: RecrutementKey = 'actifs'
 
-const ORIGIN_TAB_STATE = 'recrutementsTab'
-
-function isRecrutementKey(value: unknown): value is RecrutementKey {
-  return typeof value === 'string' && Object.hasOwn(RECRUTEMENTS_TAB_ROUTE_NAMES, value)
-}
-
-export function recrutementsOriginState(tab: RecrutementKey) {
-  return { [ORIGIN_TAB_STATE]: tab }
-}
-
-export function recrutementsListLocation(historyState: unknown): RouteLocationRaw {
-  const tab = (historyState as Record<string, unknown> | null | undefined)?.[ORIGIN_TAB_STATE]
-  return { name: RECRUTEMENTS_TAB_ROUTE_NAMES[isRecrutementKey(tab) ? tab : DEFAULT_RECRUTEMENT_TAB] }
+export function recrutementsListLocation(archive: boolean | undefined): RouteLocationRaw {
+  return { name: RECRUTEMENTS_TAB_ROUTE_NAMES[archive ? 'archives' : DEFAULT_RECRUTEMENT_TAB] }
 }
 
 export const recrutementsRoutes: RouteRecordRaw[] = [

--- a/src/web/presentation/frontend/src/features/recrutements/routes.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/routes.ts
@@ -14,10 +14,6 @@ export const RECRUTEMENTS_TAB_ROUTE_NAMES = {
 
 export const DEFAULT_RECRUTEMENT_TAB: RecrutementKey = 'actifs'
 
-export function isRecrutementKey(value: string): value is RecrutementKey {
-  return Object.hasOwn(RECRUTEMENTS_TAB_ROUTE_NAMES, value)
-}
-
 export const recrutementsRoutes: RouteRecordRaw[] = [
   {
     path: '/mes-recrutements',

--- a/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
+++ b/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
@@ -23,11 +23,7 @@ import RecrutementsFiltersDrawer from '../components/RecrutementsFiltersDrawer.v
 import { useRecrutements } from '../composables/useRecrutements'
 
 import { useRecrutementsFilters } from '../composables/useRecrutementsFilters'
-import {
-  DEFAULT_RECRUTEMENT_TAB,
-  isRecrutementKey,
-  RECRUTEMENTS_TAB_ROUTE_NAMES,
-} from '../routes'
+import { DEFAULT_RECRUTEMENT_TAB, RECRUTEMENTS_TAB_ROUTE_NAMES } from '../routes'
 
 const BREADCRUMB: CspBreadcrumbItem[] = [
   { label: 'Accueil', to: { name: 'home' } },
@@ -37,16 +33,14 @@ const BREADCRUMB: CspBreadcrumbItem[] = [
 const route = useRoute()
 const router = useRouter()
 
-const activeTab = computed<RecrutementKey, string>({
+const activeTab = computed<RecrutementKey>({
   get: () => route.meta.recrutementTab ?? DEFAULT_RECRUTEMENT_TAB,
   set: (tab) => {
-    if (isRecrutementKey(tab)) {
-      void router.push({ name: RECRUTEMENTS_TAB_ROUTE_NAMES[tab] })
-    }
+    void router.push({ name: RECRUTEMENTS_TAB_ROUTE_NAMES[tab] })
   },
 })
 
-const TABS: CspTabItem[] = [
+const TABS: CspTabItem<RecrutementKey>[] = [
   { value: 'actifs', label: 'Recrutements en cours' },
   { value: 'archives', label: 'Offres archivées' },
 ]

--- a/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
+++ b/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
@@ -24,7 +24,7 @@ import RecrutementsFiltersDrawer from '../components/RecrutementsFiltersDrawer.v
 
 import { useRecrutements } from '../composables/useRecrutements'
 import { useRecrutementsFilters } from '../composables/useRecrutementsFilters'
-import { DEFAULT_RECRUTEMENT_TAB, RECRUTEMENTS_TAB_ROUTE_NAMES, recrutementsOriginState } from '../routes'
+import { DEFAULT_RECRUTEMENT_TAB, RECRUTEMENTS_TAB_ROUTE_NAMES } from '../routes'
 
 const BREADCRUMB: CspBreadcrumbItem[] = [
   { label: 'Accueil', to: { name: 'home' } },
@@ -50,11 +50,7 @@ const showActifsSkeleton = useMinimumPending(pendingActifs, 300)
 const showArchivesSkeleton = useMinimumPending(pendingArchives, 300)
 
 function openOffre(recrutementUuid: string) {
-  void router.push({
-    name: 'recrutement-candidatures-kanban',
-    params: { recrutementUuid },
-    state: recrutementsOriginState(activeTab.value),
-  })
+  void router.push({ name: 'recrutement-candidatures-kanban', params: { recrutementUuid } })
 }
 
 const recrutementsActifsPage = ref(1)

--- a/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
+++ b/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
@@ -5,7 +5,7 @@ import type {
 import type { CspBreadcrumbItem } from '@/components/base/CspBreadcrumb/CspBreadcrumb.vue'
 import type { CspTabItem } from '@/components/base/CspTabs/CspTabs.vue'
 import { computed, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRouter } from 'vue-router'
 import CspAsyncSection from '@/components/base/CspAsyncSection/CspAsyncSection.vue'
 import CspButton from '@/components/base/CspButton/CspButton.vue'
 import CspDataTable from '@/components/base/CspDataTable/CspDataTable.vue'
@@ -16,29 +16,24 @@ import CspSkeletonTable from '@/components/base/CspSkeleton/CspSkeletonTable.vue
 import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContainer.vue'
 import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
+import { useRouteTab } from '@/composables/navigation/useRouteTab'
 import { useDisclosure } from '@/composables/ui/useDisclosure'
 import { TEMP_ORGANISME_UUID } from '@/constants/organisme'
 import { RECRUTEMENTS_ACTIFS_COLUMNS, RECRUTEMENTS_ARCHIVES_COLUMNS } from '../columns'
 import RecrutementsFiltersDrawer from '../components/RecrutementsFiltersDrawer.vue'
-import { useRecrutements } from '../composables/useRecrutements'
 
+import { useRecrutements } from '../composables/useRecrutements'
 import { useRecrutementsFilters } from '../composables/useRecrutementsFilters'
-import { DEFAULT_RECRUTEMENT_TAB, RECRUTEMENTS_TAB_ROUTE_NAMES } from '../routes'
+import { DEFAULT_RECRUTEMENT_TAB, RECRUTEMENTS_TAB_ROUTE_NAMES, recrutementsOriginState } from '../routes'
 
 const BREADCRUMB: CspBreadcrumbItem[] = [
   { label: 'Accueil', to: { name: 'home' } },
   { label: 'Mes recrutements' },
 ]
 
-const route = useRoute()
 const router = useRouter()
 
-const activeTab = computed<RecrutementKey>({
-  get: () => route.meta.recrutementTab ?? DEFAULT_RECRUTEMENT_TAB,
-  set: (tab) => {
-    void router.push({ name: RECRUTEMENTS_TAB_ROUTE_NAMES[tab] })
-  },
-})
+const activeTab = useRouteTab(RECRUTEMENTS_TAB_ROUTE_NAMES, DEFAULT_RECRUTEMENT_TAB)
 
 const TABS: CspTabItem<RecrutementKey>[] = [
   { value: 'actifs', label: 'Recrutements en cours' },
@@ -55,7 +50,11 @@ const showActifsSkeleton = useMinimumPending(pendingActifs, 300)
 const showArchivesSkeleton = useMinimumPending(pendingArchives, 300)
 
 function openOffre(recrutementUuid: string) {
-  void router.push({ name: 'recrutement-candidatures-kanban', params: { recrutementUuid } })
+  void router.push({
+    name: 'recrutement-candidatures-kanban',
+    params: { recrutementUuid },
+    state: recrutementsOriginState(activeTab.value),
+  })
 }
 
 const recrutementsActifsPage = ref(1)

--- a/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
+++ b/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
@@ -5,7 +5,7 @@ import type {
 import type { CspBreadcrumbItem } from '@/components/base/CspBreadcrumb/CspBreadcrumb.vue'
 import type { CspTabItem } from '@/components/base/CspTabs/CspTabs.vue'
 import { computed, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import CspAsyncSection from '@/components/base/CspAsyncSection/CspAsyncSection.vue'
 import CspButton from '@/components/base/CspButton/CspButton.vue'
 import CspDataTable from '@/components/base/CspDataTable/CspDataTable.vue'
@@ -23,13 +23,28 @@ import RecrutementsFiltersDrawer from '../components/RecrutementsFiltersDrawer.v
 import { useRecrutements } from '../composables/useRecrutements'
 
 import { useRecrutementsFilters } from '../composables/useRecrutementsFilters'
+import {
+  DEFAULT_RECRUTEMENT_TAB,
+  isRecrutementKey,
+  RECRUTEMENTS_TAB_ROUTE_NAMES,
+} from '../routes'
 
 const BREADCRUMB: CspBreadcrumbItem[] = [
   { label: 'Accueil', to: { name: 'home' } },
   { label: 'Mes recrutements' },
 ]
 
-const activeTab = ref<RecrutementKey>('actifs')
+const route = useRoute()
+const router = useRouter()
+
+const activeTab = computed<RecrutementKey, string>({
+  get: () => route.meta.recrutementTab ?? DEFAULT_RECRUTEMENT_TAB,
+  set: (tab) => {
+    if (isRecrutementKey(tab)) {
+      void router.push({ name: RECRUTEMENTS_TAB_ROUTE_NAMES[tab] })
+    }
+  },
+})
 
 const TABS: CspTabItem[] = [
   { value: 'actifs', label: 'Recrutements en cours' },
@@ -44,8 +59,6 @@ const {
 
 const showActifsSkeleton = useMinimumPending(pendingActifs, 300)
 const showArchivesSkeleton = useMinimumPending(pendingArchives, 300)
-
-const router = useRouter()
 
 function openOffre(recrutementUuid: string) {
   void router.push({ name: 'recrutement-candidatures-kanban', params: { recrutementUuid } })

--- a/src/web/presentation/frontend/src/router/index.test.ts
+++ b/src/web/presentation/frontend/src/router/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { routes } from './index'
+
+const RECRUTEMENT_UUID = 'aaaaaaaa-0001-0001-0001-000000000001'
+
+function resolve(path: string) {
+  return createRouter({ history: createMemoryHistory(), routes }).resolve(path)
+}
+
+describe('recrutements tab routes', () => {
+  it('maps /mes-recrutements to the actifs tab', () => {
+    const route = resolve('/mes-recrutements')
+    expect(route.name).toBe('mes-recrutements')
+    expect(route.meta.recrutementTab).toBe('actifs')
+  })
+
+  it('maps /mes-recrutements/archives to the archives tab', () => {
+    const route = resolve('/mes-recrutements/archives')
+    expect(route.name).toBe('mes-recrutements-archives')
+    expect(route.meta.recrutementTab).toBe('archives')
+  })
+
+  it('prefers the archives tab over the recrutement detail route', () => {
+    expect(resolve('/mes-recrutements/archives').name).not.toBe('recrutement-candidatures-kanban')
+  })
+})
+
+describe('recrutement detail routes', () => {
+  it('matches a uuid segment', () => {
+    const route = resolve(`/mes-recrutements/${RECRUTEMENT_UUID}`)
+    expect(route.name).toBe('recrutement-candidatures-kanban')
+    expect(route.params.recrutementUuid).toBe(RECRUTEMENT_UUID)
+  })
+
+  it('matches the etapes route under a uuid segment', () => {
+    const route = resolve(`/mes-recrutements/${RECRUTEMENT_UUID}/etapes-recrutement`)
+    expect(route.name).toBe('recrutement-etapes-recrutement')
+  })
+
+  it('falls through to not-found when the segment is not a uuid', () => {
+    expect(resolve('/mes-recrutements/archivees').name).toBe('not-found')
+    expect(resolve('/mes-recrutements/42').name).toBe('not-found')
+  })
+})
+
+describe('not-found route', () => {
+  it('catches unknown paths', () => {
+    expect(resolve('/rien-du-tout').name).toBe('not-found')
+  })
+
+  it('does not shadow known paths', () => {
+    expect(resolve('/').name).toBe('home')
+    expect(resolve('/parametres').name).toBe('parametres')
+  })
+})

--- a/src/web/presentation/frontend/src/router/index.test.ts
+++ b/src/web/presentation/frontend/src/router/index.test.ts
@@ -12,13 +12,13 @@ describe('recrutements tab routes', () => {
   it('maps /mes-recrutements to the actifs tab', () => {
     const route = resolve('/mes-recrutements')
     expect(route.name).toBe('mes-recrutements')
-    expect(route.meta.recrutementTab).toBe('actifs')
+    expect(route.meta.tab).toBe('actifs')
   })
 
   it('maps /mes-recrutements/archives to the archives tab', () => {
     const route = resolve('/mes-recrutements/archives')
     expect(route.name).toBe('mes-recrutements-archives')
-    expect(route.meta.recrutementTab).toBe('archives')
+    expect(route.meta.tab).toBe('archives')
   })
 
   it('prefers the archives tab over the recrutement detail route', () => {

--- a/src/web/presentation/frontend/src/router/index.ts
+++ b/src/web/presentation/frontend/src/router/index.ts
@@ -16,9 +16,16 @@ const appRoutes: RouteRecordRaw[] = [
   },
 ]
 
+const notFoundRoute: RouteRecordRaw = {
+  path: '/:pathMatch(.*)*',
+  name: 'not-found',
+  component: () => import('@/views/NotFoundView.vue'),
+}
+
 export const routes: RouteRecordRaw[] = [
   ...appRoutes,
   ...recrutementsRoutes,
   ...candidaturesRoutes,
   ...etapesRecrutementRoutes,
+  notFoundRoute,
 ]

--- a/src/web/presentation/frontend/src/router/params.ts
+++ b/src/web/presentation/frontend/src/router/params.ts
@@ -1,0 +1,1 @@
+export const UUID_ROUTE_PARAM = '([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})'

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -529,6 +529,7 @@ export interface components {
             /** Format: uuid */
             offer_id: string;
             intitule: string;
+            archive: boolean;
             /** Format: date-time */
             date_publication: string;
             localisation: components["schemas"]["Localisation"];

--- a/src/web/presentation/frontend/src/views/NotFoundView.vue
+++ b/src/web/presentation/frontend/src/views/NotFoundView.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import CspButton from '@/components/base/CspButton/CspButton.vue'
+import CspErrorState from '@/components/base/CspErrorState/CspErrorState.vue'
+import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContainer.vue'
+import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
+</script>
+
+<template>
+  <CspPageHeader title="Page introuvable" />
+  <CspPageContainer>
+    <CspErrorState
+      title="Cette page n’existe pas."
+      description="Le lien est peut-être incorrect ou la page a été déplacée."
+      icon="ri:compass-3-line"
+    >
+      <template #action>
+        <CspButton
+          :as="RouterLink"
+          :to="{ name: 'home' }"
+          label="Retour à l’accueil"
+          variant="primary"
+        />
+      </template>
+    </CspErrorState>
+  </CspPageContainer>
+</template>

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -78,6 +78,7 @@ class EtapeRecrutementDetailedCandidaturesSerializer(EtapeRecrutementSerializer)
 class RecrutementDetailKanbanSerializer(serializers.Serializer):
     offer_id = serializers.UUIDField()
     intitule = serializers.CharField()
+    archive = serializers.BooleanField()
     date_publication = serializers.DateTimeField()
     localisation = LocalisationSerializer()
     organisme_recruteur = OrganismeSerializer()

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -1568,6 +1568,8 @@ components:
           format: uuid
         intitule:
           type: string
+        archive:
+          type: boolean
         date_publication:
           type: string
           format: date-time
@@ -1582,6 +1584,7 @@ components:
           items:
             $ref: '#/components/schemas/EtapeRecrutementDetailedCandidatures'
       required:
+      - archive
       - categorie_offre
       - date_publication
       - etapes

--- a/src/web/tests/application/recruteur/test_get_recrutement_kanban.py
+++ b/src/web/tests/application/recruteur/test_get_recrutement_kanban.py
@@ -31,6 +31,7 @@ def _recrutement_kanban_read_model() -> RecrutementKanbanReadModel:
     return RecrutementKanbanReadModel(
         offer_id=uuid4(),
         intitule="Chargé de mission numérique",
+        archive=False,
         date_publication=datetime.now(tz=timezone.utc),
         localisation=LocalisationDto(
             zone_geographique="EU",

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_detail.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_detail.py
@@ -42,6 +42,7 @@ def _recrutement_kanban_read_model() -> RecrutementKanbanReadModel:
     return RecrutementKanbanReadModel(
         offer_id=UUID(RECRUTEMENT_UUID),
         intitule="Chargé de mission numérique",
+        archive=False,
         date_publication=datetime.now(tz=timezone.utc),
         localisation=LocalisationDto(
             zone_geographique="EU",


### PR DESCRIPTION
## 📝 Description
Ajout des onglets des les urls pour améliorer la navigation.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
Onglet dans l'URL:  /mes-recrutements (en cours) et /mes-recrutements/archives. L'onglet est déclaré en meta.tab sur la route. Pas de ref miroir ni de watcher, donc pas de désynchronisation possible.

useRouteTab<T> (composables/navigation/): générique, porte l'augmentation RouteMeta.tab et la validation. Une page à onglets fournit sa table de routes, rien de plus.

CspTabs / CspPageContainer génériques: defineModel<T> au lieu de defineModel<string>, CspTabItem<V>. Le type de activeTab suit celui du tableau tabs, plus de narrowing chez l'appelant.

Routage: format uuid contraint sur :recrutementUuid (motif partagé dans router/params.ts) et route catch-all 404 ; il n'y en avait aucune, une URL inconnue rendait une page blanche.

API: archive: bool sur RecrutementDetailKanban, dérivé de offre.archived_at. Nécessaire pour les liens « Retour à mes recrutements » du détail et des étapes en dérivent leur cible, au lieu de dépendre du chemin parcouru.

Tests: 14 : résolution des routes (statique prioritaire sur dynamique, repli 404 sur segment non-uuid), composable (lecture, navigation, retour navigateur, repli), lien de retour selon statut d'archivage.

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
