### PR TITLE
✨(api) filtrer OfferSummariesView par zone géographique (area)

### DIFF
--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.1.29"
+version = "0.1.30"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/repositories/offers_repository_interface.py
+++ b/libs/referentiel/repositories/offers_repository_interface.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from ddd.page_interface import IPage
 
 from referentiel.entities.offer import Offer
+from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.country import Country
@@ -42,6 +43,7 @@ class IOffersRepository(Protocol):
         region: Optional[List[Region]] = None,
         department: Optional[List[Department]] = None,
         country: Optional[List[Country]] = None,
+        area: Optional[List[GeographicalArea]] = None,
         domain: Optional[List[str]] = None,
         organization: Optional[List[str]] = None,
         published_within_days: Optional[int] = None,

--- a/libs/referentiel/value_objects/area.py
+++ b/libs/referentiel/value_objects/area.py
@@ -8,6 +8,7 @@ class GeographicalArea(Enum):
     AMERIQUE = "AM"
     OCEANIE = "OC"
     ANTARTIQUE = "AN"
+    MOYEN_ORIENT_AFRIQUE_DU_NORD = "MO"
 
     def __str__(self):
         return self.value

--- a/src/ingestion/infrastructure/gateways/offers_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/offers_cleaner.py
@@ -31,7 +31,9 @@ _TALENTSOFT_TO_AREA: dict[str, GeographicalArea] = {
     "_TS_CO_GeographicalArea_AmriquesCaraibe": GeographicalArea.AMERIQUE,
     "_TS_CO_GeographicalArea_Asie": GeographicalArea.ASIE,
     "_TS_CO_GeographicalArea_Europe": GeographicalArea.EUROPE,
-    "_TS_CO_GeographicalArea_MoyenOrientAfriqueduNord": GeographicalArea.AFRIQUE,
+    "_TS_CO_GeographicalArea_MoyenOrientAfriqueduNord": (
+        GeographicalArea.MOYEN_ORIENT_AFRIQUE_DU_NORD
+    ),
     "_TS_CO_GeographicalArea_Ocanie": GeographicalArea.OCEANIE,
 }
 

--- a/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
+++ b/src/ingestion/tests/unit/gateways/test_offers_cleaner.py
@@ -189,6 +189,15 @@ def test_clean_maps_category_from_custom_fields(
             "84",
             "988",
         ),
