### PR TITLE
✨(recruteur) INTERFACE : ajouter un rôle pour un agent dans un organisme

### DIFF
--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -85,7 +85,8 @@ export interface paths {
         /** Liste des agents rattachés à un organisme */
         get: operations["recruteur_organismes_parametres_agents_list"];
         put?: never;
-        post?: never;
+        /** Rattacher un agent à un organisme */
+        post: operations["recruteur_organismes_parametres_agents_create"];
         delete?: never;
         options?: never;
         head?: never;
@@ -629,6 +630,11 @@ export interface components {
         PatchedEditerNote: {
             message?: string;
         };
+        RattacherAgent: {
+            /** Format: uuid */
+            agent_uuid: string;
+            role: components["schemas"]["RoleEnum"];
+        };
         RecrutementDetail: {
             /** Format: uuid */
             offer_id: string;
@@ -698,6 +704,12 @@ export interface components {
         Responsable: {
             nom: string;
         };
+        /**
+         * @description * `responsable` - responsable
+         *     * `membre` - membre
+         * @enum {string}
+         */
+        RoleEnum: "responsable" | "membre";
         TokenError: {
             detail: string;
             code: string;
@@ -1153,6 +1165,73 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AgentOrganisme"][];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+        };
+    };
+    recruteur_organismes_parametres_agents_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organisme_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RattacherAgent"];
+                "application/x-www-form-urlencoded": components["schemas"]["RattacherAgent"];
+                "multipart/form-data": components["schemas"]["RattacherAgent"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentOrganisme"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
                 };
             };
             401: {

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -295,6 +295,8 @@ export interface components {
         AgentOrganisme: {
             /** Format: uuid */
             agent_id: string;
+            /** Format: uuid */
+            organisme_id: string;
             nom: string;
             prenom: string;
             /** Format: email */
@@ -630,11 +632,6 @@ export interface components {
         PatchedEditerNote: {
             message?: string;
         };
-        RattacherAgent: {
-            /** Format: uuid */
-            agent_uuid: string;
-            role: components["schemas"]["RoleEnum"];
-        };
         RecrutementDetail: {
             /** Format: uuid */
             offer_id: string;
@@ -710,6 +707,11 @@ export interface components {
          * @enum {string}
          */
         RoleEnum: "responsable" | "membre";
+        SetAgentRoleOnOrganisme: {
+            /** Format: uuid */
+            agent_id: string;
+            role: components["schemas"]["RoleEnum"];
+        };
         TokenError: {
             detail: string;
             code: string;
@@ -1212,9 +1214,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["RattacherAgent"];
-                "application/x-www-form-urlencoded": components["schemas"]["RattacherAgent"];
-                "multipart/form-data": components["schemas"]["RattacherAgent"];
+                "application/json": components["schemas"]["SetAgentRoleOnOrganisme"];
+                "application/x-www-form-urlencoded": components["schemas"]["SetAgentRoleOnOrganisme"];
+                "multipart/form-data": components["schemas"]["SetAgentRoleOnOrganisme"];
             };
         };
         responses: {

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -150,7 +150,7 @@ class AgentOrganismeSerializer(serializers.Serializer):
     date_creation_compte = serializers.DateTimeField()
 
 
-class RattacherAgentSerializer(serializers.Serializer):
+class SetAgentRoleOnOrganismeSerializer(serializers.Serializer):
     agent_uuid = serializers.UUIDField()
     role = serializers.ChoiceField(
         choices=[(r.value, r.value) for r in AgentOrganismeRole]

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -141,6 +141,7 @@ class CandidatureListeSerializer(serializers.Serializer):
 
 class AgentOrganismeSerializer(serializers.Serializer):
     agent_id = serializers.UUIDField()
+    organisme_id = serializers.UUIDField()
     nom = serializers.CharField()
     prenom = serializers.CharField()
     email = serializers.EmailField()
@@ -151,7 +152,7 @@ class AgentOrganismeSerializer(serializers.Serializer):
 
 
 class SetAgentRoleOnOrganismeSerializer(serializers.Serializer):
-    agent_uuid = serializers.UUIDField()
+    agent_id = serializers.UUIDField()
     role = serializers.ChoiceField(
         choices=[(r.value, r.value) for r in AgentOrganismeRole]
     )

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from presentation.commons.serializers import LocalisationSerializer, OrganismeSerializer
 
 
@@ -147,6 +148,13 @@ class AgentOrganismeSerializer(serializers.Serializer):
     role = serializers.CharField()
     date_derniere_activite = serializers.DateTimeField(allow_null=True)
     date_creation_compte = serializers.DateTimeField()
+
+
+class RattacherAgentSerializer(serializers.Serializer):
+    agent_uuid = serializers.UUIDField()
+    role = serializers.ChoiceField(
+        choices=[(r.value, r.value) for r in AgentOrganismeRole]
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -20,6 +20,7 @@ from presentation.recruteur.serializers import (
 _AGENTS_STATIQUES = [
     {
         "agent_id": uuid4(),
+        "organisme_id": "00000000-0000-0000-0000-000000000000",
         "nom": "Dupont",
         "prenom": "Jeanne",
         "email": "jeanne.dupont@example.gouv.fr",
@@ -30,6 +31,7 @@ _AGENTS_STATIQUES = [
     },
     {
         "agent_id": uuid4(),
+        "organisme_id": "00000000-0000-0000-0000-000000000000",
         "nom": "Martin",
         "prenom": "Lucas",
         "email": "lucas.martin@example.gouv.fr",
@@ -75,7 +77,8 @@ class OrganismeAgentsView(APIView):
 
         data = serializer.validated_data
         agent = {
-            "agent_id": data["agent_uuid"],
+            "agent_id": data["agent_id"],
+            "organisme_id": "00000000-0000-0000-0000-000000000000",
             "nom": "",
             "prenom": "",
             "email": "",

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -12,7 +12,7 @@ from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from presentation.api.serializers import GenericErrorSerializer, generic_response_format
 from presentation.recruteur.serializers import (
     AgentOrganismeSerializer,
-    RattacherAgentSerializer,
+    SetAgentRoleOnOrganismeSerializer,
 )
 
 # TODO : données statiques en attendant le branchement sur OrganismeAgentModel
@@ -53,7 +53,7 @@ _AGENTS_STATIQUES = [
     post=extend_schema(
         summary="Rattacher un agent à un organisme",
         tags=["recruteur"],
-        request=RattacherAgentSerializer,
+        request=SetAgentRoleOnOrganismeSerializer,
         responses={
             **generic_response_format,
             201: AgentOrganismeSerializer,
@@ -69,7 +69,7 @@ class OrganismeAgentsView(APIView):
         return Response(serializer.data)
 
     def post(self, request: Request, organisme_uuid: UUID) -> Response:
-        serializer = RattacherAgentSerializer(data=request.data)
+        serializer = SetAgentRoleOnOrganismeSerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -1,14 +1,19 @@
 from uuid import UUID, uuid4
 
-from drf_spectacular.utils import extend_schema
+from django.utils.timezone import now
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
-from presentation.api.serializers import generic_response_format
-from presentation.recruteur.serializers import AgentOrganismeSerializer
+from presentation.api.serializers import GenericErrorSerializer, generic_response_format
+from presentation.recruteur.serializers import (
+    AgentOrganismeSerializer,
+    RattacherAgentSerializer,
+)
 
 # TODO : données statiques en attendant le branchement sur OrganismeAgentModel
 # (issue à venir)
@@ -36,13 +41,25 @@ _AGENTS_STATIQUES = [
 ]
 
 
-@extend_schema(
-    summary="Liste des agents rattachés à un organisme",
-    tags=["recruteur"],
-    responses={
-        **generic_response_format,
-        200: AgentOrganismeSerializer(many=True),
-    },
+@extend_schema_view(
+    get=extend_schema(
+        summary="Liste des agents rattachés à un organisme",
+        tags=["recruteur"],
+        responses={
+            **generic_response_format,
+            200: AgentOrganismeSerializer(many=True),
+        },
+    ),
+    post=extend_schema(
+        summary="Rattacher un agent à un organisme",
+        tags=["recruteur"],
+        request=RattacherAgentSerializer,
+        responses={
+            **generic_response_format,
+            201: AgentOrganismeSerializer,
+            400: GenericErrorSerializer,
+        },
+    ),
 )
 class OrganismeAgentsView(APIView):
     permission_classes = [IsAuthenticated]
@@ -50,3 +67,22 @@ class OrganismeAgentsView(APIView):
     def get(self, request: Request, organisme_uuid: UUID) -> Response:
         serializer = AgentOrganismeSerializer(_AGENTS_STATIQUES, many=True)
         return Response(serializer.data)
+
+    def post(self, request: Request, organisme_uuid: UUID) -> Response:
+        serializer = RattacherAgentSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+        agent = {
+            "agent_id": data["agent_uuid"],
+            "nom": "",
+            "prenom": "",
+            "email": "",
+            "poste": "",
+            "role": data["role"],
+            "date_derniere_activite": None,
+            "date_creation_compte": now(),
+        }
+        out_serializer = AgentOrganismeSerializer(agent)
+        return Response(out_serializer.data, status=status.HTTP_201_CREATED)

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -427,13 +427,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RattacherAgent'
+              $ref: '#/components/schemas/SetAgentRoleOnOrganisme'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/RattacherAgent'
+              $ref: '#/components/schemas/SetAgentRoleOnOrganisme'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/RattacherAgent'
+              $ref: '#/components/schemas/SetAgentRoleOnOrganisme'
         required: true
       security:
       - jwtAuth: []
@@ -1260,6 +1260,9 @@ components:
         agent_id:
           type: string
           format: uuid
+        organisme_id:
+          type: string
+          format: uuid
         nom:
           type: string
         prenom:
@@ -1284,6 +1287,7 @@ components:
       - date_derniere_activite
       - email
       - nom
+      - organisme_id
       - poste
       - prenom
       - role
@@ -1978,17 +1982,6 @@ components:
       properties:
         message:
           type: string
-    RattacherAgent:
-      type: object
-      properties:
-        agent_uuid:
-          type: string
-          format: uuid
-        role:
-          $ref: '#/components/schemas/RoleEnum'
-      required:
-      - agent_uuid
-      - role
     RecrutementDetail:
       type: object
       properties:
@@ -2167,6 +2160,17 @@ components:
       description: |-
         * `responsable` - responsable
         * `membre` - membre
+    SetAgentRoleOnOrganisme:
+      type: object
+      properties:
+        agent_id:
+          type: string
+          format: uuid
+        role:
+          $ref: '#/components/schemas/RoleEnum'
+      required:
+      - agent_id
+      - role
     TokenError:
       type: object
       properties:

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -411,6 +411,70 @@ paths:
                 items:
                   $ref: '#/components/schemas/AgentOrganisme'
           description: ''
+    post:
+      operationId: recruteur_organismes_parametres_agents_create
+      summary: Rattacher un agent à un organisme
+      parameters:
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - recruteur
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RattacherAgent'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RattacherAgent'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RattacherAgent'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentOrganisme'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/organismes/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organismes_parametres_etapes_list
@@ -1914,6 +1978,17 @@ components:
       properties:
         message:
           type: string
+    RattacherAgent:
+      type: object
+      properties:
+        agent_uuid:
+          type: string
+          format: uuid
+        role:
+          $ref: '#/components/schemas/RoleEnum'
+      required:
+      - agent_uuid
+      - role
     RecrutementDetail:
       type: object
       properties:
@@ -2084,6 +2159,14 @@ components:
           type: string
       required:
       - nom
+    RoleEnum:
+      enum:
+      - responsable
+      - membre
+      type: string
+      description: |-
+        * `responsable` - responsable
+        * `membre` - membre
     TokenError:
       type: object
       properties:

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 from django.urls import reverse
 from rest_framework import status
 
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+
 ORGANISME_UUID = str(uuid4())
 
 AGENTS_URL = reverse(
@@ -19,3 +21,40 @@ class TestOrganismeAgentsView:
         response = authenticated_client.get(AGENTS_URL)
 
         assert response.status_code == status.HTTP_200_OK
+
+    def test_anonymous_post_is_unauthorized(self, api_client):
+        response = api_client.post(AGENTS_URL, data={}, format="json")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_rattacher_agent(self, authenticated_client):
+        agent_uuid = str(uuid4())
+
+        response = authenticated_client.post(
+            AGENTS_URL,
+            data={"agent_uuid": agent_uuid, "role": AgentOrganismeRole.MEMBRE.value},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["agent_id"] == agent_uuid
+        assert data["role"] == AgentOrganismeRole.MEMBRE.value
+
+    def test_rattacher_agent_invalid_role(self, authenticated_client):
+        response = authenticated_client.post(
+            AGENTS_URL,
+            data={"agent_uuid": str(uuid4()), "role": "not-a-role"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_rattacher_agent_requires_agent_uuid(self, authenticated_client):
+        response = authenticated_client.post(
+            AGENTS_URL,
+            data={"role": AgentOrganismeRole.MEMBRE.value},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -28,29 +28,29 @@ class TestOrganismeAgentsView:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_rattacher_agent(self, authenticated_client):
-        agent_uuid = str(uuid4())
+        agent_id = str(uuid4())
 
         response = authenticated_client.post(
             AGENTS_URL,
-            data={"agent_uuid": agent_uuid, "role": AgentOrganismeRole.MEMBRE.value},
+            data={"agent_id": agent_id, "role": AgentOrganismeRole.MEMBRE.value},
             format="json",
         )
 
         assert response.status_code == status.HTTP_201_CREATED
         data = response.json()
-        assert data["agent_id"] == agent_uuid
+        assert data["agent_id"] == agent_id
         assert data["role"] == AgentOrganismeRole.MEMBRE.value
 
     def test_rattacher_agent_invalid_role(self, authenticated_client):
         response = authenticated_client.post(
             AGENTS_URL,
-            data={"agent_uuid": str(uuid4()), "role": "not-a-role"},
+            data={"agent_id": str(uuid4()), "role": "not-a-role"},
             format="json",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_rattacher_agent_requires_agent_uuid(self, authenticated_client):
+    def test_rattacher_agent_requires_agent_id(self, authenticated_client):
         response = authenticated_client.post(
             AGENTS_URL,
             data={"role": AgentOrganismeRole.MEMBRE.value},


### PR DESCRIPTION
## 📝 Description
🎸 Ajoute la possibilité de rattacher un agent à un organisme en lui attribuant un rôle, via un POST sur la route existante organismes/{organisme_uuid}/parametres/agents. Implémentation limitée à la couche présentation, réponse statique

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications

- Presentation (recruteur) : ajout de RattacherAgentSerializer (serializers.py) pour valider agent_uuid + role
- Presentation (recruteur) : ajout de la méthode POST sur OrganismeAgentsView (views/organisme_agents.py), retour statique 201 reprenant l'agent rattaché (+ tests)
- Regénération du schéma OpenAPI interne (internal-schema.yaml) et des types front générés (api.d.ts)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
