### PR TITLE
✨(api) filtrer OfferSummariesView par mots-clés (recherche plein texte)

### DIFF
--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.1.28"
+version = "0.1.29"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/repositories/offers_repository_interface.py
+++ b/libs/referentiel/repositories/offers_repository_interface.py
@@ -48,6 +48,7 @@ class IOffersRepository(Protocol):
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
         radius_km: Optional[int] = None,
+        keywords: Optional[str] = None,
     ) -> IPage[Offer]: ...
 
     def get_by_source_id(self, source_id: UUID) -> IPage[Offer]: ...

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1226,7 +1226,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/application/ingestion/interfaces/list_offers_input.py
+++ b/src/web/application/ingestion/interfaces/list_offers_input.py
@@ -30,3 +30,4 @@ class GetFilteredOffersInput:
     latitude: Optional[float] = None
     longitude: Optional[float] = None
     radius_km: Optional[int] = None
+    keywords: Optional[str] = None

--- a/src/web/application/ingestion/usecases/list_offers.py
+++ b/src/web/application/ingestion/usecases/list_offers.py
@@ -35,4 +35,5 @@ class ListOffersUseCase(IUseCase[GetFilteredOffersInput, IPage[Offer]]):
             latitude=input_data.latitude,
             longitude=input_data.longitude,
             radius_km=input_data.radius_km,
+            keywords=input_data.keywords,
         )

--- a/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
+++ b/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
@@ -1,9 +1,12 @@
+import operator
 from datetime import datetime, timedelta
+from functools import reduce
 from typing import Dict, List
 from uuid import UUID
 
 from ddd.page_interface import IPage
 from ddd.services.logger_interface import ILogger
+from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.db import DatabaseError, transaction
 from django.db.models import F, FloatField, Q, Value
 from django.db.models.functions import ACos, Cos, Greatest, Least, Radians, Sin
@@ -28,6 +31,12 @@ from infrastructure.mappers.offer_mapper import OfferMapper
 from infrastructure.mappers.queryset_page import QuerySetPage
 
 EARTH_RADIUS_KM = 6371.0
+SEARCH_CONFIG = "french"
+KEYWORDS_SEARCH_WEIGHTS = {
+    "A": ("title",),
+    "B": ("long_title",),
+    "C": ("mission", "profile", "organization", "employer", "complements"),
+}
 
 
 class PostgresOffersRepository(IIngestionOffersRepository):
@@ -182,6 +191,7 @@ class PostgresOffersRepository(IIngestionOffersRepository):
         latitude: float | None = None,
         longitude: float | None = None,
         radius_km: int | None = None,
+        keywords: str | None = None,
     ) -> IPage[Offer]:
         qs = OfferModel.objects.filter(archived_at__isnull=active)
 
@@ -216,7 +226,13 @@ class PostgresOffersRepository(IIngestionOffersRepository):
         if latitude is not None and longitude is not None and radius_km is not None:
             qs = self._filter_by_radius(qs, latitude, longitude, radius_km)
 
-        return QuerySetPage(qs.order_by("-updated_at"), self.mapper.to_domain)
+        if keywords:
+            qs = self._filter_by_keywords(qs, keywords)
+            qs = qs.order_by("-rank", "-updated_at")
+        else:
+            qs = qs.order_by("-updated_at")
+
+        return QuerySetPage(qs, self.mapper.to_domain)
 
     @staticmethod
     def _apply_field_filters(qs, filters):
@@ -244,6 +260,18 @@ class PostgresOffersRepository(IIngestionOffersRepository):
             )
         )
         return qs.annotate(distance_km=distance_km).filter(distance_km__lte=radius_km)
+
+    @staticmethod
+    def _filter_by_keywords(qs, keywords: str):
+        vectors = [
+            SearchVector(*fields, weight=weight, config=SEARCH_CONFIG)
+            for weight, fields in KEYWORDS_SEARCH_WEIGHTS.items()
+        ]
+        search_vector = reduce(operator.add, vectors)
+        search_query = SearchQuery(keywords, config=SEARCH_CONFIG)
+        return qs.annotate(
+            search=search_vector, rank=SearchRank(search_vector, search_query)
+        ).filter(search=search_query)
 
     def get_by_source_id(self, source_id: UUID) -> IPage[Offer]:
         qs = OfferModel.objects.filter(source_id=source_id, archived_at__isnull=True)

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -265,6 +265,16 @@ class ListOffersFiltersSerializer(serializers.Serializer):
 
 
 class OfferSummariesQuerySerializer(serializers.Serializer):
+    keywords = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        help_text=(
+            "Recherche plein texte (en français) sur le titre, l'intitulé "
+            "long, la mission, le profil, l'organisme, l'employeur et les "
+            "compléments de l'offre."
+        ),
+    )
     start = serializers.IntegerField(required=False, min_value=0, default=0)
     count = serializers.IntegerField(
         required=False, min_value=1, max_value=1_000, default=100

--- a/src/web/presentation/ingestion/views/offer_summaries.py
+++ b/src/web/presentation/ingestion/views/offer_summaries.py
@@ -51,6 +51,7 @@ class OfferSummariesView(APIView):
                     latitude=query.validated_data.get("latitude"),
                     longitude=query.validated_data.get("longitude"),
                     radius_km=query.validated_data.get("radius_km"),
+                    keywords=query.validated_data.get("keywords"),
                 )
             )
 

