### PR TITLE
✨(recruteur) INTERFACE : obtenir la liste des agents d'un organisme

### DIFF
--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -75,6 +75,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/recruteur/organismes/{organisme_uuid}/parametres/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Liste des agents rattachés à un organisme */
+        get: operations["recruteur_organismes_parametres_agents_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/recruteur/organismes/{organisme_uuid}/parametres/etapes": {
         parameters: {
             query?: never;
@@ -274,6 +291,20 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        AgentOrganisme: {
+            /** Format: uuid */
+            agent_id: string;
+            nom: string;
+            prenom: string;
+            /** Format: email */
+            email: string;
+            poste: string;
+            role: string;
+            /** Format: date-time */
+            date_derniere_activite: string | null;
+            /** Format: date-time */
+            date_creation_compte: string;
+        };
         /** @enum {unknown} */
         BlankEnum: "";
         Candidat: {
@@ -1069,6 +1100,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+        };
+    };
+    recruteur_organismes_parametres_agents_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organisme_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentOrganisme"][];
                 };
             };
             401: {

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -134,6 +134,22 @@ class CandidatureListeSerializer(serializers.Serializer):
 
 
 # ---------------------------------------------------------------------------
+# Serializers pour les agents rattachés à un organisme
+# ---------------------------------------------------------------------------
+
+
+class AgentOrganismeSerializer(serializers.Serializer):
+    agent_id = serializers.UUIDField()
+    nom = serializers.CharField()
+    prenom = serializers.CharField()
+    email = serializers.EmailField()
+    poste = serializers.CharField()
+    role = serializers.CharField()
+    date_derniere_activite = serializers.DateTimeField(allow_null=True)
+    date_creation_compte = serializers.DateTimeField()
+
+
+# ---------------------------------------------------------------------------
 # Serializers pour les notes attachées à une candidature
 # ---------------------------------------------------------------------------
 

--- a/src/web/presentation/recruteur/urls.py
+++ b/src/web/presentation/recruteur/urls.py
@@ -4,6 +4,9 @@ from presentation.recruteur.views.notes import (
     CandidatureNoteDetailView,
     CandidatureNotesView,
 )
+from presentation.recruteur.views.organisme_agents import (
+    OrganismeAgentsView,
+)
 from presentation.recruteur.views.organisme_detail import (
     EtapesRecrutementOrganismeView,
     InitEtapesRecrutementOrganismeView,
@@ -49,6 +52,11 @@ urlpatterns = [
         "organismes/<uuid:organisme_uuid>/parametres/etapes/init",
         InitEtapesRecrutementOrganismeView.as_view(),
         name="organisme-parametres-etapes-init",
+    ),
+    path(
+        "organismes/<uuid:organisme_uuid>/parametres/agents",
+        OrganismeAgentsView.as_view(),
+        name="organisme-parametres-agents",
     ),
     path(
         "organismes/<uuid:organisme_uuid>/recrutements-actifs",

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -1,0 +1,51 @@
+from uuid import UUID, uuid4
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from presentation.api.serializers import generic_response_format
+from presentation.recruteur.serializers import AgentOrganismeSerializer
+
+# TODO : données statiques en attendant le branchement sur OrganismeAgentModel
+# (issue à venir)
+_AGENTS_STATIQUES = [
+    {
+        "agent_id": uuid4(),
+        "nom": "Dupont",
+        "prenom": "Jeanne",
+        "email": "jeanne.dupont@example.gouv.fr",
+        "poste": "Responsable recrutement",
+        "role": "RESPONSABLE",
+        "date_derniere_activite": "2026-08-18T09:12:00Z",
+        "date_creation_compte": "2025-01-10T08:00:00Z",
+    },
+    {
+        "agent_id": uuid4(),
+        "nom": "Martin",
+        "prenom": "Lucas",
+        "email": "lucas.martin@example.gouv.fr",
+        "poste": "Chargé de recrutement",
+        "role": "MEMBRE",
+        "date_derniere_activite": "2026-08-15T14:30:00Z",
+        "date_creation_compte": "2025-03-22T08:00:00Z",
+    },
+]
+
+
+@extend_schema(
+    summary="Liste des agents rattachés à un organisme",
+    tags=["recruteur"],
+    responses={
+        **generic_response_format,
+        200: AgentOrganismeSerializer(many=True),
+    },
+)
+class OrganismeAgentsView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request, organisme_uuid: UUID) -> Response:
+        serializer = AgentOrganismeSerializer(_AGENTS_STATIQUES, many=True)
+        return Response(serializer.data)

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from presentation.api.serializers import generic_response_format
 from presentation.recruteur.serializers import AgentOrganismeSerializer
 
@@ -18,7 +19,7 @@ _AGENTS_STATIQUES = [
         "prenom": "Jeanne",
         "email": "jeanne.dupont@example.gouv.fr",
         "poste": "Responsable recrutement",
-        "role": "RESPONSABLE",
+        "role": AgentOrganismeRole.RESPONSABLE.value,
         "date_derniere_activite": "2026-08-18T09:12:00Z",
         "date_creation_compte": "2025-01-10T08:00:00Z",
     },
@@ -28,7 +29,7 @@ _AGENTS_STATIQUES = [
         "prenom": "Lucas",
         "email": "lucas.martin@example.gouv.fr",
         "poste": "Chargé de recrutement",
-        "role": "MEMBRE",
+        "role": AgentOrganismeRole.MEMBRE.value,
         "date_derniere_activite": "2026-08-15T14:30:00Z",
         "date_creation_compte": "2025-03-22T08:00:00Z",
     },

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -362,6 +362,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+  /recruteur/organismes/{organisme_uuid}/parametres/agents:
+    get:
+      operationId: recruteur_organismes_parametres_agents_list
+      summary: Liste des agents rattachés à un organisme
+      parameters:
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - recruteur
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AgentOrganisme'
+          description: ''
   /recruteur/organismes/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organismes_parametres_etapes_list
@@ -1141,6 +1190,39 @@ paths:
           description: ''
 components:
   schemas:
+    AgentOrganisme:
+      type: object
+      properties:
+        agent_id:
+          type: string
+          format: uuid
+        nom:
+          type: string
+        prenom:
+          type: string
+        email:
+          type: string
+          format: email
+        poste:
+          type: string
+        role:
+          type: string
+        date_derniere_activite:
+          type: string
+          format: date-time
+          nullable: true
+        date_creation_compte:
+          type: string
+          format: date-time
+      required:
+      - agent_id
+      - date_creation_compte
+      - date_derniere_activite
+      - email
+      - nom
+      - poste
+      - prenom
+      - role
     BlankEnum:
       enum:
       - ''

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -1,0 +1,21 @@
+from uuid import uuid4
+
+from django.urls import reverse
+from rest_framework import status
+
+ORGANISME_UUID = str(uuid4())
+
+AGENTS_URL = reverse(
+    "recruteur:organisme-parametres-agents",
+    kwargs={"organisme_uuid": ORGANISME_UUID},
+)
+
+
+class TestOrganismeAgentsView:
+    def test_anonymous_access_is_unauthorized(self, api_client):
+        assert api_client.get(AGENTS_URL).status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_list_agents(self, authenticated_client):
+        response = authenticated_client.get(AGENTS_URL)
+
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## 📝 Description
🎸 Ajoute une route de lecture exposant la liste des agents rattachés à un organisme (GET /recruteur/organismes/{organisme_uuid}/parametres/agents), afin que le frontend puisse préparer l'interface de consultation des membres d'un organisme. Implémentation volontairement limitée à la couche présentation : les données sont statiques pour l'instant (le branchement sur OrganismeAgentModel et la garde d'accès sont prévus dans des issues à venir).

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications

- Presentation (recruteur) : ajout de OrganismeAgentsView, vue statique retournant la liste des agents d'un organisme (views/organisme_agents.py)
- Presentation (recruteur) : ajout de AgentOrganismeSerializer (serializers.py) et de la route organismes/<organisme_uuid>/parametres/agents (urls.py) (+ tests)
- Regénération du schéma OpenAPI interne (internal-schema.yaml)


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
