### PR TITLE
✨(recruteur) INTERFACE : révoquer un agent d'un organisme

### DIFF
--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -90,7 +90,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        /** Modifier un agent d'un organisme */
+        /** Modifier ou revoquer un agent d'un organisme */
         patch: operations["recruteur_organismes_parametres_agents_partial_update"];
         trace?: never;
     };
@@ -308,6 +308,8 @@ export interface components {
             date_derniere_activite: string | null;
             /** Format: date-time */
             date_creation_compte: string;
+            /** Format: date-time */
+            date_revocation?: string | null;
         };
         /** @enum {unknown} */
         BlankEnum: "";
@@ -640,6 +642,8 @@ export interface components {
             nom?: string;
             prenom?: string;
             poste?: string;
+            /** Format: date-time */
+            date_revocation?: string;
         };
         RecrutementDetail: {
             /** Format: uuid */

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -149,6 +149,7 @@ class AgentOrganismeSerializer(serializers.Serializer):
     role = serializers.CharField()
     date_derniere_activite = serializers.DateTimeField(allow_null=True)
     date_creation_compte = serializers.DateTimeField()
+    date_revocation = serializers.DateTimeField(required=False, allow_null=True)
 
 
 class SetAgentRoleOnOrganismeSerializer(serializers.Serializer):
@@ -166,6 +167,7 @@ class UpdateAgentOrganismeSerializer(serializers.Serializer):
     nom = serializers.CharField(required=False)
     prenom = serializers.CharField(required=False)
     poste = serializers.CharField(required=False)
+    date_revocation = serializers.DateTimeField(required=False)
 
 
 # ---------------------------------------------------------------------------

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -29,6 +29,7 @@ _AGENTS_STATIQUES = [
         "role": AgentOrganismeRole.RESPONSABLE.value,
         "date_derniere_activite": "2026-08-18T09:12:00Z",
         "date_creation_compte": "2025-01-10T08:00:00Z",
+        "date_revocation": None,
     },
     {
         "agent_id": uuid4(),
@@ -40,6 +41,7 @@ _AGENTS_STATIQUES = [
         "role": AgentOrganismeRole.MEMBRE.value,
         "date_derniere_activite": "2026-08-15T14:30:00Z",
         "date_creation_compte": "2025-03-22T08:00:00Z",
+        "date_revocation": None,
     },
 ]
 
@@ -64,7 +66,7 @@ _AGENTS_STATIQUES = [
         },
     ),
     patch=extend_schema(
-        summary="Modifier un agent d'un organisme",
+        summary="Modifier ou revoquer un agent d'un organisme",
         tags=["recruteur"],
         request=UpdateAgentOrganismeSerializer,
         responses={
@@ -97,6 +99,7 @@ class OrganismeAgentsView(APIView):
             "role": data["role"],
             "date_derniere_activite": None,
             "date_creation_compte": now(),
+            "date_revocation": None,
         }
         out_serializer = AgentOrganismeSerializer(agent)
         return Response(out_serializer.data, status=status.HTTP_201_CREATED)
@@ -117,6 +120,7 @@ class OrganismeAgentsView(APIView):
             "role": data.get("role", ""),
             "date_derniere_activite": None,
             "date_creation_compte": now(),
+            "date_revocation": data.get("date_revocation"),
         }
         out_serializer = AgentOrganismeSerializer(agent)
         return Response(out_serializer.data, status=status.HTTP_200_OK)

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -477,7 +477,7 @@ paths:
           description: ''
     patch:
       operationId: recruteur_organismes_parametres_agents_partial_update
-      summary: Modifier un agent d'un organisme
+      summary: Modifier ou revoquer un agent d'un organisme
       parameters:
       - in: path
         name: organisme_uuid
@@ -1344,6 +1344,10 @@ components:
         date_creation_compte:
           type: string
           format: date-time
+        date_revocation:
+          type: string
+          format: date-time
+          nullable: true
       required:
       - agent_id
       - date_creation_compte
@@ -2059,6 +2063,9 @@ components:
           type: string
         poste:
           type: string
+        date_revocation:
+          type: string
+          format: date-time
     RecrutementDetail:
       type: object
       properties:

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -102,12 +102,12 @@ class TestOrganismeAgentsView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_revoke_agent_role_on_organisme(self, authenticated_client):
-        agent_uuid = str(uuid4())
+        agent_id = str(uuid4())
 
         response = authenticated_client.patch(
             AGENTS_URL,
             data={
-                "agent_uuid": agent_uuid,
+                "agent_id": agent_id,
                 "date_revocation": "2026-08-20T10:00:00Z",
             },
             format="json",
@@ -115,5 +115,5 @@ class TestOrganismeAgentsView:
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data["agent_id"] == agent_uuid
+        assert data["agent_id"] == agent_id
         assert data["date_revocation"] == "2026-08-20T10:00:00Z"

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -100,3 +100,20 @@ class TestOrganismeAgentsView:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_revoquer_agent(self, authenticated_client):
+        agent_uuid = str(uuid4())
+
+        response = authenticated_client.patch(
+            AGENTS_URL,
+            data={
+                "agent_uuid": agent_uuid,
+                "date_revocation": "2026-08-20T10:00:00Z",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["agent_id"] == agent_uuid
+        assert data["date_revocation"] == "2026-08-20T10:00:00Z"

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -27,7 +27,7 @@ class TestOrganismeAgentsView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_rattacher_agent(self, authenticated_client):
+    def test_set_agent_role(self, authenticated_client):
         agent_id = str(uuid4())
 
         response = authenticated_client.post(
@@ -41,7 +41,7 @@ class TestOrganismeAgentsView:
         assert data["agent_id"] == agent_id
         assert data["role"] == AgentOrganismeRole.MEMBRE.value
 
-    def test_rattacher_agent_invalid_role(self, authenticated_client):
+    def test_set_agent_role_invalid_role(self, authenticated_client):
         response = authenticated_client.post(
             AGENTS_URL,
             data={"agent_id": str(uuid4()), "role": "not-a-role"},
@@ -50,7 +50,7 @@ class TestOrganismeAgentsView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_rattacher_agent_requires_agent_id(self, authenticated_client):
+    def test_set_agent_role_requires_agent_id(self, authenticated_client):
         response = authenticated_client.post(
             AGENTS_URL,
             data={"role": AgentOrganismeRole.MEMBRE.value},
@@ -101,7 +101,7 @@ class TestOrganismeAgentsView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_revoquer_agent(self, authenticated_client):
+    def test_revoke_agent_role_on_organisme(self, authenticated_client):
         agent_uuid = str(uuid4())
 
         response = authenticated_client.patch(


### PR DESCRIPTION
## 📝 Description
🎸 Ajoute la possibilité de révoquer (soft delete) le rôle d'un agent dans un organisme, en étendant le PATCH existant sur organismes/{organisme_uuid}/parametres/agents avec un champ date_revocation. 
🎸 Implémentation limitée à la couche présentation : réponse statique
🎸 Cette date sera reprise dans une issue à venir pour piloter le rattachement actif d'un agent dans la table de lien réelle.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications

- Presentation (recruteur) : ajout du champ date_revocation (optionnel, nullable) à AgentOrganismeSerializer et ModifierAgentSerializer (serializers.py)
- Presentation (recruteur) : le PATCH de OrganismeAgentsView reprend désormais date_revocation dans sa réponse (views/organisme_agents.py) (+ tests)
- Regénération du schéma OpenAPI interne (internal-schema.yaml) et des types front générés (api.d.ts)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