--- a/src/web/tests/infrastructure/referentiel/test_postgres_offers_repository.py
+++ b/src/web/tests/infrastructure/referentiel/test_postgres_offers_repository.py
@@ -424,6 +424,121 @@ class TestGetFilteredByPublicationDate:
         assert page.count() == len(offers)
 
 
+class TestGetFilteredByKeywords:
+    def test_filters_offers_matching_keywords_in_title(self, db, repository):
+        developpeur = OfferFactory.create_model(
+            title="Développeur informatique",
+            mission="Développement d'applications web",
+        )
+        OfferFactory.create_model(
+            title="Jardinier paysagiste", mission="Entretien des espaces verts"
+        )
+
+        page = repository.get_filtered(
+            active=True,
+            external_id_contains=None,
+            keywords="développeur",
+        )
+
+        ids = {offer.id for offer in page.slice(0, 10)}
+        assert ids == {developpeur.id}
+
+    def test_matches_across_multiple_fields(self, db, repository):
+        offer = OfferFactory.create_model(
+            title="Chargé de mission",
+            organization="Mairie de Bordeaux",
+        )
+        OfferFactory.create_model(
+            title="Chargé de mission", organization="Mairie de Nantes"
+        )
+
+        page = repository.get_filtered(
+            active=True,
+            external_id_contains=None,
+            keywords="Bordeaux",
+        )
+
+        ids = {o.id for o in page.slice(0, 10)}
+        assert ids == {offer.id}
+
+    def test_no_match_returns_empty_page(self, db, repository):
+        OfferFactory.create_model(title="Développeur informatique")
+
+        page = repository.get_filtered(
+            active=True,
+            external_id_contains=None,
+            keywords="astrophysicien",
+        )
+
+        assert page.count() == 0
+
+    def test_no_keywords_filter_returns_all_offers(self, db, repository):
+        offers = OfferFactory.create_model_batch(2)
+
+        page = repository.get_filtered(
+            active=True,
+            external_id_contains=None,
+        )
+
+        assert page.count() == len(offers)
+
+    def test_multiple_keywords_require_all_terms_to_match(self, db, repository):
+        both_terms = OfferFactory.create_model(
+            title="Développeur back-end Python",
+        )
+        OfferFactory.create_model(title="Développeur front-end JavaScript")
+        OfferFactory.create_model(title="Chef de projet Python")
+
+        page = repository.get_filtered(
+            active=True,
+            external_id_contains=None,
+            keywords="développeur python",
+        )
+
+        ids = {offer.id for offer in page.slice(0, 10)}
+        assert ids == {both_terms.id}
+
+    def test_combines_with_another_filter(self, db, repository):
+        matching = OfferFactory.create_model(
+            title="Développeur informatique", functional_area_code="NUM"
+        )
+        OfferFactory.create_model(
+            title="Développeur informatique", functional_area_code="ACH"
+        )
+        OfferFactory.create_model(
+            title="Jardinier paysagiste", functional_area_code="NUM"
+        )
+
+        page = repository.get_filtered(
+            active=True,
+            external_id_contains=None,
+            keywords="développeur",
+            domain=["NUM"],
+        )
+
+        ids = {offer.id for offer in page.slice(0, 10)}
+        assert ids == {matching.id}
+
+    def test_results_are_ranked_with_title_matches_first(self, db, repository):
+        title_match = OfferFactory.create_model(
+            title="Développeur informatique",
+            mission="Gestion de projets divers",
+        )
+        mission_match = OfferFactory.create_model(
+            title="Chargé de mission",
+            mission="Encadrement d'une équipe de développeurs",
+        )
+
+        page = repository.get_filtered(
+            active=True,
+            external_id_contains=None,
+            keywords="développeur",
+        )
+
+        ids = [offer.id for offer in page.slice(0, 10)]
+        assert ids == [title_match.id, mission_match.id]
+
+
 class TestGetBySourceId:
     def test_returns_only_non_archived_offers_for_source(self, db, repository):
         source_id = SourceFactory.create_model().source_id

--- a/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
+++ b/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
@@ -474,6 +474,35 @@ def test_organization_filter_with_multiple_values_is_forwarded_to_usecase(
     )
 
 
+def test_keywords_filter_is_forwarded_to_usecase(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"keywords": "développeur informatique"})
+
+    mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            keywords="développeur informatique",
+        )
+    )
+
+
+def test_blank_keywords_is_treated_as_not_provided(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"keywords": ""})
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(active=True, external_id_contains=None)
+    )
+
+
 def test_publication_date_filter_is_forwarded_to_usecase(
     mock_offer_summaries_container, authenticated_client
 ):

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },


### PR DESCRIPTION
## 📝 Description

Ajoute un filtre `keywords` sur `OfferSummariesView` utilisant la recherche plein texte PostgreSQL (`SearchVector`/`SearchQuery`/`SearchRank`, config française) sur titre, intitulé long, mission, profil, organisme, employeur et compléments, avec le titre pondéré plus fort et un tri par score de pertinence décroissant.

#941 

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
