### PR TITLE
♻️(recruteur-presentation) add versant and counts in get_organismes

### DIFF
--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -515,6 +515,7 @@ export interface components {
             /** Format: uuid */
             organisme_uuid: string;
             nom: string;
+            versant: components["schemas"]["VersantEnum"];
             siret: string;
             gestionnaire: string | null;
             gestion_ats: boolean;
@@ -522,6 +523,21 @@ export interface components {
             date_derniere_activite: string;
             /** Format: date-time */
             date_creation: string;
+        };
+        OrganismesList: {
+            /** Format: uuid */
+            organisme_uuid: string;
+            nom: string;
+            versant: components["schemas"]["VersantEnum"];
+            siret: string;
+            gestionnaire: string | null;
+            gestion_ats: boolean;
+            /** Format: date-time */
+            date_derniere_activite: string;
+            /** Format: date-time */
+            date_creation: string;
+            nombre_agents: number;
+            nombre_offres_publiees: number;
         };
         PaginatedCandidatureListeList: {
             /** @example 1 */
@@ -913,7 +929,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["OrganismeDetail"][];
+                    "application/json": components["schemas"]["OrganismesList"][];
                 };
             };
             401: {

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -12,11 +12,17 @@ from presentation.commons.serializers import LocalisationSerializer, OrganismeSe
 class OrganismeDetailSerializer(serializers.Serializer):
     organisme_uuid = serializers.UUIDField()
     nom = serializers.CharField()
+    versant = serializers.ChoiceField(choices=[c.value for c in Verse])
     siret = serializers.CharField(min_length=14, max_length=14)
     gestionnaire = serializers.CharField(allow_null=True)
     gestion_ats = serializers.BooleanField()
     date_derniere_activite = serializers.DateTimeField()
     date_creation = serializers.DateTimeField()
+
+
+class OrganismesListSerializer(OrganismeDetailSerializer):
+    nombre_agents = serializers.IntegerField()
+    nombre_offres_publiees = serializers.IntegerField()
 
 
 class CreateOrganismeSerializer(serializers.Serializer):

--- a/src/web/presentation/recruteur/views/organismes.py
+++ b/src/web/presentation/recruteur/views/organismes.py
@@ -25,23 +25,10 @@ from presentation.api.serializers import (
 from presentation.recruteur.serializers import (
     CreateOrganismeSerializer,
     OrganismeDetailSerializer,
+    OrganismesListSerializer,
 )
 
 _FROZEN_TS = datetime.now(tz=timezone.utc)
-
-
-def fake_organismes() -> list[dict]:
-    return [
-        {
-            "nom": org.nom,
-            "siret": org.siret.code,
-            "gestion_ats": True,
-            "gestionnaire": None,
-            "date_derniere_activite": "2026-01-15T10:00:00Z",
-            "date_creation": "2026-01-01T09:00:00Z",
-        }
-        for org in OrganismeFactory.create_entity_batch()
-    ]
 
 
 @extend_schema_view(
@@ -50,7 +37,7 @@ def fake_organismes() -> list[dict]:
         tags=["recruteur"],
         responses={
             **generic_response_format,
-            200: OrganismeDetailSerializer(many=True),
+            200: OrganismesListSerializer(many=True),
         },
     ),
     post=extend_schema(
@@ -84,14 +71,17 @@ class OrganismesView(APIView):
                 {
                     "organisme_uuid": organisme.entity_id,
                     "nom": organisme.nom,
+                    "versant": organisme.versant.value,
                     "siret": organisme.siret.code,
                     "gestion_ats": organisme.gestion_ats,
                     "date_creation": organisme.date_creation,
                     "date_derniere_activite": organisme.date_derniere_activite,
+                    "nombre_agents": 10,
+                    "nombre_offres_publiees": 20,
                 }
                 for organisme in organismes
             ]
-            return Response(OrganismeDetailSerializer(organismes_dto, many=True).data)
+            return Response(OrganismesListSerializer(organismes_dto, many=True).data)
         except OperationOrganismeRefusee as e:
             serializer = GenericErrorSerializer({"error": str(e)})
             return Response(serializer.data, status=status.HTTP_403_FORBIDDEN)

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -238,7 +238,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/OrganismeDetail'
+                  $ref: '#/components/schemas/OrganismesList'
           description: ''
     post:
       operationId: recruteur_organismes_create
@@ -1668,6 +1668,8 @@ components:
           format: uuid
         nom:
           type: string
+        versant:
+          $ref: '#/components/schemas/VersantEnum'
         siret:
           type: string
           maxLength: 14
@@ -1691,6 +1693,47 @@ components:
       - nom
       - organisme_uuid
       - siret
+      - versant
+    OrganismesList:
+      type: object
+      properties:
+        organisme_uuid:
+          type: string
+          format: uuid
+        nom:
+          type: string
+        versant:
+          $ref: '#/components/schemas/VersantEnum'
+        siret:
+          type: string
+          maxLength: 14
+          minLength: 14
+        gestionnaire:
+          type: string
+          nullable: true
+        gestion_ats:
+          type: boolean
+        date_derniere_activite:
+          type: string
+          format: date-time
+        date_creation:
+          type: string
+          format: date-time
+        nombre_agents:
+          type: integer
+        nombre_offres_publiees:
+          type: integer
+      required:
+      - date_creation
+      - date_derniere_activite
+      - gestion_ats
+      - gestionnaire
+      - nom
+      - nombre_agents
+      - nombre_offres_publiees
+      - organisme_uuid
+      - siret
+      - versant
     PaginatedCandidatureListeList:
       type: object
       required:

--- a/src/web/tests/presentation/recruteur/test_views_organismes.py
+++ b/src/web/tests/presentation/recruteur/test_views_organismes.py
@@ -60,8 +60,21 @@ class TestOrganismesView:
         response = authenticated_client.get(ORGANISME_URL)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()[0]["organisme_uuid"] == str(organismes[0].entity_id)
-        assert len(response.json()) == len(organismes)
+        assert response.json() == [
+            {
+                "organisme_uuid": str(organisme.entity_id),
+                "nom": organisme.nom,
+                "versant": organisme.versant.value,
+                "siret": organisme.siret.code,
+                "gestionnaire": None,
+                "gestion_ats": organisme.gestion_ats,
+                "date_creation": organisme.date_creation,
+                "date_derniere_activite": organisme.date_derniere_activite,
+                "nombre_agents": 10,
+                "nombre_offres_publiees": 20,
+            }
+            for organisme in organismes
+        ]
 
     @pytest.mark.parametrize(
         ("exception", "expected_status", "expected_body"),


### PR DESCRIPTION
## 📝 Description
Pour éviter un endpoint get organisme detail dans le contexte des administrateurs / staff, on étoffe le serializer qui retourne des organismes en liste avec le champ manquant : versant.

Il manquait aussi le nombre de comptes agents et le nombre d'offres publiées cf. [écran](https://www.figma.com/design/Yr6ef0DVqJbDG5ouzduW7F/CSPLab---ATS?node-id=2479-137881&t=a2v8ezw7KRQd8BQg-0)).


## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [ ] 👀 J’ai demandé une revue à une personne de l’équipe.
