### PR TITLE
✨(api) filtrer OffersListView par latitude, longitude et rayon

### DIFF
--- a/src/web/presentation/ingestion/openapi.py
+++ b/src/web/presentation/ingestion/openapi.py
@@ -275,6 +275,11 @@ critères suivants :
 - `region` — un ou plusieurs codes région (ex. `11,84`)
 - `departement` — un ou plusieurs codes département (ex. `75,69`)
 - `pays` — un ou plusieurs codes pays alpha-3 (ex. `FRA,BEL`)
+- filtre géographique par rayon autour d'un point, les trois paramètres
+  doivent être fournis ensemble :
+  - `latitude` — latitude du point en degrés décimaux (entre -90 et 90)
+  - `longitude` — longitude du point en degrés décimaux (entre -180 et 180)
+  - `radius` — rayon de recherche en kilomètres (entier positif)
 
 Les filtres à valeurs multiples acceptent une liste de valeurs séparées par une
 virgule. Une valeur invalide pour l'un de ces filtres renvoie une erreur `400`.

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -189,6 +189,47 @@ class ListOffersFiltersSerializer(serializers.Serializer):
         help_text="Valeurs séparées par une virgule (ex. `FRA,BEL`).",
         source="country",
     )
+    latitude = serializers.FloatField(
+        required=False,
+        min_value=-90,
+        max_value=90,
+        default=None,
+        help_text=(
+            "Filtre géographique : latitude du point en degrés décimaux "
+            "(à fournir avec `longitude` et `radius`)."
+        ),
+    )
+    longitude = serializers.FloatField(
+        required=False,
+        min_value=-180,
+        max_value=180,
+        default=None,
+        help_text=(
+            "Filtre géographique : longitude du point en degrés décimaux "
+            "(à fournir avec `latitude` et `radius`)."
+        ),
+    )
+    radius = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        default=None,
+        source="radius_km",
+        help_text=(
+            "Filtre géographique : rayon de recherche en kilomètres "
+            "(à fournir avec `latitude` et `longitude`)."
+        ),
+    )
+
+    _GEO_FIELDS = ("latitude", "longitude", "radius_km")
+
+    def validate(self, data):
+        provided = [key for key in self._GEO_FIELDS if data.get(key) is not None]
+        if provided and len(provided) != len(self._GEO_FIELDS):
+            raise serializers.ValidationError(
+                "Les paramètres latitude, longitude et radius doivent être "
+                "fournis ensemble."
+            )
+        return data
 
 
 class OfferSummariesQuerySerializer(serializers.Serializer):
@@ -218,13 +259,34 @@ class OfferSummariesQuerySerializer(serializers.Serializer):
     )
     country = _CommaSeparatedCodeField(COUNTRY_NAMES, "pays", Country)
     latitude = serializers.FloatField(
-        required=False, min_value=-90, max_value=90, default=None
+        required=False,
+        min_value=-90,
+        max_value=90,
+        default=None,
+        help_text=(
+            "Filtre géographique : latitude du point en degrés décimaux "
+            "(à fournir avec `longitude` et `radius`)."
+        ),
     )
     longitude = serializers.FloatField(
-        required=False, min_value=-180, max_value=180, default=None
+        required=False,
+        min_value=-180,
+        max_value=180,
+        default=None,
+        help_text=(
+            "Filtre géographique : longitude du point en degrés décimaux "
+            "(à fournir avec `latitude` et `radius`)."
+        ),
     )
     radius = serializers.IntegerField(
-        required=False, min_value=1, default=None, source="radius_km"
+        required=False,
+        min_value=1,
+        default=None,
+        source="radius_km",
+        help_text=(
+            "Filtre géographique : rayon de recherche en kilomètres "
+            "(à fournir avec `latitude` et `longitude`)."
+        ),
     )
 
     _GEO_FIELDS = ("latitude", "longitude", "radius_km")

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -391,6 +391,11 @@ paths:
         - `region` — un ou plusieurs codes région (ex. `11,84`)
         - `departement` — un ou plusieurs codes département (ex. `75,69`)
         - `pays` — un ou plusieurs codes pays alpha-3 (ex. `FRA,BEL`)