+        (
+            "_TS_CO_GeographicalArea_MoyenOrientAfriqueduNord",
+            "FRA",
+            "R11",
+            "75",
+            "MO",
+            "11",
+            "75",
+        ),
     ],
 )
 def test_clean_maps_geographical_area(

--- a/src/ingestion/tests/unit/test_value_objects.py
+++ b/src/ingestion/tests/unit/test_value_objects.py
@@ -55,6 +55,7 @@ class TestGeographicalArea:
         assert GeographicalArea.AMERIQUE.value == "AM"
         assert GeographicalArea.OCEANIE.value == "OC"
         assert GeographicalArea.ANTARTIQUE.value == "AN"
+        assert GeographicalArea.MOYEN_ORIENT_AFRIQUE_DU_NORD.value == "MO"
 
 
 class TestLocalisation:

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1226,7 +1226,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/application/ingestion/interfaces/list_offers_input.py
+++ b/src/web/application/ingestion/interfaces/list_offers_input.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.country import Country
@@ -24,6 +25,7 @@ class GetFilteredOffersInput:
     region: Optional[List[Region]] = None
     department: Optional[List[Department]] = None
     country: Optional[List[Country]] = None
+    area: Optional[List[GeographicalArea]] = None
     domain: Optional[List[str]] = None
     organization: Optional[List[str]] = None
     published_within_days: Optional[int] = None

--- a/src/web/application/ingestion/usecases/list_offers.py
+++ b/src/web/application/ingestion/usecases/list_offers.py
@@ -29,6 +29,7 @@ class ListOffersUseCase(IUseCase[GetFilteredOffersInput, IPage[Offer]]):
             region=input_data.region,
             department=input_data.department,
             country=input_data.country,
+            area=input_data.area,
             domain=input_data.domain,
             organization=input_data.organization,
             published_within_days=input_data.published_within_days,

--- a/src/web/infrastructure/gateways/ingestion/offers_cleaner.py
+++ b/src/web/infrastructure/gateways/ingestion/offers_cleaner.py
@@ -33,7 +33,9 @@ _TALENTSOFT_TO_AREA: dict[str, GeographicalArea] = {
     "_TS_CO_GeographicalArea_AmriquesCaraibe": GeographicalArea.AMERIQUE,
     "_TS_CO_GeographicalArea_Asie": GeographicalArea.ASIE,
     "_TS_CO_GeographicalArea_Europe": GeographicalArea.EUROPE,
-    "_TS_CO_GeographicalArea_MoyenOrientAfriqueduNord": GeographicalArea.AFRIQUE,
+    "_TS_CO_GeographicalArea_MoyenOrientAfriqueduNord": (
+        GeographicalArea.MOYEN_ORIENT_AFRIQUE_DU_NORD
+    ),
     "_TS_CO_GeographicalArea_Ocanie": GeographicalArea.OCEANIE,
 }
 

--- a/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
+++ b/src/web/infrastructure/repositories/shared/postgres_offers_repository.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from referentiel.entities.offer import Offer
 from referentiel.exceptions.offer_errors import OfferDoesNotExist
 from referentiel.types import IUpsertResult
+from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.country import Country
@@ -185,6 +186,7 @@ class PostgresOffersRepository(IIngestionOffersRepository):
         region: List[Region] | None = None,
         department: List[Department] | None = None,
         country: List[Country] | None = None,
+        area: List[GeographicalArea] | None = None,
         domain: List[str] | None = None,
         organization: List[str] | None = None,
         published_within_days: int | None = None,
@@ -214,6 +216,7 @@ class PostgresOffersRepository(IIngestionOffersRepository):
                 ("region__in", region, lambda r: r.code),
                 ("department__in", department, lambda d: d.code),
                 ("country__in", country, str),
+                ("area__in", area, lambda a: a.value),
                 ("functional_area_code__in", domain, str),
                 ("organization__in", organization, str),
             ],

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -647,9 +647,10 @@ export interface components {
          *     * `AM` - AMERIQUE
          *     * `OC` - OCEANIE
          *     * `AN` - ANTARTIQUE
+         *     * `MO` - MOYEN_ORIENT_AFRIQUE_DU_NORD
          * @enum {string}
          */
-        ZoneGeographiqueEnum: "AF" | "EU" | "AS" | "AM" | "OC" | "AN";
+        ZoneGeographiqueEnum: "AF" | "EU" | "AS" | "AM" | "OC" | "AN" | "MO";
     };
     responses: never;
     parameters: never;

--- a/src/web/presentation/ingestion/legacy_client_aliases.py
+++ b/src/web/presentation/ingestion/legacy_client_aliases.py
@@ -32,6 +32,15 @@ WORKING_PLACE_CODE_ALIASES = {
     "1814": "TELETRAVAIL",
 }
 
