### PR TITLE
✨(identite) INTERFACE : ajouter la liste des organismes de rattachement d'un utilisateur agent

### DIFF
--- a/src/web/application/identite/usecases/get_utilisateur_details.py
+++ b/src/web/application/identite/usecases/get_utilisateur_details.py
@@ -1,9 +1,19 @@
+from dataclasses import replace
 from uuid import UUID
 
 from domain.identite.entities.utilisateurs import Utilisateur
 from domain.identite.repositories.utilisateur_repository_interface import (
     IUtilisateurRepository,
 )
+from domain.identite.value_objects.organisme_role import OrganismeRole
+
+STATIC_ORGANISMES = [
+    OrganismeRole(
+        organisme_uuid=UUID("00000000-0000-0000-0000-000000000000"),
+        nom="Ministère de la Transition Écologique",
+        role="responsable",
+    )
+]
 
 
 class GetUtilisateurDetailUsecase:
@@ -11,4 +21,5 @@ class GetUtilisateurDetailUsecase:
         self.utilisateur_repository = utilisateur_repository
 
     def execute(self, entity_id: UUID) -> Utilisateur:
-        return self.utilisateur_repository.get_by_entity_id(entity_id)
+        utilisateur = self.utilisateur_repository.get_by_entity_id(entity_id)
+        return replace(utilisateur, organismes=STATIC_ORGANISMES)

--- a/src/web/application/identite/usecases/get_utilisateur_details.py
+++ b/src/web/application/identite/usecases/get_utilisateur_details.py
@@ -6,12 +6,13 @@ from domain.identite.repositories.utilisateur_repository_interface import (
     IUtilisateurRepository,
 )
 from domain.identite.value_objects.organisme_role import OrganismeRole
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
 
 STATIC_ORGANISMES = [
     OrganismeRole(
         organisme_uuid=UUID("00000000-0000-0000-0000-000000000000"),
         nom="Ministère de la Transition Écologique",
-        role="responsable",
+        role=AgentOrganismeRole.RESPONSABLE.value,
     )
 ]
 

--- a/src/web/application/identite/usecases/get_utilisateur_details.py
+++ b/src/web/application/identite/usecases/get_utilisateur_details.py
@@ -23,4 +23,4 @@ class GetUtilisateurDetailUsecase:
 
     def execute(self, entity_id: UUID) -> Utilisateur:
         utilisateur = self.utilisateur_repository.get_by_entity_id(entity_id)
-        return replace(utilisateur, organismes=STATIC_ORGANISMES)
+        return replace(utilisateur, organisme_roles=STATIC_ORGANISMES)

--- a/src/web/domain/identite/entities/utilisateurs.py
+++ b/src/web/domain/identite/entities/utilisateurs.py
@@ -1,7 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from ddd.entity import Entity
 from pydantic import EmailStr
+
+from domain.identite.value_objects.organisme_role import OrganismeRole
 
 
 @dataclass(kw_only=True)
@@ -10,3 +12,4 @@ class Utilisateur(Entity):
     prenom: str
     nom: str
     is_superuser: bool = False
+    organismes: list[OrganismeRole] = field(default_factory=list)

--- a/src/web/domain/identite/entities/utilisateurs.py
+++ b/src/web/domain/identite/entities/utilisateurs.py
@@ -12,4 +12,4 @@ class Utilisateur(Entity):
     prenom: str
     nom: str
     is_superuser: bool = False
-    organismes: list[OrganismeRole] = field(default_factory=list)
+    organisme_roles: list[OrganismeRole] = field(default_factory=list)

--- a/src/web/domain/identite/value_objects/organisme_role.py
+++ b/src/web/domain/identite/value_objects/organisme_role.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass
+class OrganismeRole:
+    organisme_uuid: UUID
+    nom: str
+    role: str

--- a/src/web/infrastructure/factories/identite/utilisateur_factory.py
+++ b/src/web/infrastructure/factories/identite/utilisateur_factory.py
@@ -27,7 +27,7 @@ class UtilisateurFactory:
             prenom=prenom or fake.first_name(),
             nom=nom or fake.last_name(),
             is_superuser=is_superuser,
