### PR TITLE
✨(api) ajouter les filtres domaine, organisme et date_publication sur OffersListView

### DIFF
--- a/src/web/presentation/ingestion/openapi.py
+++ b/src/web/presentation/ingestion/openapi.py
@@ -275,6 +275,13 @@ critères suivants :
 - `region` — un ou plusieurs codes région (ex. `11,84`)
 - `departement` — un ou plusieurs codes département (ex. `75,69`)
 - `pays` — un ou plusieurs codes pays alpha-3 (ex. `FRA,BEL`)
+- `domaine` — un ou plusieurs codes de domaine fonctionnel (ex. `NUM,ACH`)
+- `organisme` — un ou plusieurs noms d'organisme (nom exact). Répéter le
+  paramètre pour filtrer sur plusieurs organismes (ex.
+  `?organisme=Foo&organisme=Bar`), ne pas séparer les valeurs par une
+  virgule, le nom d'un organisme pouvant en contenir une.
+- `date_publication` — nombre de jours négatif pour ne retourner que les
+  offres publiées au cours des N derniers jours (ex. `-7`)
 - filtre géographique par rayon autour d'un point, les trois paramètres
   doivent être fournis ensemble :
   - `latitude` — latitude du point en degrés décimaux (entre -90 et 90)

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -190,6 +190,37 @@ class ListOffersFiltersSerializer(serializers.Serializer):
         help_text="Valeurs séparées par une virgule (ex. `FRA,BEL`).",
         source="country",
     )
