### PR TITLE
✨(recruteur) INTERFACE : modïfier un agent dans un organisme

### DIFF
--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -633,7 +633,7 @@ export interface components {
         PatchedEditerNote: {
             message?: string;
         };
-        PatchedModifierAgent: {
+        PatchedUpdateAgentOrganisme: {
             /** Format: uuid */
             agent_uuid?: string;
             role?: components["schemas"]["RoleEnum"];
@@ -1290,9 +1290,9 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/json": components["schemas"]["PatchedModifierAgent"];
-                "application/x-www-form-urlencoded": components["schemas"]["PatchedModifierAgent"];
-                "multipart/form-data": components["schemas"]["PatchedModifierAgent"];
+                "application/json": components["schemas"]["PatchedUpdateAgentOrganisme"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedUpdateAgentOrganisme"];
+                "multipart/form-data": components["schemas"]["PatchedUpdateAgentOrganisme"];
             };
         };
         responses: {

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -635,7 +635,7 @@ export interface components {
         };
         PatchedUpdateAgentOrganisme: {
             /** Format: uuid */
-            agent_uuid?: string;
+            agent_id?: string;
             role?: components["schemas"]["RoleEnum"];
             nom?: string;
             prenom?: string;

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -90,7 +90,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** Modifier un agent d'un organisme */
+        patch: operations["recruteur_organismes_parametres_agents_partial_update"];
         trace?: never;
     };
     "/recruteur/organismes/{organisme_uuid}/parametres/etapes": {
@@ -631,6 +632,14 @@ export interface components {
         };
         PatchedEditerNote: {
             message?: string;
+        };
+        PatchedModifierAgent: {
+            /** Format: uuid */
+            agent_uuid?: string;
+            role?: components["schemas"]["RoleEnum"];
+            nom?: string;
+            prenom?: string;
+            poste?: string;
         };
         RecrutementDetail: {
             /** Format: uuid */
@@ -1221,6 +1230,73 @@ export interface operations {
         };
         responses: {
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentOrganisme"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+        };
+    };
+    recruteur_organismes_parametres_agents_partial_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organisme_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PatchedModifierAgent"];
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedModifierAgent"];
+                "multipart/form-data": components["schemas"]["PatchedModifierAgent"];
+            };
+        };
+        responses: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -159,7 +159,7 @@ class SetAgentRoleOnOrganismeSerializer(serializers.Serializer):
 
 
 class UpdateAgentOrganismeSerializer(serializers.Serializer):
-    agent_uuid = serializers.UUIDField()
+    agent_id = serializers.UUIDField()
     role = serializers.ChoiceField(
         choices=[(r.value, r.value) for r in AgentOrganismeRole], required=False
     )

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -158,7 +158,7 @@ class SetAgentRoleOnOrganismeSerializer(serializers.Serializer):
     )
 
 
-class ModifierAgentSerializer(serializers.Serializer):
+class UpdateAgentOrganismeSerializer(serializers.Serializer):
     agent_uuid = serializers.UUIDField()
     role = serializers.ChoiceField(
         choices=[(r.value, r.value) for r in AgentOrganismeRole], required=False

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -158,6 +158,16 @@ class SetAgentRoleOnOrganismeSerializer(serializers.Serializer):
     )
 
 
+class ModifierAgentSerializer(serializers.Serializer):
+    agent_uuid = serializers.UUIDField()
+    role = serializers.ChoiceField(
+        choices=[(r.value, r.value) for r in AgentOrganismeRole], required=False
+    )
+    nom = serializers.CharField(required=False)
+    prenom = serializers.CharField(required=False)
+    poste = serializers.CharField(required=False)
+
+
 # ---------------------------------------------------------------------------
 # Serializers pour les notes attachées à une candidature
 # ---------------------------------------------------------------------------

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -108,7 +108,7 @@ class OrganismeAgentsView(APIView):
 
         data = serializer.validated_data
         agent = {
-            "agent_id": data["agent_uuid"],
+            "agent_id": data["agent_id"],
             "organisme_id": "00000000-0000-0000-0000-000000000000",
             "nom": data.get("nom", ""),
             "prenom": data.get("prenom", ""),

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -12,6 +12,7 @@ from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from presentation.api.serializers import GenericErrorSerializer, generic_response_format
 from presentation.recruteur.serializers import (
     AgentOrganismeSerializer,
+    ModifierAgentSerializer,
     SetAgentRoleOnOrganismeSerializer,
 )
 
@@ -62,6 +63,16 @@ _AGENTS_STATIQUES = [
             400: GenericErrorSerializer,
         },
     ),
+    patch=extend_schema(
+        summary="Modifier un agent d'un organisme",
+        tags=["recruteur"],
+        request=ModifierAgentSerializer,
+        responses={
+            **generic_response_format,
+            200: AgentOrganismeSerializer,
+            400: GenericErrorSerializer,
+        },
+    ),
 )
 class OrganismeAgentsView(APIView):
     permission_classes = [IsAuthenticated]
@@ -89,3 +100,22 @@ class OrganismeAgentsView(APIView):
         }
         out_serializer = AgentOrganismeSerializer(agent)
         return Response(out_serializer.data, status=status.HTTP_201_CREATED)