-            organismes=organismes or [],
+            organisme_roles=organismes or [],
         )
 
     @staticmethod

--- a/src/web/infrastructure/factories/identite/utilisateur_factory.py
+++ b/src/web/infrastructure/factories/identite/utilisateur_factory.py
@@ -3,6 +3,7 @@ from uuid import UUID, uuid4
 from faker import Faker
 
 from domain.identite.entities.utilisateurs import Utilisateur
+from domain.identite.value_objects.organisme_role import OrganismeRole
 from infrastructure.django_apps.users.models import UserModel
 
 fake = Faker()
@@ -18,6 +19,7 @@ class UtilisateurFactory:
         prenom: str | None = None,
         nom: str | None = None,
         is_superuser: bool = False,
+        organismes: list[OrganismeRole] | None = None,
     ) -> Utilisateur:
         return Utilisateur(
             entity_id=entity_id or uuid4(),
@@ -25,6 +27,7 @@ class UtilisateurFactory:
             prenom=prenom or fake.first_name(),
             nom=nom or fake.last_name(),
             is_superuser=is_superuser,
+            organismes=organismes or [],
         )
 
     @staticmethod

--- a/src/web/presentation/frontend/src/stores/currentUser.test.ts
+++ b/src/web/presentation/frontend/src/stores/currentUser.test.ts
@@ -7,57 +7,57 @@ import { getMe } from '@/api/utilisateur'
 import { useCurrentUser } from './currentUser'
 
 vi.mock('@/api/utilisateur', () => ({
-        getMe: vi.fn(),
+  getMe: vi.fn(),
 }))
 
 function mountUseCurrentUser() {
-        let result!: ReturnType<typeof useCurrentUser>
+  let result!: ReturnType<typeof useCurrentUser>
 
-        mount(defineComponent({
-                setup() {
-                        result = useCurrentUser()
-                        return () => h('div')
-                },
-        }), {
-                global: {
-                        plugins: [createPinia(), PiniaColada],
-                },
-        })
+  mount(defineComponent({
+    setup() {
+      result = useCurrentUser()
+      return () => h('div')
+    },
+  }), {
+    global: {
+      plugins: [createPinia(), PiniaColada],
+    },
+  })
 
-        return result
+  return result
 }
 
 describe('useCurrentUser', () => {
-        beforeEach(() => {
-                vi.mocked(getMe).mockReset()
-        })
+  beforeEach(() => {
+    vi.mocked(getMe).mockReset()
+  })
 
-        it('fetches user and exposes reactive state', async () => {
-                const userData = {
-                        email: 'test@example.com',
-                        prenom: 'Jean',
-                        nom: 'Dupont',
-                        organisme: [{ organisme_uuid: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', nom: 'Ministère de la Transition Écologique', role: 'responsable' }],
-                }
-                vi.mocked(getMe).mockResolvedValue(userData)
+  it('fetches user and exposes reactive state', async () => {
+    const userData = {
+      email: 'test@example.com',
+      prenom: 'Jean',
+      nom: 'Dupont',
+      organisme: [{ organisme_uuid: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', nom: 'Ministère de la Transition Écologique', role: 'responsable' }],
+    }
+    vi.mocked(getMe).mockResolvedValue(userData)
 
-                const { user, displayName, isPending } = mountUseCurrentUser()
+    const { user, displayName, isPending } = mountUseCurrentUser()
 
-                await vi.waitFor(() => expect(isPending.value).toBe(false))
+    await vi.waitFor(() => expect(isPending.value).toBe(false))
 
-                expect(user.value).toEqual(userData)
-                expect(displayName.value).toBe('Jean Dupont')
-        })
+    expect(user.value).toEqual(userData)
+    expect(displayName.value).toBe('Jean Dupont')
+  })
 
-        it('handles fetch error gracefully', async () => {
-                const networkError = new Error('Network error')
-                vi.mocked(getMe).mockRejectedValue(networkError)
+  it('handles fetch error gracefully', async () => {
+    const networkError = new Error('Network error')
+    vi.mocked(getMe).mockRejectedValue(networkError)
 
-                const { user, error, isPending } = mountUseCurrentUser()
+    const { user, error, isPending } = mountUseCurrentUser()
 
-                await vi.waitFor(() => expect(isPending.value).toBe(false))
+    await vi.waitFor(() => expect(isPending.value).toBe(false))
 
-                expect(user.value).toBeNull()
-                expect(error.value).toBe(networkError)
-        })
+    expect(user.value).toBeNull()
+    expect(error.value).toBe(networkError)
+  })
 })

--- a/src/web/presentation/frontend/src/stores/currentUser.test.ts
+++ b/src/web/presentation/frontend/src/stores/currentUser.test.ts
@@ -37,7 +37,7 @@ describe('useCurrentUser', () => {
       email: 'test@example.com',
       prenom: 'Jean',
       nom: 'Dupont',
-      organisme: [{ organisme_uuid: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', nom: 'Ministère de la Transition Écologique', role: 'responsable' }],
+      organisme_roles: [{ organisme_uuid: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', nom: 'Ministère de la Transition Écologique', role: 'responsable' }],
     }
     vi.mocked(getMe).mockResolvedValue(userData)
 

--- a/src/web/presentation/frontend/src/stores/currentUser.test.ts
+++ b/src/web/presentation/frontend/src/stores/currentUser.test.ts
@@ -7,52 +7,57 @@ import { getMe } from '@/api/utilisateur'
 import { useCurrentUser } from './currentUser'
 
 vi.mock('@/api/utilisateur', () => ({
-  getMe: vi.fn(),
+        getMe: vi.fn(),
 }))
 
 function mountUseCurrentUser() {
-  let result!: ReturnType<typeof useCurrentUser>
+        let result!: ReturnType<typeof useCurrentUser>
 
-  mount(defineComponent({
-    setup() {
-      result = useCurrentUser()
-      return () => h('div')
-    },
-  }), {
-    global: {
-      plugins: [createPinia(), PiniaColada],
-    },
-  })
+        mount(defineComponent({
+                setup() {
+                        result = useCurrentUser()
+                        return () => h('div')
+                },
+        }), {
+                global: {
+                        plugins: [createPinia(), PiniaColada],
+                },
+        })
 
-  return result
+        return result
 }
 
 describe('useCurrentUser', () => {
-  beforeEach(() => {
-    vi.mocked(getMe).mockReset()
-  })
+        beforeEach(() => {
+                vi.mocked(getMe).mockReset()
+        })
 
-  it('fetches user and exposes reactive state', async () => {
-    const userData = { email: 'test@example.com', prenom: 'Jean', nom: 'Dupont' }
-    vi.mocked(getMe).mockResolvedValue(userData)
+        it('fetches user and exposes reactive state', async () => {
+                const userData = {
+                        email: 'test@example.com',
+                        prenom: 'Jean',
+                        nom: 'Dupont',
+                        organisme: [{ organisme_uuid: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1', nom: 'Ministère de la Transition Écologique', role: 'responsable' }],
+                }
+                vi.mocked(getMe).mockResolvedValue(userData)
 
-    const { user, displayName, isPending } = mountUseCurrentUser()
+                const { user, displayName, isPending } = mountUseCurrentUser()
 
-    await vi.waitFor(() => expect(isPending.value).toBe(false))
+                await vi.waitFor(() => expect(isPending.value).toBe(false))
 
-    expect(user.value).toEqual(userData)
-    expect(displayName.value).toBe('Jean Dupont')
-  })
+                expect(user.value).toEqual(userData)
+                expect(displayName.value).toBe('Jean Dupont')
+        })
 
-  it('handles fetch error gracefully', async () => {
-    const networkError = new Error('Network error')
-    vi.mocked(getMe).mockRejectedValue(networkError)
+        it('handles fetch error gracefully', async () => {
+                const networkError = new Error('Network error')
+                vi.mocked(getMe).mockRejectedValue(networkError)
 
-    const { user, error, isPending } = mountUseCurrentUser()
+                const { user, error, isPending } = mountUseCurrentUser()
 
-    await vi.waitFor(() => expect(isPending.value).toBe(false))
+                await vi.waitFor(() => expect(isPending.value).toBe(false))
 
-    expect(user.value).toBeNull()
-    expect(error.value).toBe(networkError)
-  })
+                expect(user.value).toBeNull()
+                expect(error.value).toBe(networkError)
+        })
 })

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -700,7 +700,7 @@ export interface components {
             email: string;
             prenom: string;
             nom: string;
-            organisme: components["schemas"]["OrganismeRole"][];
+            organisme_roles: components["schemas"]["OrganismeRole"][];
         };
         /**
          * @description * `FPT` - FPT

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -524,6 +524,12 @@ export interface components {
             /** Format: date-time */
             date_creation: string;
         };
+        OrganismeRole: {
+            /** Format: uuid */
+            organisme_uuid: string;
+            nom: string;
+            role: string;
+        };
         OrganismesList: {
             /** Format: uuid */
             organisme_uuid: string;
@@ -694,6 +700,7 @@ export interface components {
             email: string;
             prenom: string;
             nom: string;
+            organisme: components["schemas"]["OrganismeRole"][];
         };
         /**
          * @description * `FPT` - FPT

--- a/src/web/presentation/identite/serializers.py
+++ b/src/web/presentation/identite/serializers.py
@@ -1,7 +1,14 @@
 from rest_framework import serializers
 
 
+class OrganismeRoleSerializer(serializers.Serializer):
+    organisme_uuid = serializers.UUIDField()
+    nom = serializers.CharField()
+    role = serializers.CharField()
+
+
 class UtilisateurSerializer(serializers.Serializer):
     email = serializers.EmailField()
     prenom = serializers.CharField()
     nom = serializers.CharField()
+    organisme = OrganismeRoleSerializer(source="organismes", many=True)

--- a/src/web/presentation/identite/serializers.py
+++ b/src/web/presentation/identite/serializers.py
@@ -11,4 +11,4 @@ class UtilisateurSerializer(serializers.Serializer):
     email = serializers.EmailField()
     prenom = serializers.CharField()
     nom = serializers.CharField()
-    organisme = OrganismeRoleSerializer(source="organismes", many=True)
+    organisme_roles = OrganismeRoleSerializer(many=True)

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -2076,14 +2076,14 @@ components:
           type: string
         nom:
           type: string
-        organisme:
+        organisme_roles:
           type: array
           items:
             $ref: '#/components/schemas/OrganismeRole'
       required:
       - email
       - nom
-      - organisme
+      - organisme_roles
       - prenom
     VersantEnum:
       enum:

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -1694,6 +1694,20 @@ components:
       - organisme_uuid
       - siret
       - versant
+    OrganismeRole:
+      type: object
+      properties:
+        organisme_uuid:
+          type: string
+          format: uuid
+        nom:
+          type: string
+        role:
+          type: string
+      required:
+      - nom
+      - organisme_uuid
+      - role
     OrganismesList:
       type: object
       properties:
@@ -2062,9 +2076,14 @@ components:
           type: string
         nom:
           type: string
+        organisme:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganismeRole'
       required:
       - email
       - nom
+      - organisme
       - prenom
     VersantEnum:
       enum:

--- a/src/web/tests/infrastructure/identite/test_get_utilisateurs_details.py
+++ b/src/web/tests/infrastructure/identite/test_get_utilisateurs_details.py
@@ -26,7 +26,7 @@ def test_get_existing_user(db, test_user, identite_integration_container):
     usecase = identite_integration_container.get_utilisateur_details_usecase()
     result = usecase.execute(test_user.username)
 
-    assert result == replace(test_user.to_entity(), organismes=STATIC_ORGANISMES)
+    assert result == replace(test_user.to_entity(), organisme_roles=STATIC_ORGANISMES)
 
 
 def test_get_unknown_uuid(db, identite_integration_container):

--- a/src/web/tests/infrastructure/identite/test_get_utilisateurs_details.py
+++ b/src/web/tests/infrastructure/identite/test_get_utilisateurs_details.py
@@ -1,6 +1,9 @@
+from dataclasses import replace
+
 import pytest
 from faker import Faker
 
+from application.identite.usecases.get_utilisateur_details import STATIC_ORGANISMES
 from config.app_config import AppConfig
 from domain.identite.errors.identite_errors import UtilisateurNexistePas
 from infrastructure.di.identite.identite_container import IdentiteContainer
@@ -23,7 +26,7 @@ def test_get_existing_user(db, test_user, identite_integration_container):
     usecase = identite_integration_container.get_utilisateur_details_usecase()
     result = usecase.execute(test_user.username)
 
-    assert result == test_user.to_entity()
+    assert result == replace(test_user.to_entity(), organismes=STATIC_ORGANISMES)
 
 
 def test_get_unknown_uuid(db, identite_integration_container):

--- a/src/web/tests/presentation/identite/views/test_utilisateur_details.py
+++ b/src/web/tests/presentation/identite/views/test_utilisateur_details.py
@@ -1,10 +1,12 @@
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from django.urls import reverse
 from rest_framework import status
 
 from domain.identite.errors.identite_errors import UtilisateurNexistePas
+from domain.identite.value_objects.organisme_role import OrganismeRole
 from infrastructure.factories.identite.utilisateur_factory import UtilisateurFactory
 
 URL = reverse("identite:user-details")
@@ -33,7 +35,10 @@ def test_authentified_access(authenticated_client):
 
 
 def test_returned_payload(mock_container, authenticated_client, test_user):
-    entity = UtilisateurFactory.create_entity()
+    organisme_role = OrganismeRole(
+        organisme_uuid=uuid4(), nom="Organisme de test", role="responsable"
+    )
+    entity = UtilisateurFactory.create_entity(organismes=[organisme_role])
 
     mock_usecase = MagicMock()
     mock_usecase.execute.return_value = entity
@@ -49,6 +54,13 @@ def test_returned_payload(mock_container, authenticated_client, test_user):
         "email": entity.email,
         "prenom": entity.prenom,
         "nom": entity.nom,
+        "organisme": [
+            {
+                "organisme_uuid": str(organisme_role.organisme_uuid),
+                "nom": organisme_role.nom,
+                "role": organisme_role.role,
+            }
+        ],
     }
 
 

--- a/src/web/tests/presentation/identite/views/test_utilisateur_details.py
+++ b/src/web/tests/presentation/identite/views/test_utilisateur_details.py
@@ -54,7 +54,7 @@ def test_returned_payload(mock_container, authenticated_client, test_user):
         "email": entity.email,
         "prenom": entity.prenom,
         "nom": entity.nom,
-        "organisme": [
+        "organisme_roles": [
             {
                 "organisme_uuid": str(organisme_role.organisme_uuid),
                 "nom": organisme_role.nom,


### PR DESCRIPTION
## 📝 Description
🎸 Transmet au front, via la route utilisateur/me, le ou les organismes pour lesquels l'agent connecté possède un rôle. La donnée est alimentée de façon statique pour l'instant ; elle sera rendue dynamique dans une issue à venir (liaison réelle avec OrganismeAgentModel).

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications

- Ajout du value object OrganismeRole (organisme_uuid, nom, role) dans domain/identite/value_objects/
- Ajout du champ organismes: list[OrganismeRole] sur l'entité Utilisateur
- GetUtilisateurDetailUsecase alimente ce champ avec une liste statique (STATIC_ORGANISMES, marquée d'un TODO pour le passage en dynamique)
- Nouveau OrganismeRoleSerializer, exposé sur UtilisateurSerializer sous le nom organisme (source="organismes")
- UtilisateurFactory.create_entity accepte désormais un paramètre optionnel organismes pour les tests
- Mise à jour des tests (test_get_utilisateurs_details.py, test_utilisateur_details.py) pour couvrir le nouveau champ
- Régénération de internal-schema.yaml et de api.d.ts (types frontend)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