+        - filtre géographique par rayon autour d'un point, les trois paramètres
+          doivent être fournis ensemble :
+          - `latitude` — latitude du point en degrés décimaux (entre -90 et 90)
+          - `longitude` — longitude du point en degrés décimaux (entre -180 et 180)
+          - `radius` — rayon de recherche en kilomètres (entier positif)
 
         Les filtres à valeurs multiples acceptent une liste de valeurs séparées par une
         virgule. Une valeur invalide pour l'un de ces filtres renvoie une erreur `400`.
@@ -654,6 +659,15 @@ paths:
               * `WLF` - WLF
         description: Valeurs séparées par une virgule (ex. `75,69`).
       - in: query
+        name: latitude
+        schema:
+          type: number
+          format: double
+          maximum: 90
+          minimum: -90
+        description: 'Filtre géographique : latitude du point en degrés décimaux (à
+          fournir avec `longitude` et `radius`).'
+      - in: query
         name: lieu_de_travail
         schema:
           type: array
@@ -668,6 +682,15 @@ paths:
               * `SUR_SITE` - Sur site
               * `TELETRAVAIL` - Télétravail
         description: Valeurs séparées par une virgule (ex. `SUR_SITE,TELETRAVAIL`).
+      - in: query
+        name: longitude
+        schema:
+          type: number
+          format: double
+          maximum: 180
+          minimum: -180
+        description: 'Filtre géographique : longitude du point en degrés décimaux
+          (à fournir avec `latitude` et `radius`).'
       - in: query
         name: management
         schema:
@@ -1211,6 +1234,13 @@ paths:
               * `ZMB` - Zambie
               * `ZWE` - Zimbabwe
         description: Valeurs séparées par une virgule (ex. `FRA,BEL`).
+      - in: query
+        name: radius
+        schema:
+          type: integer
+          minimum: 1
+        description: 'Filtre géographique : rayon de recherche en kilomètres (à fournir
+          avec `latitude` et `longitude`).'
       - in: query
         name: region
         schema:

--- a/src/web/tests/presentation/ingestion/views/test_list_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_list_offers.py
@@ -382,6 +382,84 @@ def test_invalid_pays_returns_400(mock_offers_container, authenticated_client):
     assert "INVALID" in response.json()["error"]
 
 
+def test_geo_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(
+        URL, {"latitude": "48.8566", "longitude": "2.3522", "radius": "10"}
+    )
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            latitude=48.8566,
+            longitude=2.3522,
+            radius_km=10,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"latitude": "48.8566"},
+        {"longitude": "2.3522"},
+        {"radius": "10"},
+        {"latitude": "48.8566", "longitude": "2.3522"},
+        {"latitude": "48.8566", "radius": "10"},
+        {"longitude": "2.3522", "radius": "10"},
+    ],
+)
+def test_partial_geo_filter_returns_400(
+    mock_offers_container, authenticated_client, params
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, params)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_radius_below_one_returns_400(mock_offers_container, authenticated_client):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(
+        URL, {"latitude": "48.8566", "longitude": "2.3522", "radius": "0"}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_non_integer_radius_returns_400(mock_offers_container, authenticated_client):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(
+        URL, {"latitude": "48.8566", "longitude": "2.3522", "radius": "10.5"}
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"latitude": "-91", "longitude": "2.3522", "radius": "10"},
+        {"latitude": "48.8566", "longitude": "181", "radius": "10"},
+    ],
+)
+def test_out_of_range_lat_lon_returns_400(
+    mock_offers_container, authenticated_client, params
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, params)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
 def test_returns_error_500(mock_offers_container, authenticated_client):
     mock_usecase = MagicMock()
     mock_usecase.execute.side_effect = Exception("db error")


### PR DESCRIPTION
## 📝 Description

Ajoute les mêmes filtres géographiques que OfferSummariesView sur l'endpoint /offres, avec la documentation OpenAPI et les tests associés. #1097 

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