+
+    def patch(self, request: Request, organisme_uuid: UUID) -> Response:
+        serializer = ModifierAgentSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+        agent = {
+            "agent_id": data["agent_uuid"],
+            "nom": data.get("nom", ""),
+            "prenom": data.get("prenom", ""),
+            "email": "",
+            "poste": data.get("poste", ""),
+            "role": data.get("role", ""),
+            "date_derniere_activite": None,
+            "date_creation_compte": now(),
+        }
+        out_serializer = AgentOrganismeSerializer(agent)
+        return Response(out_serializer.data, status=status.HTTP_200_OK)

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -12,8 +12,8 @@ from domain.recruteur.value_objects.roles import AgentOrganismeRole
 from presentation.api.serializers import GenericErrorSerializer, generic_response_format
 from presentation.recruteur.serializers import (
     AgentOrganismeSerializer,
-    ModifierAgentSerializer,
     SetAgentRoleOnOrganismeSerializer,
+    UpdateAgentOrganismeSerializer,
 )
 
 # TODO : données statiques en attendant le branchement sur OrganismeAgentModel
@@ -66,7 +66,7 @@ _AGENTS_STATIQUES = [
     patch=extend_schema(
         summary="Modifier un agent d'un organisme",
         tags=["recruteur"],
-        request=ModifierAgentSerializer,
+        request=UpdateAgentOrganismeSerializer,
         responses={
             **generic_response_format,
             200: AgentOrganismeSerializer,
@@ -102,7 +102,7 @@ class OrganismeAgentsView(APIView):
         return Response(out_serializer.data, status=status.HTTP_201_CREATED)
 
     def patch(self, request: Request, organisme_uuid: UUID) -> Response:
-        serializer = ModifierAgentSerializer(data=request.data)
+        serializer = UpdateAgentOrganismeSerializer(data=request.data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -109,6 +109,7 @@ class OrganismeAgentsView(APIView):
         data = serializer.validated_data
         agent = {
             "agent_id": data["agent_uuid"],
+            "organisme_id": "00000000-0000-0000-0000-000000000000",
             "nom": data.get("nom", ""),
             "prenom": data.get("prenom", ""),
             "email": "",

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -475,6 +475,69 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+    patch:
+      operationId: recruteur_organismes_parametres_agents_partial_update
+      summary: Modifier un agent d'un organisme
+      parameters:
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - recruteur
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedModifierAgent'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedModifierAgent'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedModifierAgent'
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentOrganisme'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/organismes/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organismes_parametres_etapes_list
@@ -1981,6 +2044,20 @@ components:
       type: object
       properties:
         message:
+          type: string
+    PatchedModifierAgent:
+      type: object
+      properties:
+        agent_uuid:
+          type: string
+          format: uuid
+        role:
+          $ref: '#/components/schemas/RoleEnum'
+        nom:
+          type: string
+        prenom:
+          type: string
+        poste:
           type: string
     RecrutementDetail:
       type: object

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -2048,7 +2048,7 @@ components:
     PatchedUpdateAgentOrganisme:
       type: object
       properties:
-        agent_uuid:
+        agent_id:
           type: string
           format: uuid
         role:

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -491,13 +491,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedModifierAgent'
+              $ref: '#/components/schemas/PatchedUpdateAgentOrganisme'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedModifierAgent'
+              $ref: '#/components/schemas/PatchedUpdateAgentOrganisme'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedModifierAgent'
+              $ref: '#/components/schemas/PatchedUpdateAgentOrganisme'
       security:
       - jwtAuth: []
       - cookieAuth: []
@@ -2045,7 +2045,7 @@ components:
       properties:
         message:
           type: string
-    PatchedModifierAgent:
+    PatchedUpdateAgentOrganisme:
       type: object
       properties:
         agent_uuid:

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -65,12 +65,12 @@ class TestOrganismeAgentsView:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_modifier_agent(self, authenticated_client):
-        agent_uuid = str(uuid4())
+        agent_id = str(uuid4())
 
         response = authenticated_client.patch(
             AGENTS_URL,
             data={
-                "agent_uuid": agent_uuid,
+                "agent_id": agent_id,
                 "role": AgentOrganismeRole.RESPONSABLE.value,
                 "poste": "Directeur des recrutements",
             },
@@ -79,14 +79,14 @@ class TestOrganismeAgentsView:
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data["agent_id"] == agent_uuid
+        assert data["agent_id"] == agent_id
         assert data["role"] == AgentOrganismeRole.RESPONSABLE.value
         assert data["poste"] == "Directeur des recrutements"
 
     def test_modifier_agent_invalid_role(self, authenticated_client):
         response = authenticated_client.patch(
             AGENTS_URL,
-            data={"agent_uuid": str(uuid4()), "role": "not-a-role"},
+            data={"agent_id": str(uuid4()), "role": "not-a-role"},
             format="json",
         )
 

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -58,3 +58,45 @@ class TestOrganismeAgentsView:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_anonymous_patch_is_unauthorized(self, api_client):
+        response = api_client.patch(AGENTS_URL, data={}, format="json")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_modifier_agent(self, authenticated_client):
+        agent_uuid = str(uuid4())
+
+        response = authenticated_client.patch(
+            AGENTS_URL,
+            data={
+                "agent_uuid": agent_uuid,
+                "role": AgentOrganismeRole.RESPONSABLE.value,
+                "poste": "Directeur des recrutements",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["agent_id"] == agent_uuid
+        assert data["role"] == AgentOrganismeRole.RESPONSABLE.value
+        assert data["poste"] == "Directeur des recrutements"
+
+    def test_modifier_agent_invalid_role(self, authenticated_client):
+        response = authenticated_client.patch(
+            AGENTS_URL,
+            data={"agent_uuid": str(uuid4()), "role": "not-a-role"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_modifier_agent_requires_agent_uuid(self, authenticated_client):
+        response = authenticated_client.patch(
+            AGENTS_URL,
+            data={"role": AgentOrganismeRole.MEMBRE.value},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -64,7 +64,7 @@ class TestOrganismeAgentsView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_modifier_agent(self, authenticated_client):
+    def test_update_agent(self, authenticated_client):
         agent_id = str(uuid4())
 
         response = authenticated_client.patch(
@@ -83,7 +83,7 @@ class TestOrganismeAgentsView:
         assert data["role"] == AgentOrganismeRole.RESPONSABLE.value
         assert data["poste"] == "Directeur des recrutements"
 
-    def test_modifier_agent_invalid_role(self, authenticated_client):
+    def test_update_agent_invalid_role(self, authenticated_client):
         response = authenticated_client.patch(
             AGENTS_URL,
             data={"agent_id": str(uuid4()), "role": "not-a-role"},
@@ -92,7 +92,7 @@ class TestOrganismeAgentsView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_modifier_agent_requires_agent_uuid(self, authenticated_client):
+    def test_update_agent_requires_agent_id(self, authenticated_client):
         response = authenticated_client.patch(
             AGENTS_URL,
             data={"role": AgentOrganismeRole.MEMBRE.value},


### PR DESCRIPTION
## 📝 Description
🎸 Ajoute la possibilité de modifier un agent d'un organisme (rôle, nom, prénom et/ou poste) via un PATCH sur la route existante organismes/{organisme_uuid}/parametres/agents. Implémentation limitée à la couche présentation, réponse statique

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications

- Presentation (recruteur) : ajout de ModifierAgentSerializer (serializers.py), agent_uuid requis, role/nom/prenom/poste optionnels (mise à jour partielle)
- Presentation (recruteur) : ajout de la méthode PATCH sur OrganismeAgentsView (views/organisme_agents.py), retour statique 200 reprenant les champs soumis (+ tests)
- Regénération du schéma OpenAPI interne (internal-schema.yaml) et des types front générés (api.d.ts)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