+AREA_CODE_ALIASES = {
+    "22": "EUROPE",
+    "19": "AFRIQUE",
+    "20": "AMERIQUE",
+    "21": "ASIE",
+    "23": "MOYEN_ORIENT_AFRIQUE_DU_NORD",
+    "24": "OCEANIE",
+}
+
 REGION_CODE_ALIASES = {
     "198": "84",
     "200": "27",

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -2,6 +2,7 @@ import gettext
 
 import pycountry
 from drf_spectacular.utils import extend_schema_field
+from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractKind, ContractType
 from referentiel.value_objects.country import Country
@@ -25,6 +26,7 @@ from rest_framework import serializers
 from presentation.api.serializers import GenericErrorSerializer
 from presentation.commons.serializers import LocalisationSerializer, OrganismeSerializer
 from presentation.ingestion.legacy_client_aliases import (
+    AREA_CODE_ALIASES,
     CATEGORY_CODE_ALIASES,
     CONTRACT_TYPE_CODE_ALIASES,
     COUNTRY_CODE_ALIASES,
@@ -127,14 +129,14 @@ class _CommaSeparatedCodeField(serializers.MultipleChoiceField):
 def _resolve_location_codes(value):
     """
     For each legacy client identifier provided in `locations`, detects
-    whether it refers to a country, a region or a department, then
-    translates it to the corresponding target code. Legacy identifiers are
-    unique across the three referentials, so a given identifier can only
-    match one type.
+    whether it refers to a country, a region, a department or a
+    geographical area, then translates it to the corresponding target
+    code. Legacy identifiers are unique across the four referentials, so a
+    given identifier can only match one type.
     """
     requested = [part.strip() for part in value.split(",") if part.strip()]
 
-    countries, regions, departments, invalid = [], [], [], []
+    countries, regions, departments, areas, invalid = [], [], [], [], []
     for code in requested:
         if code in COUNTRY_CODE_ALIASES:
             countries.append(COUNTRY_CODE_ALIASES[code])
@@ -142,6 +144,8 @@ def _resolve_location_codes(value):
             regions.append(REGION_CODE_ALIASES[code])
         elif code in DEPARTMENT_CODE_ALIASES:
             departments.append(DEPARTMENT_CODE_ALIASES[code])
+        elif code in AREA_CODE_ALIASES:
+            areas.append(AREA_CODE_ALIASES[code])
         else:
             invalid.append(code)
 
@@ -150,7 +154,7 @@ def _resolve_location_codes(value):
             "Valeurs de localisation invalides : {}.".format(", ".join(invalid))
         )
 
-    return countries, regions, departments
+    return countries, regions, departments, areas
 
 
 class _AliasedIntegerField(serializers.IntegerField):
@@ -397,6 +401,9 @@ class OfferSummariesQuerySerializer(serializers.Serializer):
     country = _CommaSeparatedCodeField(
         COUNTRY_NAMES, "pays", Country, aliases=COUNTRY_CODE_ALIASES
     )
+    area = _CommaSeparatedEnumField(
+        GeographicalArea, "zone géographique", aliases=AREA_CODE_ALIASES
+    )
     domain = _CommaSeparatedCodeField(
         DOMAIN_NAMES, "domaine", lambda code: code, aliases=DOMAIN_CODE_ALIASES
     )
@@ -407,9 +414,10 @@ class OfferSummariesQuerySerializer(serializers.Serializer):
         help_text=(
             "Filtre géographique par identifiants du référentiel legacy du "
             "client, séparés par une virgule (ex. `?locations=27,208,330`). "
-            "Le type (pays, région ou département) de chaque identifiant est "
-            "détecté automatiquement et vient compléter les filtres "
-            "`country`, `region` et `department`."
+            "Le type (pays, région, département ou zone géographique) de "
+            "chaque identifiant est détecté automatiquement et vient "
+            "compléter les filtres `country`, `region`, `department` et "
+            "`area`."
         ),
     )
     organization = serializers.ListField(
@@ -480,8 +488,8 @@ class OfferSummariesQuerySerializer(serializers.Serializer):
 
         locations = data.pop("locations", None)
         if locations:
-            country_codes, region_codes, department_codes = _resolve_location_codes(
-                locations
+            country_codes, region_codes, department_codes, area_names = (
+                _resolve_location_codes(locations)
             )
             if country_codes:
                 data["country"] = (data.get("country") or []) + [
@@ -494,6 +502,10 @@ class OfferSummariesQuerySerializer(serializers.Serializer):
             if department_codes:
                 data["department"] = (data.get("department") or []) + [
                     Department(code=code) for code in department_codes
+                ]
+            if area_names:
+                data["area"] = (data.get("area") or []) + [
+                    GeographicalArea[name] for name in area_names
                 ]
 
         return data

--- a/src/web/presentation/ingestion/views/offer_summaries.py
+++ b/src/web/presentation/ingestion/views/offer_summaries.py
@@ -43,6 +43,7 @@ class OfferSummariesView(APIView):
                     region=query.validated_data.get("region"),
                     department=query.validated_data.get("department"),
                     country=query.validated_data.get("country"),
+                    area=query.validated_data.get("area"),
                     domain=query.validated_data.get("domain"),
                     organization=query.validated_data.get("organization"),
                     published_within_days=query.validated_data.get(

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -1856,6 +1856,7 @@ components:
       - AM
       - OC
       - AN
+      - MO
       type: string
       description: |-
         * `AF` - AFRIQUE
@@ -1864,6 +1865,7 @@ components:
         * `AM` - AMERIQUE
         * `OC` - OCEANIE
         * `AN` - ANTARTIQUE
+        * `MO` - MOYEN_ORIENT_AFRIQUE_DU_NORD
   securitySchemes:
     cookieAuth:
       type: apiKey

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -2981,6 +2981,7 @@ components:
       - AM
       - OC
       - AN
+      - MO
       type: string
       description: |-
         * `AF` - AFRIQUE
@@ -2989,6 +2990,7 @@ components:
         * `AM` - AMERIQUE
         * `OC` - OCEANIE
         * `AN` - ANTARTIQUE
+        * `MO` - MOYEN_ORIENT_AFRIQUE_DU_NORD
   securitySchemes:
     ApiKeyAuth:
       type: apiKey

--- a/src/web/tests/infrastructure/ingestion/test_clean_documents.py
+++ b/src/web/tests/infrastructure/ingestion/test_clean_documents.py
@@ -420,6 +420,16 @@ def test_execute_clean_offers_with_category(
             "84",
             "988",
         ),
+        (
+            "_TS_CO_GeographicalArea_MoyenOrientAfriqueduNord",
+            "FRA",
+            "R11",
+            "75",
+            "MO",
+            "FRA",
+            "11",
+            "75",
+        ),
     ],
 )
 def test_execute_clean_offers_with_geographical_area(

--- a/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
+++ b/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from django.urls import reverse
 from drf_spectacular.generators import SchemaGenerator
+from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.country import Country
@@ -567,12 +568,62 @@ def test_invalid_country_returns_400(
     assert "INVALID" in response.json()["error"]
 
 
-def test_locations_filter_detects_country_region_and_department(
+def test_area_filter_is_forwarded_to_usecase(
     mock_offer_summaries_container, authenticated_client
 ):
     _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
 
-    authenticated_client.get(URL, {"locations": "29,198,330"})
+    authenticated_client.get(URL, {"area": "EUROPE,AFRIQUE"})
+
+    mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            area=[GeographicalArea.EUROPE, GeographicalArea.AFRIQUE],
+        )
+    )
+
+
+def test_area_legacy_numeric_codes_are_translated(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"area": "22,19,20,21,23,24"})
+
+    mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            area=[
+                GeographicalArea.EUROPE,
+                GeographicalArea.AFRIQUE,
+                GeographicalArea.AMERIQUE,
+                GeographicalArea.ASIE,
+                GeographicalArea.MOYEN_ORIENT_AFRIQUE_DU_NORD,
+                GeographicalArea.OCEANIE,
+            ],
+        )
+    )
+
+
+def test_invalid_area_returns_400(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"area": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+
+
+def test_locations_filter_detects_country_region_department_and_area(
+    mock_offer_summaries_container, authenticated_client
+):
+    _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"locations": "29,198,330,19"})
 
     mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
         GetFilteredOffersInput(
@@ -581,6 +632,7 @@ def test_locations_filter_detects_country_region_and_department(
             country=[Country("DEU")],
             region=[Region(code="84")],
             department=[Department(code="01")],
+            area=[GeographicalArea.AFRIQUE],
         )
     )
 
