### PR TITLE
✨(ats-recrutements) Ajoute un autoscroll au kanban pour améliorer l'ux

### DIFF
--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@atlaskit/pragmatic-drag-and-drop':
         specifier: ^2.0.1
         version: 2.0.1
+      '@atlaskit/pragmatic-drag-and-drop-auto-scroll':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@atlaskit/pragmatic-drag-and-drop-hitbox':
         specifier: ^2.0.0
         version: 2.0.0
@@ -271,6 +274,9 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@atlaskit/pragmatic-drag-and-drop-auto-scroll@3.0.0':
+    resolution: {integrity: sha512-8TlkMi417zIPrTnCpbNV0Ce63JTKBn3dGkqiadkGQROvzDAox7Y9TYRHpvbQiEdtPoHWnmyRBi+RsGDxXsQxgQ==}
 
   '@atlaskit/pragmatic-drag-and-drop-hitbox@2.0.0':
     resolution: {integrity: sha512-vkXCB/23pT8YgYU8biGmR9uu0fr9oWoaq2GMSKyiNPk3reA12XVrCdgB2SLBoB24Ic1FOm9PdaQJ9ZSUQdCVpw==}
@@ -4551,6 +4557,11 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@atlaskit/pragmatic-drag-and-drop-auto-scroll@3.0.0':
+    dependencies:
+      '@atlaskit/pragmatic-drag-and-drop': 2.0.1
+      '@babel/runtime': 7.29.7
 
   '@atlaskit/pragmatic-drag-and-drop-hitbox@2.0.0':
     dependencies:

--- a/src/web/presentation/frontend/package.json
+++ b/src/web/presentation/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
     "@atlaskit/pragmatic-drag-and-drop-live-region": "^2.0.0",
     "@iconify/vue": "^5.0.1",

--- a/src/web/presentation/frontend/src/composables/dnd/useKanbanDnd.ts
+++ b/src/web/presentation/frontend/src/composables/dnd/useKanbanDnd.ts
@@ -1,5 +1,6 @@
 import type { Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 import type { Ref } from 'vue'
+import { autoScrollForElements } from '@atlaskit/pragmatic-drag-and-drop-auto-scroll/element'
 import { attachClosestEdge, extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 import { draggable, dropTargetForElements, monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
 import { onMounted, onUnmounted, ref, watch } from 'vue'
@@ -116,6 +117,25 @@ export function useDropTargetKanbanColumn(options: UseDropTargetKanbanColumnOpti
   )
 
   return { isDraggedOver, closestEdge }
+}
+
+interface UseKanbanBoardAutoScrollOptions {
+  element: Ref<HTMLElement | null>
+}
+
+export function useKanbanBoardAutoScroll(options: UseKanbanBoardAutoScrollOptions) {
+  watch(
+    options.element,
+    (element, _, onCleanup) => {
+      if (!element)
+        return
+
+      const cleanup = autoScrollForElements({ element })
+
+      onCleanup(cleanup)
+    },
+    { flush: 'post', immediate: true },
+  )
 }
 
 interface UseKanbanBoardMonitorOptions {

--- a/src/web/presentation/frontend/src/features/candidatures/components/CandidaturesKanbanBoard.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/components/CandidaturesKanbanBoard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { EtapeRecrutementDetailedCandidatures } from '../types'
 import type { KanbanDropEvent } from '@/composables/dnd/useKanbanDnd'
-import { useKanbanBoardMonitor } from '@/composables/dnd/useKanbanDnd'
+import { ref } from 'vue'
+import { useKanbanBoardAutoScroll, useKanbanBoardMonitor } from '@/composables/dnd/useKanbanDnd'
 import CandidatureKanbanColumn from './CandidatureKanbanColumn.vue'
 
 const props = defineProps<{
@@ -15,6 +16,8 @@ const emit = defineEmits<{
   toggleColumnSelection: [etape: EtapeRecrutementDetailedCandidatures]
 }>()
 
+const boardRef = ref<HTMLElement | null>(null)
+
 useKanbanBoardMonitor({
   boardId: props.boardId,
   onDrop: (event) => {
@@ -23,10 +26,15 @@ useKanbanBoardMonitor({
     }
   },
 })
+
+useKanbanBoardAutoScroll({ element: boardRef })
 </script>
 
 <template>
-  <div class="candidatures-kanban-board">
+  <div
+    ref="boardRef"
+    class="candidatures-kanban-board"
+  >
     <CandidatureKanbanColumn
       v-for="etape in etapes"
       :key="etape.etape_uuid"


### PR DESCRIPTION
## 📝 Description
**Problème**
Lorsqu'on drag and drop une candidature dans une colonne masqué par la taille de l'écran, le kanban doit scroller horizontalement. Le scroll est saccadé et difficile à atteindre.

**Solution**
Ajoute un autoscroll au kanban pour améliorer l'ux. Le scroll horizontal s'active maintenant automatiquement et de façon fluide quand on approche du bord du kanban pendant un drag.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
Ajout du package `@atlaskit/pragmatic-drag-and-drop-auto-scroll`
Nouvelle fonction `useKanbanBoardAutoScroll` dans `useKanbanDnd.ts`

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [ ] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
