### PR TITLE
✨(api) filtrer OffersListView par zone géographique (area)

### DIFF
--- a/src/web/presentation/ingestion/openapi.py
+++ b/src/web/presentation/ingestion/openapi.py
@@ -275,6 +275,7 @@ critères suivants :
 - `region` — un ou plusieurs codes région (ex. `11,84`)
 - `departement` — un ou plusieurs codes département (ex. `75,69`)
 - `pays` — un ou plusieurs codes pays alpha-3 (ex. `FRA,BEL`)
+- `zone` — une ou plusieurs zones géographiques (ex. `EUROPE,ASIE`)
 - `domaine` — un ou plusieurs codes de domaine fonctionnel (ex. `NUM,ACH`)
 - `organisme` — un ou plusieurs noms d'organisme (nom exact). Répéter le
   paramètre pour filtrer sur plusieurs organismes (ex.

--- a/src/web/presentation/ingestion/serializers.py
+++ b/src/web/presentation/ingestion/serializers.py
@@ -258,6 +258,12 @@ class ListOffersFiltersSerializer(serializers.Serializer):
         help_text="Valeurs séparées par une virgule (ex. `FRA,BEL`).",
         source="country",
     )
+    zone = _CommaSeparatedEnumField(
+        GeographicalArea,
+        "zone géographique",
+        help_text="Valeurs séparées par une virgule (ex. `EUROPE,ASIE`).",
+        source="area",
+    )
     domaine = _CommaSeparatedCodeField(
         DOMAIN_NAMES,
         "domaine",

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -391,6 +391,7 @@ paths:
         - `region` — un ou plusieurs codes région (ex. `11,84`)
         - `departement` — un ou plusieurs codes département (ex. `75,69`)
         - `pays` — un ou plusieurs codes pays alpha-3 (ex. `FRA,BEL`)
+        - `zone` — une ou plusieurs zones géographiques (ex. `EUROPE,ASIE`)
         - `domaine` — un ou plusieurs codes de domaine fonctionnel (ex. `NUM,ACH`)
         - `organisme` — un ou plusieurs noms d'organisme (nom exact). Répéter le
           paramètre pour filtrer sur plusieurs organismes (ex.
@@ -1431,6 +1432,29 @@ paths:
               * `FPE` - FPE
               * `FPH` - FPH
         description: Valeurs séparées par une virgule (ex. `FPE,FPT`).
+      - in: query
+        name: zone
+        schema:
+          type: array
+          items:
+            enum:
+            - AFRIQUE
+            - EUROPE
+            - ASIE
+            - AMERIQUE
+            - OCEANIE
+            - ANTARTIQUE
+            - MOYEN_ORIENT_AFRIQUE_DU_NORD
+            type: string
+            description: |-
+              * `AFRIQUE` - AF
+              * `EUROPE` - EU
+              * `ASIE` - AS
+              * `AMERIQUE` - AM
+              * `OCEANIE` - OC
+              * `ANTARTIQUE` - AN
+              * `MOYEN_ORIENT_AFRIQUE_DU_NORD` - MO
+        description: Valeurs séparées par une virgule (ex. `EUROPE,ASIE`).
       tags:
       - offres
       security:

--- a/src/web/tests/presentation/ingestion/views/test_list_offers.py
+++ b/src/web/tests/presentation/ingestion/views/test_list_offers.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from django.urls import reverse
 from faker import Faker
+from referentiel.value_objects.area import GeographicalArea
 from referentiel.value_objects.category import Category
 from referentiel.value_objects.contract_type import ContractType
 from referentiel.value_objects.country import Country
@@ -378,6 +379,31 @@ def test_invalid_pays_returns_400(mock_offers_container, authenticated_client):
     _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
 
     response = authenticated_client.get(URL, {"pays": "INVALID"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "INVALID" in response.json()["error"]
+
+
+def test_zone_filter_is_forwarded_to_usecase(
+    mock_offers_container, authenticated_client
+):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    authenticated_client.get(URL, {"zone": "EUROPE,AFRIQUE"})
+
+    mock_offers_container.list_offers_usecase.return_value.execute.assert_called_once_with(
+        GetFilteredOffersInput(
+            active=True,
+            external_id_contains=None,
+            area=[GeographicalArea.EUROPE, GeographicalArea.AFRIQUE],
+        )
+    )
+
+
+def test_invalid_zone_returns_400(mock_offers_container, authenticated_client):
+    _make_paginated_mock(mock_offers_container, num_offers=0, offers_slice=[])
+
+    response = authenticated_client.get(URL, {"zone": "INVALID"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "INVALID" in response.json()["error"]


### PR DESCRIPTION
## 📝 Description

Ajoute le filtre `zone` sur `OffersListView`, sur le même principe que le filtre `area` déjà présent sur `OfferSummariesView`. Le usecase et le repository géraient déjà ce filtre, seul le serializer manquait.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