+    domaine = _CommaSeparatedCodeField(
+        DOMAIN_NAMES,
+        "domaine",
+        lambda code: code,
+        help_text="Valeurs séparées par une virgule (ex. `NUM,ACH`).",
+        source="domain",
+    )
+    organisme = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=None,
+        source="organization",
+        help_text=(
+            "Filtre sur l'organisme (nom exact). Répéter le paramètre pour "
+            "filtrer sur plusieurs organismes (ex. "
+            "`?organisme=Foo&organisme=Bar`). Ne pas séparer les valeurs par "
+            "une virgule, le nom d'un organisme pouvant en contenir une."
+        ),
+    )
+    date_publication = serializers.IntegerField(
+        required=False,
+        max_value=-1,
+        default=None,
+        source="published_within_days",
+        help_text=(
+            "Filtre sur la date de publication : nombre de jours négatif "
+            "pour ne retourner que les offres publiées au cours des N "
+            "derniers jours (ex. `-7` pour les offres publiées ces 7 "
+            "derniers jours)."
+        ),
+    )
     latitude = serializers.FloatField(
         required=False,
         min_value=-90,

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -391,6 +391,13 @@ paths:
         - `region` — un ou plusieurs codes région (ex. `11,84`)
         - `departement` — un ou plusieurs codes département (ex. `75,69`)
         - `pays` — un ou plusieurs codes pays alpha-3 (ex. `FRA,BEL`)
+        - `domaine` — un ou plusieurs codes de domaine fonctionnel (ex. `NUM,ACH`)
+        - `organisme` — un ou plusieurs noms d'organisme (nom exact). Répéter le
+          paramètre pour filtrer sur plusieurs organismes (ex.
+          `?organisme=Foo&organisme=Bar`), ne pas séparer les valeurs par une
+          virgule, le nom d'un organisme pouvant en contenir une.
+        - `date_publication` — nombre de jours négatif pour ne retourner que les
+          offres publiées au cours des N derniers jours (ex. `-7`)
         - filtre géographique par rayon autour d'un point, les trois paramètres
           doivent être fournis ensemble :
           - `latitude` — latitude du point en degrés décimaux (entre -90 et 90)
@@ -435,6 +442,14 @@ paths:
               * `B` - B
               * `C` - C
         description: Valeurs séparées par une virgule (ex. `A,B`).
+      - in: query
+        name: date_publication
+        schema:
+          type: integer
+          maximum: -1
+        description: 'Filtre sur la date de publication : nombre de jours négatif
+          pour ne retourner que les offres publiées au cours des N derniers jours
+          (ex. `-7` pour les offres publiées ces 7 derniers jours).'
       - in: query
         name: departement
         schema:
@@ -659,6 +674,73 @@ paths:
               * `WLF` - WLF
         description: Valeurs séparées par une virgule (ex. `75,69`).
       - in: query
+        name: domaine
+        schema:
+          type: array
+          items:
+            enum:
+            - ACH
+            - AGR
+            - AMT
+            - ASP
+            - BAT
+            - COM
+            - CTL
+            - CUL
+            - DEF
+            - DIR
+            - DOC
+            - ENS
+            - ENV
+            - FIP
+            - GBF
+            - GRH
+            - INT
+            - JUR
+            - JUS
+            - LOG
+            - MED
+            - NUM
+            - RCH
+            - REN
+            - SAN
+            - SEC
+            - SOC
+            - TRA
+            - USA
+            type: string
+            description: |-
+              * `ACH` - Achat
+              * `AGR` - Agriculture
+              * `AMT` - Aménagement et développement durable du territoire
+              * `ASP` - Animation, jeunesse et sports
+              * `BAT` - Bâtiment
+              * `COM` - Communication
+              * `CTL` - Organisation, contrôle et évaluation
+              * `CUL` - Culture et Patrimoine
+              * `DEF` - Défense
+              * `DIR` - Direction et pilotage des politiques publiques
+              * `DOC` - Lecture publique et Documentation
+              * `ENS` - Enseignement et Formation
+              * `ENV` - Environnement
+              * `FIP` - Finances publiques
+              * `GBF` - Gestion budgétaire et financière
+              * `GRH` - Ressources humaines
+              * `INT` - International
+              * `JUR` - Affaires juridiques
+              * `JUS` - Justice
+              * `LOG` - Interventions techniques et logistiques
+              * `MED` - Médical et paramédical
+              * `NUM` - Numérique
+              * `RCH` - Recherche
+              * `REN` - Renseignement
+              * `SAN` - Prévention, conseil et pilotage en santé
+              * `SEC` - Sécurité
+              * `SOC` - Social, enfance et famille
+              * `TRA` - Transports
+              * `USA` - Relation à l'usager
+        description: Valeurs séparées par une virgule (ex. `NUM,ACH`).
+      - in: query
         name: latitude
         schema:
           type: number
@@ -719,6 +801,16 @@ paths:
               * `CONFIRME` - Confirmé
               * `EXPERT` - Expert
         description: Valeurs séparées par une virgule (ex. `DEBUTANT,EXPERT`).
+      - in: query
+        name: organisme
+        schema:
+          type: array
+          items:
+            type: string
+        description: Filtre sur l'organisme (nom exact). Répéter le paramètre pour
+          filtrer sur plusieurs organismes (ex. `?organisme=Foo&organisme=Bar`). Ne
+          pas séparer les valeurs par une virgule, le nom d'un organisme pouvant en
+          contenir une.
       - name: page
         required: false
         in: query

--- a/src/web/tests/presentation/ingestion/views/test_list_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_list_offers.py
@@ -9,6 +9,7 @@ from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.country import Country
 from referentiel.value_objects.department import Department
+from referentiel.value_objects.domaine_fonctionnel import DomaineFonctionnel
 from referentiel.value_objects.experience_level import ExperienceLevel
 from referentiel.value_objects.offer_conditions import Management, WorkingPlace
 from referentiel.value_objects.region import Region
@@ -380,6 +381,95 @@ def test_invalid_pays_returns_400(mock_offers_container, authenticated_client):
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "INVALID" in response.json()["error"]
+
+
+def test_domaine_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"domaine": "NUM,ACH"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            domain=[DomaineFonctionnel.NUMERIQUE.value, DomaineFonctionnel.ACHAT.value],
+        )
+    )
+
+
+def test_invalid_domaine_returns_400(mock_offers_container, authenticated_client):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"domaine": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+
+
+def test_organisme_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, [("organisme", "Mairie de Paris")])
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            organization=["Mairie de Paris"],
+        )
+    )
+
+
+def test_organisme_filter_with_multiple_values_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(
+        URL,
+        [
+            ("organisme", "Mairie de Paris"),
+            ("organisme", "Société Générale, SA"),
+        ],
+    )
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            organization=["Mairie de Paris", "Société Générale, SA"],
+        )
+    )
+
+
+def test_date_publication_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"date_publication": "-7"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            published_within_days=-7,
+        )
+    )
+
+
+def test_positive_date_publication_returns_400(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"date_publication": "7"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_geo_filter_is_forwarded_to_usecase(


### PR DESCRIPTION
## 📝 Description

Ajoute les mêmes filtres domaine/organisme/date de publication que OfferSummariesView (#1099) sur l'endpoint /offres, avec la documentation OpenAPI et les tests associés.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
