### PR TITLE
✨(api) filtrer OffersListView par mots-clés (recherche plein texte)

### DIFF
--- a/src/web/presentation/ingestion/openapi.py
+++ b/src/web/presentation/ingestion/openapi.py
@@ -287,6 +287,9 @@ critères suivants :
   - `latitude` — latitude du point en degrés décimaux (entre -90 et 90)
   - `longitude` — longitude du point en degrés décimaux (entre -180 et 180)
   - `radius` — rayon de recherche en kilomètres (entier positif)
+- `mots_cles` — recherche plein texte (en français) sur le titre,
+  l'intitulé long, la mission, le profil, l'organisme, l'employeur et les
+  compléments de l'offre
 
 Les filtres à valeurs multiples acceptent une liste de valeurs séparées par une
 virgule. Une valeur invalide pour l'un de ces filtres renvoie une erreur `400`.

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -251,6 +251,17 @@ class ListOffersFiltersSerializer(serializers.Serializer):
             "(à fournir avec `latitude` et `longitude`)."
         ),
     )
+    mots_cles = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        source="keywords",
+        help_text=(
+            "Recherche plein texte (en français) sur le titre, l'intitulé "
+            "long, la mission, le profil, l'organisme, l'employeur et les "
+            "compléments de l'offre."
+        ),
+    )
 
     _GEO_FIELDS = ("latitude", "longitude", "radius_km")
 

--- a/src/web/presentation/static/api/guide_api.md
+++ b/src/web/presentation/static/api/guide_api.md
@@ -129,6 +129,7 @@ par lots plutôt qu'en une seule fois). La pagination se pilote avec les paramè
 | `organisme` | Filtrer par nom exact d'organisme | Répéter le paramètre pour en filtrer plusieurs (ex. `?organisme=Foo&organisme=Bar`) — ne pas séparer les valeurs par une virgule, un nom d'organisme pouvant en contenir une |
 | `date_publication` | Ne retourner que les offres publiées au cours des N derniers jours | Entier négatif (ex. `-7`) |
 | `latitude`, `longitude`, `radius` | Filtre géographique par rayon autour d'un point — **les trois doivent être fournis ensemble** | `latitude`/`longitude` en degrés décimaux, `radius` en kilomètres (entier positif) |
+| `mots_cles` | Recherche plein texte (en français) sur le titre, l'intitulé long, la mission, le profil, l'organisme, l'employeur et les compléments de l'offre | Texte libre |
 
 > Les filtres à valeurs multiples acceptent une liste de valeurs séparées par une
 > virgule. Une valeur invalide pour l'un de ces filtres renvoie une erreur `400`.

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -403,6 +403,9 @@ paths:
           - `latitude` — latitude du point en degrés décimaux (entre -90 et 90)
           - `longitude` — longitude du point en degrés décimaux (entre -180 et 180)
           - `radius` — rayon de recherche en kilomètres (entier positif)
+        - `mots_cles` — recherche plein texte (en français) sur le titre,
+          l'intitulé long, la mission, le profil, l'organisme, l'employeur et les
+          compléments de l'offre
 
         Les filtres à valeurs multiples acceptent une liste de valeurs séparées par une
         virgule. Une valeur invalide pour l'un de ces filtres renvoie une erreur `400`.
@@ -786,6 +789,14 @@ paths:
               * `SANS` - Sans management
               * `AVEC` - Avec management
         description: Valeurs séparées par une virgule (ex. `SANS,AVEC`).
+      - in: query
+        name: mots_cles
+        schema:
+          type: string
+          minLength: 1
+        description: Recherche plein texte (en français) sur le titre, l'intitulé
+          long, la mission, le profil, l'organisme, l'employeur et les compléments
+          de l'offre.
       - in: query
         name: niveau_experience
         schema:

--- a/src/web/tests/presentation/ingestion/views/test_list_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_list_offers.py
@@ -446,6 +446,35 @@ def test_organisme_filter_with_multiple_values_is_forwarded_to_usecase(
     )
 
 
+def test_keywords_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"mots_cles": "développeur informatique"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            keywords="développeur informatique",
+        )
+    )
+
+
+def test_blank_keywords_is_treated_as_not_provided(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"mots_cles": ""})
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(active=True, external_id_contains=None)
+    )
+
+
 def test_date_publication_filter_is_forwarded_to_usecase(
     mock_offers_container, authenticated_client
 ):


### PR DESCRIPTION
## 📝 Description
Ajoute un filtre `mots_cles` sur `OffersListView` (`GET /api/v1/offres/`), réutilisant le filtre plein texte PostgreSQL déjà en place pour OfferSummariesView. Mets à jour le schéma OpenAPI et `guide_api.md`.

#1110 

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