@@ -591,7 +643,13 @@ def test_locations_filter_is_merged_with_explicit_filters(
     _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
 
     authenticated_client.get(
-        URL, {"locations": "198", "region": "11", "country": "fra"}
+        URL,
+        {
+            "locations": "198,19",
+            "region": "11",
+            "country": "fra",
+            "area": "EUROPE",
+        },
     )
 
     mock_offer_summaries_container.list_offers_usecase.return_value.execute.assert_called_once_with(
@@ -600,6 +658,7 @@ def test_locations_filter_is_merged_with_explicit_filters(
             external_id_contains=None,
             country=[Country("FRA")],
             region=[Region(code="11"), Region(code="84")],
+            area=[GeographicalArea.EUROPE, GeographicalArea.AFRIQUE],
         )
     )
 

--- a/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
+++ b/src/web/tests/presentation/ingestion/views/test_offer_summaries.py
@@ -607,9 +607,7 @@ def test_area_legacy_numeric_codes_are_translated(
     )
 
 
-def test_invalid_area_returns_400(
-    mock_offer_summaries_container, authenticated_client
-):
+def test_invalid_area_returns_400(mock_offer_summaries_container, authenticated_client):
     _make_paginated_mock(mock_offer_summaries_container, total=0, offers_slice=[])
 
     response = authenticated_client.get(URL, {"area": "INVALID"})

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },


### PR DESCRIPTION
## 📝 Description

Ajoute le filtre `area` sur `OfferSummariesView`, basé sur `GeographicalArea` (zone continentale déjà présente sur `Offer` mais jamais exposée). Gère également les codes legacy du client (19-24) et détecte désormais les zones dans le filtre `locations=`, au même titre que pays/région/département.

Ajoute par ailleurs la zone Moyen-Orient/Afrique du Nord, jusqu'ici mappée à tort sur Afrique dans le mapping TalentSoft.

Fixes https://github.com/betagouv/csplab/issues/1133
En lien avec #941 

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
