### PR TITLE
✨(ats-recrutements) Clarification comportement drawer et modale traitement par lot

### DIFF
--- a/src/web/presentation/frontend/src/features/candidatures/components/ChangerEtapeDrawer.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/components/ChangerEtapeDrawer.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   sourceEtape: EtapeRecrutementDetailedCandidatures | null
   selectedCandidatureUuids: Set<string>
   etapes: EtapeRecrutement[]
+  initialEtapeUuid?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -25,7 +26,7 @@ const selectedEtapeUuid = ref<string>('')
 
 watch(() => props.open, (isOpen) => {
   if (isOpen) {
-    selectedEtapeUuid.value = ''
+    selectedEtapeUuid.value = props.initialEtapeUuid ?? ''
   }
 })
 

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
@@ -43,9 +43,19 @@ const boardId = computed(() => `kanban-${recrutementUuid.value}`)
 const isDrawerOpen = ref(false)
 const isRefusDialogOpen = ref(false)
 const drawerInitialEtapeUuid = ref<string | null>(null)
+const pendingMove = ref<KanbanDropEvent | null>(null)
 
 const refusEtapeUuid = computed(() => {
   return recrutementEtapes.value.find(e => e.categorie === 'REFUS')?.etape_uuid ?? null
+})
+
+const pendingCandidature = computed(() => {
+  const move = pendingMove.value
+  if (!move)
+    return null
+
+  const etape = candidatureKanban.value.find(e => e.etape_uuid === move.sourceColumnId)
+  return etape?.candidatures.find(c => c.uuid === move.cardId) ?? null
 })
 
 const sourceEtape = computed(() => {
@@ -61,6 +71,12 @@ const selectedCandidatureUuids = computed(() => {
 })
 
 function handleMove(event: KanbanDropEvent) {
+  if (event.sourceColumnId !== event.targetColumnId && event.targetColumnId === refusEtapeUuid.value) {
+    pendingMove.value = event
+    isRefusDialogOpen.value = true
+    return
+  }
+
   moveCandidature({
     sourceColumnId: event.sourceColumnId,
     targetColumnId: event.targetColumnId,
@@ -83,22 +99,21 @@ function handleRefuser(): void {
 }
 
 function handleConfirmRefus(): void {
-  const refusEtape = recrutementEtapes.value.find(e => e.categorie === 'REFUS')
-  if (!refusEtape)
+  if (!pendingMove.value)
     return
 
-  const candidaturesByEtape = new Map<string, string[]>()
-
-  for (const [etapeUuid, uuids] of selectedByEtape.value) {
-    candidaturesByEtape.set(etapeUuid, [...uuids])
-  }
-
-  moveCandidaturesBatch({
-    candidaturesByEtape,
-    targetColumnId: refusEtape.etape_uuid,
+  moveCandidature({
+    sourceColumnId: pendingMove.value.sourceColumnId,
+    targetColumnId: pendingMove.value.targetColumnId,
+    cardId: pendingMove.value.cardId,
   })
 
-  clearSelection()
+  pendingMove.value = null
+  isRefusDialogOpen.value = false
+}
+
+function handleCancelRefus(): void {
+  pendingMove.value = null
   isRefusDialogOpen.value = false
 }
 
@@ -132,12 +147,14 @@ const countLabel = computed(() => {
 })
 
 const refusDescription = computed(() => {
-  const n = selectedCount.value
-  return `Vous êtes sur le point de refuser ${n} ${pluralize(n, 'candidature')}. `
-    + `Cette action n'est pas définitive, néanmoins ${pluralize(n, 'le', 'les')} `
-    + `${pluralize(n, 'candidat', 'candidats')} ${pluralize(n, 'sera', 'seront')} `
-    + `${pluralize(n, 'informé', 'informés')} du changement de statut de `
-    + `${pluralize(n, 'sa', 'leur')} candidature.`
+  const candidature = pendingCandidature.value
+  const candidatLabel = candidature
+    ? `${candidature.candidat.prenom} ${candidature.candidat.nom}`
+    : 'ce candidat'
+
+  return `Vous êtes sur le point de refuser la candidature de ${candidatLabel}. `
+    + `Cette action n'est pas définitive, néanmoins le candidat sera informé du changement `
+    + `de statut de sa candidature.`
 })
 </script>
 
@@ -195,7 +212,7 @@ const refusDescription = computed(() => {
       :open="isRefusDialogOpen"
       size="sm"
       title="Refus de candidature"
-      @update:open="isRefusDialogOpen = $event"
+      @update:open="(open) => { if (!open) handleCancelRefus() }"
     >
       {{ refusDescription }}
 
@@ -204,7 +221,7 @@ const refusDescription = computed(() => {
           <CspButton
             label="Annuler"
             variant="secondary"
-            @click="isRefusDialogOpen = false"
+            @click="handleCancelRefus"
           />
           <CspButton
             label="Valider"

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesKanbanView.vue
@@ -42,6 +42,11 @@ const {
 const boardId = computed(() => `kanban-${recrutementUuid.value}`)
 const isDrawerOpen = ref(false)
 const isRefusDialogOpen = ref(false)
+const drawerInitialEtapeUuid = ref<string | null>(null)
+
+const refusEtapeUuid = computed(() => {
+  return recrutementEtapes.value.find(e => e.categorie === 'REFUS')?.etape_uuid ?? null
+})
 
 const sourceEtape = computed(() => {
   if (!currentEtapeUuid.value)
@@ -68,11 +73,13 @@ function handleToggleColumnSelection(etape: EtapeRecrutementDetailedCandidatures
 }
 
 function handleOpenChangerEtape(): void {
+  drawerInitialEtapeUuid.value = null
   isDrawerOpen.value = true
 }
 
 function handleRefuser(): void {
-  isRefusDialogOpen.value = true
+  drawerInitialEtapeUuid.value = refusEtapeUuid.value
+  isDrawerOpen.value = true
 }
 
 function handleConfirmRefus(): void {
@@ -178,6 +185,7 @@ const refusDescription = computed(() => {
       :source-etape="sourceEtape"
       :selected-candidature-uuids="selectedCandidatureUuids"
       :etapes="recrutementEtapes"
+      :initial-etape-uuid="drawerInitialEtapeUuid"
       @update:open="handleDrawerClose"
       @confirm="handleConfirmBatchMove"
       @toggle-candidature="handleToggleCandidature"


### PR DESCRIPTION
## 📝 Description
Lors d'une sélection par lot, le bouton raccourci `refuser` doit ouvrir le panneau latéral avec l'étape `refus` pré-sélectionnée.
Le drag and drop d'une seule carte en colonne `refus` doit ouvrir la modale de refus.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)
<img width="1510" height="835" alt="Capture d’écran 2026-08-06 à 11 53 12" src="https://github.com/user-attachments/assets/5f265735-dfa8-49f2-b98d-824aa4eb35d4" />
<img width="1509" height="838" alt="Capture d’écran 2026-08-06 à 11 53 42" src="https://github.com/user-attachments/assets/9e4d5c71-251a-4619-81f5-f06d45c9677c" />

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
