### PR TITLE
✅(ats-presentation) add e2e harness for the ats spa

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -169,6 +169,13 @@ jobs:
       - name: Install Playwright OS dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: uv run playwright install-deps chromium
+      - uses: ./.github/actions/setup-pnpm-node
+        with:
+          lock-file-path: src/web/pnpm-lock.yaml
+      - name: Build frontend for e2e
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
       - name: Test Web suite with coverage
         run: uv run pytest -m "e2e" .
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -27,28 +27,8 @@ jobs:
               - ".github/workflows/web.yml"
               - ".github/actions/**"
 
-  build-web:
-    needs: check-changes
-    if: github.event_name == 'push' || needs.check-changes.outputs.relevant == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./src/web
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-uv-python
-        with:
-          service-path: src/web
-      - uses: ./.github/actions/setup-pnpm-node
-        with:
-          lock-file-path: src/web/pnpm-lock.yaml
-      - name: Install frontend dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build frontend
-        run: pnpm run build
-
   lint-web:
-    needs: [check-changes, build-web]
+    needs: check-changes
     if: github.event_name == 'push' || needs.check-changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -79,7 +59,7 @@ jobs:
       - name: Lint frontend
         run: pnpm --filter csplab-frontend lint
       - name: TypeScript check
-        run: pnpm --filter csplab-frontend build
+        run: pnpm --filter csplab-frontend typecheck
       - name: Test frontend with coverage
         run: pnpm --filter csplab-frontend test:run --coverage
       - name: Check no migrations are missing
@@ -95,7 +75,7 @@ jobs:
             (echo "::error::Le schéma OpenAPI interne ou les types TypeScript ne sont pas synchronisés avec le schéma OpenAPI. Lancez 'make frontend-types' et committez." && exit 1)
 
   test-web:
-    needs: [check-changes, build-web]
+    needs: check-changes
     if: github.event_name == 'push' || needs.check-changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     services:

--- a/src/web/presentation/frontend/src/components/layout/CspSidebar/CspSidebarUser.vue
+++ b/src/web/presentation/frontend/src/components/layout/CspSidebar/CspSidebarUser.vue
@@ -68,6 +68,7 @@ const { isDark, toggle: toggleColorMode } = useColorMode()
         <div
           v-if="isExpanded || isMobile"
           class="csp-sidebar-user__info"
+          data-testid="sidebar-user-info"
         >
           <span class="csp-sidebar-user__name">{{ name }}</span>
           <span

--- a/src/web/tests/presentation/ats/e2e/conftest.py
+++ b/src/web/tests/presentation/ats/e2e/conftest.py
@@ -1,26 +1,14 @@
-import os
 from pathlib import Path
 
 import pytest
 from django.conf import settings as django_settings
-from django.db import connections
 from django.test import Client
 from playwright.sync_api import BrowserContext, Page
 
 from infrastructure.django_apps.users.models import UserModel
 from infrastructure.factories.seed_recruteur_datas import seed_recruteur_datas
 
-os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
-
 SEED_AGENT_EMAIL = "marie.dupont@transition-eco.gouv.fr"
-
-
-@pytest.fixture(autouse=True)
-def close_worker_thread_connections():
-    # Override the async version from shared_fixtures to avoid event loop
-    # conflicts with Playwright, which manages its own event loop.
-    yield
-    connections.close_all()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -31,14 +19,6 @@ def require_frontend_build() -> None:
             "Frontend build missing: the ATS e2e tests serve the built SPA. "
             "Run `make frontend-build` first."
         )
-
-
-@pytest.fixture(scope="session")
-def browser_context_args(browser_context_args: dict) -> dict:
-    return {
-        **browser_context_args,
-        "locale": "fr-FR",
-    }
 
 
 @pytest.fixture(autouse=True)

