### PR TITLE
🐛(ingestion) ignorer le préfixe ER pour calculer le domaine RMFPv2

### DIFF
--- a/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
+++ b/src/ingestion/infrastructure/external_gateways/dtos/offer_upsert_payload.py
@@ -124,10 +124,12 @@ class OfferUpsertPayload(BaseModel):
             ]
 
         domaine_length = 3
+        er_prefix = "ER"
+        family_code = offer.family_code or ""
+        if family_code.startswith(er_prefix):
+            family_code = family_code[len(er_prefix) :]
         domaine = (
-            offer.family_code[:domaine_length]
-            if offer.family_code and len(offer.family_code) >= domaine_length
-            else ""
+            family_code[:domaine_length] if len(family_code) >= domaine_length else ""
         )
 
         return cls(

--- a/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
+++ b/src/ingestion/tests/unit/test_web_publish_offer_gateway.py
@@ -190,6 +190,20 @@ async def test_publish_serializes_management(gateway, httpx_mock: HTTPXMock):
 
 
 @pytest.mark.asyncio
+async def test_publish_serializes_domaine_skipping_er_prefix(
+    gateway, httpx_mock: HTTPXMock
+):
+    httpx_mock.add_response(method="POST", url=PUBLISH_URL, status_code=201)
+    offer = Offer(**{**MINIMAL_OFFER.__dict__, "family_code": "ERMED007"})
+
+    await gateway.publish(PublishOfferInput(source_id=SOURCE_ID, offer=offer))
+
+    body = json.loads(httpx_mock.get_requests()[0].content)
+    assert body["offres"][0]["profession"]["domaine"] == "MED"
+    assert body["offres"][0]["profession"]["metier"] == "ERMED007"
+
+
+@pytest.mark.asyncio
 async def test_publish_uses_end_publication_date_as_fin_publication(
     gateway, httpx_mock: HTTPXMock
 ):


### PR DESCRIPTION
## 📝 Description

Corrige le code `domaine` suite à https://github.com/betagouv/csplab/pull/1089 dans `ingestion`.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