--- a/src/web/tests/presentation/ats/e2e/conftest.py
+++ b/src/web/tests/presentation/ats/e2e/conftest.py
@@ -1,0 +1,77 @@
+import os
+from pathlib import Path
+
+import pytest
+from django.conf import settings as django_settings
+from django.db import connections
+from django.test import Client
+from playwright.sync_api import BrowserContext, Page
+
+from infrastructure.django_apps.users.models import UserModel
+from infrastructure.factories.seed_recruteur_datas import seed_recruteur_datas
+
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
+
+SEED_AGENT_EMAIL = "marie.dupont@transition-eco.gouv.fr"
+
+
+@pytest.fixture(autouse=True)
+def close_worker_thread_connections():
+    # Override the async version from shared_fixtures to avoid event loop
+    # conflicts with Playwright, which manages its own event loop.
+    yield
+    connections.close_all()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_frontend_build() -> None:
+    manifest = Path(django_settings.STATIC_DIR) / "frontend" / "manifest.json"
+    if not manifest.exists():
+        pytest.fail(
+            "Frontend build missing: the ATS e2e tests serve the built SPA. "
+            "Run `make frontend-build` first."
+        )
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args: dict) -> dict:
+    return {
+        **browser_context_args,
+        "locale": "fr-FR",
+    }
+
+
+@pytest.fixture(autouse=True)
+def insecure_cookies(settings) -> None:
+    # live_server serves plain http; Secure cookies would never reach it.
+    settings.SESSION_COOKIE_SECURE = False
+    settings.CSRF_COOKIE_SECURE = False
+
+
+@pytest.fixture
+def seed(db) -> dict:
+    return seed_recruteur_datas(force=True)
+
+
+@pytest.fixture
+def agent_user(seed) -> UserModel:
+    return UserModel.objects.get(email=SEED_AGENT_EMAIL)
+
+
+@pytest.fixture
+def authenticated_page(
+    page: Page, context: BrowserContext, live_server, agent_user
+) -> Page:
+    client = Client()
+    client.force_login(agent_user)
+    session_cookie = client.cookies[django_settings.SESSION_COOKIE_NAME]
+    context.add_cookies(
+        [
+            {
+                "name": django_settings.SESSION_COOKIE_NAME,
+                "value": session_cookie.value,
+                "url": live_server.url,
+            }
+        ]
+    )
+    return page

--- a/src/web/tests/presentation/ats/e2e/conftest.py
+++ b/src/web/tests/presentation/ats/e2e/conftest.py
@@ -6,9 +6,7 @@ from django.test import Client
 from playwright.sync_api import BrowserContext, Page
 
 from infrastructure.django_apps.users.models import UserModel
-from infrastructure.factories.seed_recruteur_datas import seed_recruteur_datas
-
-SEED_AGENT_EMAIL = "marie.dupont@transition-eco.gouv.fr"
+from infrastructure.factories.identite.agent_factory import AgentFactory
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -29,13 +27,8 @@ def insecure_cookies(settings) -> None:
 
 
 @pytest.fixture
-def seed(db) -> dict:
-    return seed_recruteur_datas(force=True)
-
-
-@pytest.fixture
-def agent_user(seed) -> UserModel:
-    return UserModel.objects.get(email=SEED_AGENT_EMAIL)
+def agent_user(db) -> UserModel:
+    return AgentFactory.create_model().utilisateur
 
 
 @pytest.fixture

--- a/src/web/tests/presentation/ats/e2e/test_smoke.py
+++ b/src/web/tests/presentation/ats/e2e/test_smoke.py
@@ -1,0 +1,26 @@
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.presentation.ats.e2e.conftest import SEED_AGENT_EMAIL
+
+
+@pytest.mark.e2e
+class TestAtsSmoke:
+    def test_login_form_then_spa_boots(
+        self, page: Page, live_server, seed: dict
+    ) -> None:
+        page.goto(f"{live_server.url}/utilisateur/connexion")
+        page.get_by_label("Email").fill(SEED_AGENT_EMAIL)
+        page.get_by_role("textbox", name="Mot de passe").fill(seed["seed_password"])
+        page.get_by_role("button", name="Se connecter").click()
+
+        page.goto(f"{live_server.url}/ats/")
+        expect(page.get_by_test_id("sidebar-user-info")).to_have_text("Marie Dupont")
+
+    def test_session_cookie_authenticates_the_spa(
+        self, authenticated_page: Page, live_server
+    ) -> None:
+        authenticated_page.goto(f"{live_server.url}/ats/")
+        expect(authenticated_page.get_by_test_id("sidebar-user-info")).to_have_text(
+            "Marie Dupont"
+        )

--- a/src/web/tests/presentation/ats/e2e/test_smoke.py
+++ b/src/web/tests/presentation/ats/e2e/test_smoke.py
@@ -1,26 +1,29 @@
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests.presentation.ats.e2e.conftest import SEED_AGENT_EMAIL
+from infrastructure.django_apps.users.models import UserModel
+from infrastructure.factories.identite.utilisateur_factory import DEFAULT_PASSWORD
 
 
 @pytest.mark.e2e
 class TestAtsSmoke:
     def test_login_form_then_spa_boots(
-        self, page: Page, live_server, seed: dict
+        self, page: Page, live_server, agent_user: UserModel
     ) -> None:
         page.goto(f"{live_server.url}/utilisateur/connexion")
-        page.get_by_label("Email").fill(SEED_AGENT_EMAIL)
-        page.get_by_role("textbox", name="Mot de passe").fill(seed["seed_password"])
+        page.get_by_label("Email").fill(agent_user.email)
+        page.get_by_role("textbox", name="Mot de passe").fill(DEFAULT_PASSWORD)
         page.get_by_role("button", name="Se connecter").click()
 
         page.goto(f"{live_server.url}/ats/")
-        expect(page.get_by_test_id("sidebar-user-info")).to_have_text("Marie Dupont")
+        expect(page.get_by_test_id("sidebar-user-info")).to_have_text(
+            f"{agent_user.first_name} {agent_user.last_name}"
+        )
 
     def test_session_cookie_authenticates_the_spa(
-        self, authenticated_page: Page, live_server
+        self, authenticated_page: Page, live_server, agent_user: UserModel
     ) -> None:
         authenticated_page.goto(f"{live_server.url}/ats/")
         expect(authenticated_page.get_by_test_id("sidebar-user-info")).to_have_text(
-            "Marie Dupont"
+            f"{agent_user.first_name} {agent_user.last_name}"
         )

--- a/src/web/tests/presentation/ats/e2e/test_smoke.py
+++ b/src/web/tests/presentation/ats/e2e/test_smoke.py
@@ -1,5 +1,8 @@
+import re
+
 import pytest
-from playwright.sync_api import Page, expect
+from django.conf import settings as django_settings
+from playwright.sync_api import BrowserContext, Page, expect
 
 from infrastructure.django_apps.users.models import UserModel
 from infrastructure.factories.identite.utilisateur_factory import DEFAULT_PASSWORD
@@ -26,4 +29,35 @@ class TestAtsSmoke:
         authenticated_page.goto(f"{live_server.url}/ats/")
         expect(authenticated_page.get_by_test_id("sidebar-user-info")).to_have_text(
             f"{agent_user.first_name} {agent_user.last_name}"
+        )
+
+    def test_login_form_rejects_bad_credentials(
+        self, page: Page, live_server, agent_user: UserModel
+    ) -> None:
+        page.goto(f"{live_server.url}/utilisateur/connexion")
+        page.get_by_label("Email").fill(agent_user.email)
+        page.get_by_role("textbox", name="Mot de passe").fill("wrong-password")
+        page.get_by_role("button", name="Se connecter").click()
+
+        expect(page.get_by_role("alert")).to_contain_text(
+            "Adresse e-mail ou mot de passe incorrect"
+        )
+        expect(page).to_have_url(re.compile("/utilisateur/connexion"))
+
+    def test_invalid_session_redirects_to_login(
+        self, page: Page, context: BrowserContext, live_server, db
+    ) -> None:
+        context.add_cookies(
+            [
+                {
+                    "name": django_settings.SESSION_COOKIE_NAME,
+                    "value": "invalid-session",
+                    "url": live_server.url,
+                }
+            ]
+        )
+        page.goto(f"{live_server.url}/ats/")
+
+        expect(page).to_have_url(
+            re.compile(r"/utilisateur/connexion\?next="), timeout=10000
         )

--- a/src/web/tests/presentation/candidate/e2e/conftest.py
+++ b/src/web/tests/presentation/candidate/e2e/conftest.py
@@ -1,27 +1,6 @@
-import os
-
 import pytest
-from django.db import connections
 
 from tests.utils.pdf_test_utils import cv_pdf_path  # noqa F401
-
-os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
-
-
-@pytest.fixture(autouse=True)
-def close_worker_thread_connections():
-    # Override the async version from shared_fixtures to avoid event loop
-    # conflicts with Playwright, which manages its own event loop.
-    yield
-    connections.close_all()
-
-
-@pytest.fixture(scope="session")
-def browser_context_args(browser_context_args: dict) -> dict:
-    return {
-        **browser_context_args,
-        "locale": "fr-FR",
-    }
 
 
 @pytest.fixture(scope="session")

--- a/src/web/tests/presentation/conftest.py
+++ b/src/web/tests/presentation/conftest.py
@@ -1,0 +1,22 @@
+import os
+
+import pytest
+from django.db import connections
+
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
+
+
+@pytest.fixture(autouse=True)
+def close_worker_thread_connections():
+    # Override the async version from shared_fixtures to avoid event loop
+    # conflicts with Playwright, which manages its own event loop.
+    yield
+    connections.close_all()
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args: dict) -> dict:
+    return {
+        **browser_context_args,
+        "locale": "fr-FR",
+    }


### PR DESCRIPTION
## 📝 Description
🎸 Ajoute un harnais de tests e2e pour le frontend vuejs

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Modifications
- configure pytest/playwright pour l'accès à l'app vue (seed, fixture, cookies)
- ajoute un test simple pour vérifier que l'auth est possible et persistante depuis le front
- supprime les builds frontend redondants dans le workflow web.yml, un seul suffit et devient nécessaire avant de lancer la suite e2e

## 🏝️ Comment tester (si applicable)
- `make frontend-build`
- `make test-e2e`

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
