### PR TITLE
✨(ingestion) ajoute le référentiel GIPCDG pour l'import des organismes

### DIFF
--- a/env.d/ingestion-example
+++ b/env.d/ingestion-example
@@ -4,6 +4,10 @@
 # signatures. Add as many entries as needed.
 TALENTSOFT_CREDENTIALS=[]
 
+# API key sent as X-API-Key when calling the GIPCDG collectivités endpoint
+# (emploi-territorial.fr) for the organismes import.
+GIPCDG_API_KEY=
+
 WEB_BASE_URL=
 WEB_API_KEY=
 

--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.4"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.2.4"
+version = "0.2.5"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.6"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/tests/test_department.py
+++ b/libs/referentiel/tests/test_department.py
@@ -8,16 +8,22 @@ from referentiel.value_objects.department import Department
     [
         pytest.param("01053", "01", id="metropole"),
         pytest.param("97120", "971", id="dom"),
-        pytest.param("5", None, id="too_short"),
-        pytest.param("97", None, id="dom_prefix_without_enough_digits"),
-        pytest.param("00042", None, id="invalid_department"),
     ],
 )
 def test_from_commune_code(cog_commune, expected_code):
     department = Department.from_commune_code(cog_commune)
 
-    if expected_code is None:
-        assert department is None
-    else:
-        assert department is not None
-        assert department.code == expected_code
+    assert department.code == expected_code
+
+
+@pytest.mark.parametrize(
+    "cog_commune",
+    [
+        pytest.param("5", id="too_short"),
+        pytest.param("97", id="dom_prefix_without_enough_digits"),
+        pytest.param("00042", id="invalid_department"),
+    ],
+)
+def test_from_commune_code_raises_on_invalid_code(cog_commune):
+    with pytest.raises(ValueError):
+        Department.from_commune_code(cog_commune)

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },

--- a/libs/referentiel/value_objects/department.py
+++ b/libs/referentiel/value_objects/department.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, ValidationError, field_validator
 
 COMMUNE_CODE_LENGTH = 2
 DOM_TOM_COMMUNE_CODE_LENGTH = 3
+DEPARTMENT_CODE_LENGTH = 2
+DOM_TOM_DEPARTMENT_CODE_LENGTH = 3
 
 
 class Department(BaseModel):
@@ -134,18 +136,27 @@ class Department(BaseModel):
         return self.NAMES.get(self.code, self.code)
 
     @classmethod
+    def from_department_code(cls, code: str) -> Optional["Department"]:
+        normalized = code.strip().lstrip("0")
+        if not normalized:
+            raise ValueError(f"Invalid department code: {code}")
+        formatted = (
+            normalized.zfill(DOM_TOM_DEPARTMENT_CODE_LENGTH)
+            if len(normalized) >= DOM_TOM_DEPARTMENT_CODE_LENGTH
+            else normalized.zfill(DEPARTMENT_CODE_LENGTH)
+        )
+        return cls(code=formatted)
+
+    @classmethod
     def from_commune_code(cls, cog_commune: str) -> Optional["Department"]:
         if len(cog_commune) < COMMUNE_CODE_LENGTH:
-            return None
+            raise ValidationError(cog_commune)
 
         if cog_commune[:COMMUNE_CODE_LENGTH] in ("97", "98"):
             if len(cog_commune) < DOM_TOM_COMMUNE_CODE_LENGTH:
-                return None
+                raise ValidationError(cog_commune)
             code = cog_commune[:DOM_TOM_COMMUNE_CODE_LENGTH]
         else:
             code = cog_commune[:COMMUNE_CODE_LENGTH]
 
-        try:
-            return cls(code=code)
-        except ValidationError:
-            return None
+        return cls(code=code)

--- a/libs/referentiel/value_objects/department.py
+++ b/libs/referentiel/value_objects/department.py
@@ -1,6 +1,6 @@
-from typing import ClassVar, Optional
+from typing import ClassVar
 
-from pydantic import BaseModel, ValidationError, field_validator
+from pydantic import BaseModel, field_validator
 
 COMMUNE_CODE_LENGTH = 2
 DOM_TOM_COMMUNE_CODE_LENGTH = 3
@@ -136,7 +136,7 @@ class Department(BaseModel):
         return self.NAMES.get(self.code, self.code)
 
     @classmethod
-    def from_department_code(cls, code: str) -> Optional["Department"]:
+    def from_department_code(cls, code: str) -> "Department":
         normalized = code.strip().lstrip("0")
         if not normalized:
             raise ValueError(f"Invalid department code: {code}")
@@ -148,13 +148,13 @@ class Department(BaseModel):
         return cls(code=formatted)
 
     @classmethod
-    def from_commune_code(cls, cog_commune: str) -> Optional["Department"]:
+    def from_commune_code(cls, cog_commune: str) -> "Department":
         if len(cog_commune) < COMMUNE_CODE_LENGTH:
-            raise ValidationError(cog_commune)
+            raise ValueError(f"Invalid commune code: {cog_commune}")
 
         if cog_commune[:COMMUNE_CODE_LENGTH] in ("97", "98"):
             if len(cog_commune) < DOM_TOM_COMMUNE_CODE_LENGTH:
-                raise ValidationError(cog_commune)
+                raise ValueError(f"Invalid commune code: {cog_commune}")
             code = cog_commune[:DOM_TOM_COMMUNE_CODE_LENGTH]
         else:
             code = cog_commune[:COMMUNE_CODE_LENGTH]

--- a/src/ingestion/api/config.py
+++ b/src/ingestion/api/config.py
@@ -20,6 +20,12 @@ class Settings(BaseSettings):
     # credentials are only used to verify webhook signatures.
     talentsoft_credentials: list[TalentsoftCredential] = []
 
+    gipcdg_api_key: str | None = None
+    # https://emploi-territorial.fr/api
+    gipcdg_collectivites_api_url: HttpUrl = HttpUrl(
+        "https://emploi-territorial.fr/api/cdg/collectivites?etab=5&limit=1000"
+    )
+
     web_base_url: str | None = None
     web_api_key: str | None = None
 

--- a/src/ingestion/api/config.py
+++ b/src/ingestion/api/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     gipcdg_api_key: str | None = None
     # https://emploi-territorial.fr/api
     gipcdg_collectivites_api_url: HttpUrl = HttpUrl(
-        "https://emploi-territorial.fr/api/cdg/collectivites?etab=5&limit=1000"
+        "https://emploi-territorial.fr/api/cdg/collectivites?limit=1000"
     )
 
     web_base_url: str | None = None

--- a/src/ingestion/api/config.py
+++ b/src/ingestion/api/config.py
@@ -20,6 +20,8 @@ class Settings(BaseSettings):
     # credentials are only used to verify webhook signatures.
     talentsoft_credentials: list[TalentsoftCredential] = []
 
+    gipcdg_api_key: str | None = None
+
     web_base_url: str | None = None
     web_api_key: str | None = None
 

--- a/src/ingestion/application/usecases/clean_raw_organismes.py
+++ b/src/ingestion/application/usecases/clean_raw_organismes.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timezone
 
+from pydantic import ValidationError
 from referentiel.entities.organisme import Organisme
 
 from domain.gateways.organismes_cleaner import IOrganismesCleaner
@@ -36,9 +37,17 @@ class CleanRawOrganismesUsecase:
                 cleaned_ids.append(raw_organisme.id)
                 try:
                     organisme = self._organismes_cleaner.clean(raw_organisme)
+                except ValidationError as e:
+                    logger.warning(
+                        "Invalid data for raw organisme %s: %s",
+                        raw_organisme.external_id,
+                        e,
+                    )
+                    continue
                 except Exception:
                     logger.exception(
-                        "Failed to clean raw organisme %s", raw_organisme.external_id
+                        "Unexpected error cleaning raw organisme %s",
+                        raw_organisme.external_id,
                     )
                     continue
                 if organisme is not None:

--- a/src/ingestion/bin/clean_raw_organismes.py
+++ b/src/ingestion/bin/clean_raw_organismes.py
@@ -9,14 +9,19 @@ from infrastructure.di.container import create_container
 logging.basicConfig(level=logging.INFO)
 
 
-async def _run(referentiel: str) -> None:
+async def _run(referentiel: OrganismeReferentiel) -> None:
     container = create_container()
     await container.clean_raw_organismes_usecase().execute(referentiel)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--referentiel", default=OrganismeReferentiel.FINESS)
+    parser.add_argument(
+        "--referentiel",
+        default=OrganismeReferentiel.FINESS,
+        type=OrganismeReferentiel,
+        choices=list(OrganismeReferentiel),
+    )
     args = parser.parse_args()
     asyncio.run(_run(args.referentiel))
 

--- a/src/ingestion/bin/import_organismes.py
+++ b/src/ingestion/bin/import_organismes.py
@@ -9,19 +9,10 @@ from infrastructure.di.container import Container, create_container
 
 logging.basicConfig(level=logging.INFO)
 
-USE_CASES = {
-    OrganismeReferentiel.FINESS: lambda container: (
-        container.import_organismes_usecase()
-    ),
-    OrganismeReferentiel.GIPCDG: lambda container: (
-        container.import_organismes_gipcdg_usecase()
-    ),
-}
-
 
 async def _run(referentiel: OrganismeReferentiel) -> None:
     container: Container = create_container()
-    use_case = USE_CASES[referentiel](container)
+    use_case = container.import_organismes_usecase_for(referentiel)
     await use_case.execute(ImportOrganismesCommand(referentiel=referentiel))
 
 

--- a/src/ingestion/bin/import_organismes.py
+++ b/src/ingestion/bin/import_organismes.py
@@ -1,23 +1,40 @@
 #!/usr/bin/env python
+import argparse
 import asyncio
 import logging
 
 from application.usecases.import_organismes import ImportOrganismesCommand
 from domain.value_objects.organisme_referentiel import OrganismeReferentiel
-from infrastructure.di.container import create_container
+from infrastructure.di.container import Container, create_container
 
 logging.basicConfig(level=logging.INFO)
 
+USE_CASES = {
+    OrganismeReferentiel.FINESS: lambda container: (
+        container.import_organismes_usecase()
+    ),
+    OrganismeReferentiel.GIPCDG: lambda container: (
+        container.import_organismes_gipcdg_usecase()
+    ),
+}
+
 
 async def _run(referentiel: OrganismeReferentiel) -> None:
-    container = create_container()
-    await container.import_organismes_usecase().execute(
-        ImportOrganismesCommand(referentiel=referentiel)
-    )
+    container: Container = create_container()
+    use_case = USE_CASES[referentiel](container)
+    await use_case.execute(ImportOrganismesCommand(referentiel=referentiel))
 
 
 def main() -> None:
-    asyncio.run(_run(OrganismeReferentiel.FINESS))
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--referentiel",
+        default=OrganismeReferentiel.FINESS,
+        type=OrganismeReferentiel,
+        choices=list(OrganismeReferentiel),
+    )
+    args = parser.parse_args()
+    asyncio.run(_run(args.referentiel))
 
 
 if __name__ == "__main__":

--- a/src/ingestion/bin/import_organismes.py
+++ b/src/ingestion/bin/import_organismes.py
@@ -1,20 +1,30 @@
 #!/usr/bin/env python
+import argparse
 import asyncio
 import logging
 
 from application.use_cases.import_organismes import ImportOrganismesCommand
-from infrastructure.di.container import create_container
+from infrastructure.di.container import Container, create_container
 
 logging.basicConfig(level=logging.INFO)
 
+USE_CASES = {
+    "FINESS": lambda container: container.import_organismes_use_case(),
+    "GIPCDG": lambda container: container.import_organismes_gipcdg_use_case(),
+}
 
-async def _run() -> None:
-    container = create_container()
-    await container.import_organismes_use_case().execute(ImportOrganismesCommand())
+
+async def _run(referentiel: str) -> None:
+    container: Container = create_container()
+    use_case = USE_CASES[referentiel](container)
+    await use_case.execute(ImportOrganismesCommand())
 
 
 def main() -> None:
-    asyncio.run(_run())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--referentiel", default="FINESS", choices=sorted(USE_CASES))
+    args = parser.parse_args()
+    asyncio.run(_run(args.referentiel))
 
 
 if __name__ == "__main__":

--- a/src/ingestion/bin/import_organismes.py
+++ b/src/ingestion/bin/import_organismes.py
@@ -5,14 +5,18 @@ import logging
 
 from application.usecases.import_organismes import ImportOrganismesCommand
 from domain.value_objects.organisme_referentiel import OrganismeReferentiel
-from infrastructure.di.container import Container, create_container
+from infrastructure.di.container import (
+    Container,
+    create_container,
+    import_organismes_usecase_for,
+)
 
 logging.basicConfig(level=logging.INFO)
 
 
 async def _run(referentiel: OrganismeReferentiel) -> None:
     container: Container = create_container()
-    use_case = container.import_organismes_usecase_for(referentiel)
+    use_case = import_organismes_usecase_for(container, referentiel)
     await use_case.execute(ImportOrganismesCommand(referentiel=referentiel))
 
 

--- a/src/ingestion/bin/organismes_pipeline.py
+++ b/src/ingestion/bin/organismes_pipeline.py
@@ -12,22 +12,14 @@ from infrastructure.di.container import Container, create_container
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-IMPORT_USE_CASES = {
-    OrganismeReferentiel.FINESS: lambda container: (
-        container.import_organismes_usecase()
-    ),
-    OrganismeReferentiel.GIPCDG: lambda container: (
-        container.import_organismes_gipcdg_usecase()
-    ),
-}
-
 
 async def _run() -> None:
     container: Container = create_container()
 
     organismes: list[Organisme] = []
     for referentiel in OrganismeReferentiel:
-        import_result = await IMPORT_USE_CASES[referentiel](container).execute(
+        use_case = container.import_organismes_usecase_for(referentiel)
+        import_result = await use_case.execute(
             ImportOrganismesCommand(referentiel=referentiel)
         )
         if import_result.referentiel is None:

--- a/src/ingestion/bin/organismes_pipeline.py
+++ b/src/ingestion/bin/organismes_pipeline.py
@@ -2,28 +2,49 @@
 import asyncio
 import logging
 
+from referentiel.entities.organisme import Organisme
+
 from application.usecases.import_organismes import ImportOrganismesCommand
 from application.usecases.publish_organismes import PublishOrganismesCommand
 from domain.value_objects.organisme_referentiel import OrganismeReferentiel
-from infrastructure.di.container import create_container
+from infrastructure.di.container import Container, create_container
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+IMPORT_USE_CASES = {
+    OrganismeReferentiel.FINESS: lambda container: (
+        container.import_organismes_usecase()
+    ),
+    OrganismeReferentiel.GIPCDG: lambda container: (
+        container.import_organismes_gipcdg_usecase()
+    ),
+}
+
 
 async def _run() -> None:
-    container = create_container()
+    container: Container = create_container()
 
-    import_result = await container.import_organismes_usecase().execute(
-        ImportOrganismesCommand(referentiel=OrganismeReferentiel.FINESS)
-    )
-    if import_result.referentiel is None:
-        logger.info("No organismes imported, skipping clean and publish")
+    organismes: list[Organisme] = []
+    for referentiel in OrganismeReferentiel:
+        import_result = await IMPORT_USE_CASES[referentiel](container).execute(
+            ImportOrganismesCommand(referentiel=referentiel)
+        )
+        if import_result.referentiel is None:
+            logger.info(
+                "No organismes imported for referentiel %s, skipping clean",
+                referentiel,
+            )
+            continue
+
+        organismes += await container.clean_raw_organismes_usecase().execute(
+            import_result.referentiel
+        )
+
+    if not organismes:
+        logger.info("No organismes to publish, skipping publish")
         return
 
-    organismes = await container.clean_raw_organismes_usecase().execute(
-        import_result.referentiel
-    )
     await container.publish_organismes_usecase().execute(
         PublishOrganismesCommand(organismes=organismes)
     )

--- a/src/ingestion/bin/organismes_pipeline.py
+++ b/src/ingestion/bin/organismes_pipeline.py
@@ -7,7 +7,11 @@ from referentiel.entities.organisme import Organisme
 from application.usecases.import_organismes import ImportOrganismesCommand
 from application.usecases.publish_organismes import PublishOrganismesCommand
 from domain.value_objects.organisme_referentiel import OrganismeReferentiel
-from infrastructure.di.container import Container, create_container
+from infrastructure.di.container import (
+    Container,
+    create_container,
+    import_organismes_usecase_for,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -18,7 +22,7 @@ async def _run() -> None:
 
     organismes: list[Organisme] = []
     for referentiel in OrganismeReferentiel:
-        use_case = container.import_organismes_usecase_for(referentiel)
+        use_case = import_organismes_usecase_for(container, referentiel)
         import_result = await use_case.execute(
             ImportOrganismesCommand(referentiel=referentiel)
         )

--- a/src/ingestion/domain/value_objects/organisme.py
+++ b/src/ingestion/domain/value_objects/organisme.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass
 from datetime import date
 from typing import Any
+
+from pydantic.dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/src/ingestion/domain/value_objects/organisme_referentiel.py
+++ b/src/ingestion/domain/value_objects/organisme_referentiel.py
@@ -3,3 +3,4 @@ from enum import StrEnum
 
 class OrganismeReferentiel(StrEnum):
     FINESS = "FINESS"
+    GIPCDG = "GIPCDG"

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -37,6 +37,9 @@ from infrastructure.external_gateways.base_web_gateway import WebGatewayCredenti
 from infrastructure.external_gateways.finess_organisme_gateway import (
     FinessOrganismeGateway,
 )
+from infrastructure.external_gateways.gipcdg_organisme_gateway import (
+    GipcdgOrganismeGateway,
+)
 from infrastructure.external_gateways.talentsoft_client import (
     TalentsoftConfig,
     TalentsoftFrontClient,
@@ -141,6 +144,22 @@ class Container(containers.DeclarativeContainer):
         providers.Factory(
             ImportOrganismesUsecase,
             organisme_gateway=organisme_gateway,
+            raw_organisme_repository=raw_organisme_repository,
+        )
+    )
+
+    gipcdg_organisme_gateway: providers.Provider[IOrganismeGateway] = (
+        providers.Singleton(
+            GipcdgOrganismeGateway,
+            api_key=config.gipcdg_api_key,
+            collectivites_api_url=config.gipcdg_collectivites_api_url,
+        )
+    )
+
+    import_organismes_gipcdg_usecase: providers.Provider[ImportOrganismesUsecase] = (
+        providers.Factory(
+            ImportOrganismesUsecase,
+            organisme_gateway=gipcdg_organisme_gateway,
             raw_organisme_repository=raw_organisme_repository,
         )
     )
@@ -272,6 +291,10 @@ def create_container() -> Container:
     container.config.web_api_key.from_value(settings.web_api_key)
     container.config.database_url.from_value(settings.database_url)
     container.config.talentsoft_credentials.from_value(settings.talentsoft_credentials)
+    container.config.gipcdg_api_key.from_value(settings.gipcdg_api_key)
+    container.config.gipcdg_collectivites_api_url.from_value(
+        str(settings.gipcdg_collectivites_api_url)
+    )
 
     _logger = logging.getLogger(__name__)
     register_talentsoft_front_clients(

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -30,6 +30,7 @@ from domain.repositories.raw_organisme_repository import IRawOrganismeRepository
 from domain.repositories.sources_repository import ISourcesRepository
 from domain.repositories.webhook_repository import IWebhookRepository
 from domain.value_objects.credentials import Credentials
+from domain.value_objects.organisme_referentiel import OrganismeReferentiel
 from domain.value_objects.talentsoft_credential import TalentsoftCredential
 from infrastructure.credentials_store import CredentialsStore
 from infrastructure.database import make_engine
@@ -163,6 +164,13 @@ class Container(containers.DeclarativeContainer):
             raw_organisme_repository=raw_organisme_repository,
         )
     )
+
+    def import_organismes_usecase_for(
+        self, referentiel: OrganismeReferentiel
+    ) -> ImportOrganismesUsecase:
+        if referentiel == OrganismeReferentiel.GIPCDG:
+            return self.import_organismes_gipcdg_usecase()
+        return self.import_organismes_usecase()
 
     organismes_cleaner: providers.Provider[IOrganismesCleaner] = providers.Singleton(
         OrganismesCleaner

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -34,6 +34,9 @@ from infrastructure.database import make_engine
 from infrastructure.external_gateways.finess_organisme_gateway import (
     FinessOrganismeGateway,
 )
+from infrastructure.external_gateways.gipcdg_organisme_gateway import (
+    GipcdgOrganismeGateway,
+)
 from infrastructure.external_gateways.talentsoft_client import (
     TalentsoftConfig,
     TalentsoftFrontClient,
@@ -108,6 +111,12 @@ def _make_offers_by_source_gateway(
     return WebOffersBySourceGateway(client=client, base_url=base_url, api_key=api_key)
 
 
+def _make_gipcdg_organisme_gateway(api_key: str | None) -> IOrganismeGateway:
+    if not api_key:
+        raise ValueError("GIPCDG_API_KEY is required")
+    return GipcdgOrganismeGateway(api_key=api_key)
+
+
 def _make_publish_offer_gateway(
     client: httpx.AsyncClient, base_url: str | None, api_key: str | None
 ) -> IPublishOfferGateway:
@@ -161,6 +170,21 @@ class Container(containers.DeclarativeContainer):
         providers.Factory(
             ImportOrganismesUseCase,
             organisme_gateway=organisme_gateway,
+            raw_organisme_repository=raw_organisme_repository,
+        )
+    )
+
+    gipcdg_organisme_gateway: providers.Provider[IOrganismeGateway] = (
+        providers.Singleton(
+            _make_gipcdg_organisme_gateway,
+            api_key=config.gipcdg_api_key,
+        )
+    )
+
+    import_organismes_gipcdg_use_case: providers.Provider[ImportOrganismesUseCase] = (
+        providers.Factory(
+            ImportOrganismesUseCase,
+            organisme_gateway=gipcdg_organisme_gateway,
             raw_organisme_repository=raw_organisme_repository,
         )
     )
@@ -283,6 +307,7 @@ def create_container() -> Container:
     container.config.web_api_key.from_value(settings.web_api_key)
     container.config.database_url.from_value(settings.database_url)
     container.config.talentsoft_credentials.from_value(settings.talentsoft_credentials)
+    container.config.gipcdg_api_key.from_value(settings.gipcdg_api_key)
 
     _logger = logging.getLogger(__name__)
     register_talentsoft_front_clients(

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -165,13 +165,6 @@ class Container(containers.DeclarativeContainer):
         )
     )
 
-    def import_organismes_usecase_for(
-        self, referentiel: OrganismeReferentiel
-    ) -> ImportOrganismesUsecase:
-        if referentiel == OrganismeReferentiel.GIPCDG:
-            return self.import_organismes_gipcdg_usecase()
-        return self.import_organismes_usecase()
-
     organismes_cleaner: providers.Provider[IOrganismesCleaner] = providers.Singleton(
         OrganismesCleaner
     )
@@ -290,6 +283,14 @@ class Container(containers.DeclarativeContainer):
         webhook_repository=webhook_repository,
         dispatch_process_webhook=dispatch_save_raw_offer_webhook,
     )
+
+
+def import_organismes_usecase_for(
+    container: Container, referentiel: OrganismeReferentiel
+) -> ImportOrganismesUsecase:
+    if referentiel == OrganismeReferentiel.GIPCDG:
+        return container.import_organismes_gipcdg_usecase()
+    return container.import_organismes_usecase()
 
 
 def create_container() -> Container:

--- a/src/ingestion/infrastructure/external_gateways/finess_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/finess_organisme_gateway.py
@@ -108,6 +108,6 @@ class FinessOrganismeGateway(IOrganismeGateway):
                 continue
             yield OrganismeData(
                 referentiel=OrganismeReferentiel.FINESS,
-                external_id=numero_finess,
+                external_id=str(numero_finess),
                 data=ege,
             )

--- a/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
@@ -7,9 +7,9 @@ from pydantic.dataclasses import dataclass
 
 from domain.gateways.organisme_gateway import IOrganismeGateway
 from domain.value_objects.organisme import OrganismeData, OrganismeImportResource
+from domain.value_objects.organisme_referentiel import OrganismeReferentiel
 from infrastructure.exceptions.exceptions import ExternalApiError
 
-REFERENTIEL_GIPCDG = "GIPCDG"
 API_STATUS_OK = 200
 
 
@@ -47,7 +47,7 @@ class GipcdgOrganismeGateway(IOrganismeGateway):
                 if external_id is None:
                     continue
                 yield OrganismeData(
-                    referentiel=REFERENTIEL_GIPCDG,
+                    referentiel=OrganismeReferentiel.GIPCDG,
                     external_id=str(external_id),
                     data=collectivite,
                 )

--- a/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
@@ -36,9 +36,34 @@ class GipcdgOrganismeGateway(IOrganismeGateway):
     def stream_organismes(
         self, resource: OrganismeImportResource
     ) -> Iterator[OrganismeData]:
+        offset = 0
+        while True:
+            collectivites = self._fetch_page(resource.url, offset)
+            if not collectivites:
+                return
+
+            for collectivite in collectivites:
+                external_id = collectivite.get("id_col")
+                if external_id is None:
+                    continue
+                yield OrganismeData(
+                    referentiel=REFERENTIEL_GIPCDG,
+                    external_id=str(external_id),
+                    data=collectivite,
+                )
+
+            last_rank = collectivites[-1].get("_rank")
+            total = collectivites[-1].get("_total")
+            if last_rank is None or total is None or last_rank >= total:
+                return
+
+            offset += len(collectivites)
+
+    def _fetch_page(self, url: str, offset: int) -> list[dict]:
+        request_url = httpx.URL(url).copy_merge_params({"offset": offset})
         try:
             response = httpx.get(
-                resource.url,
+                request_url,
                 headers={"X-API-Key": self.api_key, "Accept": "application/json"},
                 timeout=self.timeout,
             )
@@ -46,22 +71,14 @@ class GipcdgOrganismeGateway(IOrganismeGateway):
         except httpx.HTTPError as err:
             raise ExternalApiError(
                 "Erreur lors de la récupération des collectivités GIPCDG",
-                details={"url": resource.url, "error": str(err)},
+                details={"url": str(request_url), "error": str(err)},
             ) from err
 
         payload = response.json()
         if payload.get("status") != API_STATUS_OK:
             raise ExternalApiError(
                 "Réponse invalide de l'API GIPCDG",
-                details={"url": resource.url, "status": payload.get("status")},
+                details={"url": str(request_url), "status": payload.get("status")},
             )
 
-        for collectivite in payload.get("success") or []:
-            external_id = collectivite.get("id_col")
-            if external_id is None:
-                continue
-            yield OrganismeData(
-                referentiel=REFERENTIEL_GIPCDG,
-                external_id=str(external_id),
-                data=collectivite,
-            )
+        return payload.get("success") or []

--- a/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
@@ -1,0 +1,59 @@
+from datetime import date
+from typing import Iterator
+
+import httpx
+
+from domain.gateways.organisme_gateway import IOrganismeGateway
+from domain.value_objects.organisme import OrganismeData, OrganismeImportResource
+from infrastructure.exceptions.exceptions import ExternalApiError
+
+# https://emploi-territorial.fr/api
+COLLECTIVITES_API_URL = (
+    "https://emploi-territorial.fr/api/cdg/collectivites?etab=5&limit=1000"
+)
+REFERENTIEL_GIPCDG = "GIPCDG"
+API_STATUS_OK = 200
+
+
+class GipcdgOrganismeGateway(IOrganismeGateway):
+    def __init__(self, api_key: str, timeout: int = 30):
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def find_resource(self) -> OrganismeImportResource:
+        return OrganismeImportResource(
+            url=COLLECTIVITES_API_URL, millesime=date.today()
+        )
+
+    def stream_organismes(
+        self, resource: OrganismeImportResource
+    ) -> Iterator[OrganismeData]:
+        try:
+            response = httpx.get(
+                resource.url,
+                headers={"X-API-Key": self.api_key, "Accept": "application/json"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as err:
+            raise ExternalApiError(
+                "Erreur lors de la récupération des collectivités GIPCDG",
+                details={"url": resource.url, "error": str(err)},
+            ) from err
+
+        payload = response.json()
+        if payload.get("status") != API_STATUS_OK:
+            raise ExternalApiError(
+                "Réponse invalide de l'API GIPCDG",
+                details={"url": resource.url, "status": payload.get("status")},
+            )
+
+        for collectivite in payload.get("success") or []:
+            external_id = collectivite.get("id_col")
+            if external_id is None:
+                continue
+            yield OrganismeData(
+                referentiel=REFERENTIEL_GIPCDG,
+                external_id=str(external_id),
+                data=collectivite,
+            )

--- a/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/gipcdg_organisme_gateway.py
@@ -1,0 +1,67 @@
+from datetime import date
+from typing import Iterator
+
+import httpx
+from pydantic import HttpUrl
+from pydantic.dataclasses import dataclass
+
+from domain.gateways.organisme_gateway import IOrganismeGateway
+from domain.value_objects.organisme import OrganismeData, OrganismeImportResource
+from infrastructure.exceptions.exceptions import ExternalApiError
+
+REFERENTIEL_GIPCDG = "GIPCDG"
+API_STATUS_OK = 200
+
+
+@dataclass(frozen=True)
+class GipcdgConfig:
+    api_key: str
+    collectivites_api_url: HttpUrl
+
+
+class GipcdgOrganismeGateway(IOrganismeGateway):
+    def __init__(self, api_key: str, collectivites_api_url: str, timeout: int = 30):
+        config = GipcdgConfig(
+            api_key=api_key, collectivites_api_url=HttpUrl(collectivites_api_url)
+        )
+        self.api_key = config.api_key
+        self.collectivites_api_url = str(config.collectivites_api_url)
+        self.timeout = timeout
+
+    def find_resource(self) -> OrganismeImportResource:
+        return OrganismeImportResource(
+            url=self.collectivites_api_url, millesime=date.today()
+        )
+
+    def stream_organismes(
+        self, resource: OrganismeImportResource
+    ) -> Iterator[OrganismeData]:
+        try:
+            response = httpx.get(
+                resource.url,
+                headers={"X-API-Key": self.api_key, "Accept": "application/json"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as err:
+            raise ExternalApiError(
+                "Erreur lors de la récupération des collectivités GIPCDG",
+                details={"url": resource.url, "error": str(err)},
+            ) from err
+
+        payload = response.json()
+        if payload.get("status") != API_STATUS_OK:
+            raise ExternalApiError(
+                "Réponse invalide de l'API GIPCDG",
+                details={"url": resource.url, "status": payload.get("status")},
+            )
+
+        for collectivite in payload.get("success") or []:
+            external_id = collectivite.get("id_col")
+            if external_id is None:
+                continue
+            yield OrganismeData(
+                referentiel=REFERENTIEL_GIPCDG,
+                external_id=str(external_id),
+                data=collectivite,
+            )

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -68,11 +68,23 @@ class OrganismesCleaner:
         best_by_siret: dict[SIRET, Organisme] = {}
         for organisme in organismes:
             current_best = best_by_siret.get(organisme.siret)
-            if current_best is None or self._external_id_key(
-                organisme
-            ) < self._external_id_key(current_best):
+            if current_best is None or self._is_better(organisme, current_best):
                 best_by_siret[organisme.siret] = organisme
         return list(best_by_siret.values())
+
+    @classmethod
+    def _is_better(cls, candidate: Organisme, current_best: Organisme) -> bool:
+        # Le plus récemment créé l'emporte ; à égalité (ou en l'absence de
+        # date_creation, ex. FINESS), le plus petit external_id l'emporte.
+        candidate_date = candidate.date_creation
+        best_date = current_best.date_creation
+        if candidate_date != best_date:
+            if best_date is None:
+                return True
+            if candidate_date is None:
+                return False
+            return candidate_date > best_date
+        return cls._external_id_key(candidate) < cls._external_id_key(current_best)
 
     @staticmethod
     def _is_active_porteuse(data: dict[str, Any], infos: dict[str, Any]) -> bool:
@@ -124,6 +136,11 @@ class OrganismesCleaner:
             return None
 
         data = raw_organisme.data
+        if data.get("is_attached"):
+            # Secteurs internes rattachés à une collectivité mère (même SIRET)
+            # via col_mere_id : ce ne sont pas des organismes distincts.
+            return None
+
         nom = Nom(value=data.get("libl_col") or data.get("libc_col") or "")
         siret = SIRET(code=data.get("siret_col", ""))
         localisation = self._map_localisation_gipcdg(data, raw_organisme.external_id)

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError, field_validator
 from referentiel.entities.organisme import Organisme
 from referentiel.value_objects.department import Department
 from referentiel.value_objects.localisation import Localisation
@@ -31,14 +31,28 @@ def _load_allowed_categories(csv_path: Path) -> set[str]:
         return {row["code"].strip() for row in reader if row.get("code")}
 
 
+class Nom(BaseModel):
+    value: str
+
+    @field_validator("value")
+    @classmethod
+    def validate_nom(cls, v: str) -> str:
+        nom = v.strip()
+        if not nom:
+            raise ValueError("nom is required")
+        return nom
+
+
 class OrganismesCleaner:
     def __init__(self, categories_csv_path: Path = _CATEGORIES_CSV) -> None:
         self._allowed_categories = _load_allowed_categories(categories_csv_path)
 
     def clean(self, raw_organisme: RawOrganisme) -> Optional[Organisme]:
-        if raw_organisme.referentiel != OrganismeReferentiel.FINESS:
-            return None
-        return self._clean_finess(raw_organisme)
+        if raw_organisme.referentiel == OrganismeReferentiel.FINESS:
+            return self._clean_finess(raw_organisme)
+        if raw_organisme.referentiel == OrganismeReferentiel.GIPCDG:
+            return self._clean_gipcdg(raw_organisme)
+        return None
 
     def dedupe_by_siret(self, organismes: list[Organisme]) -> list[Organisme]:
         best_by_siret: dict[SIRET, Organisme] = {}
@@ -79,22 +93,13 @@ class OrganismesCleaner:
         if categorie not in self._allowed_categories:
             return None
 
-        nom = self._map_nom(infos)
-        if not nom:
-            logger.warning(
-                "RawOrganisme %s has no nom, skipping", raw_organisme.external_id
-            )
-            return None
-
-        siret = self._map_siret(infos, raw_organisme.external_id)
-        if siret is None:
-            return None
-
-        localisation = self._map_localisation(data)
+        nom = Nom(value=infos.get("nomEgeLong") or infos.get("nomEgeCourt") or "")
+        siret = SIRET(code=infos.get("siret", ""))
+        localisation = self._map_localisation(data, raw_organisme.external_id)
 
         return Organisme.build(
             entity_id=uuid4(),
-            nom=nom,
+            nom=nom.value,
             versant=Verse.FPH,
             siret=siret,
             localisation=localisation,
@@ -104,40 +109,66 @@ class OrganismesCleaner:
             millesime=raw_organisme.millesime,
         )
 
-    def _map_nom(self, infos: dict[str, Any]) -> Optional[str]:
-        nom = infos.get("nomEgeLong") or infos.get("nomEgeCourt")
-        return nom.strip() if nom else None
-
-    def _map_siret(self, infos: dict[str, Any], external_id: str) -> Optional[SIRET]:
-        siret_str = infos.get("siret")
-        if not siret_str:
-            logger.warning("RawOrganisme %s has no siret, skipping", external_id)
-            return None
-        try:
-            return SIRET(code=siret_str)
-        except ValidationError:
-            logger.warning("Invalid SIRET %s for organisme %s", siret_str, external_id)
+    def _clean_gipcdg(self, raw_organisme: RawOrganisme) -> Optional[Organisme]:
+        if not raw_organisme.data:
             return None
 
-    def _map_localisation(self, data: dict[str, Any]) -> Optional[Localisation]:
-        adresses = data.get("adresse") or []
-        if not adresses:
-            return None
+        data = raw_organisme.data
+        nom = Nom(value=data.get("libl_col") or data.get("libc_col") or "")
+        siret = SIRET(code=data.get("siret_col", ""))
+        localisation = self._map_localisation_gipcdg(data, raw_organisme.external_id)
 
-        adresse = adresses[0]
-        cog_commune = adresse.get("cogCommune")
-        if not cog_commune:
-            return None
-
-        department = Department.from_commune_code(cog_commune)
-        if department is None:
-            return None
-
-        latitude, longitude = self._extract_coordinates(adresse)
-
-        return Localisation.from_department(
-            department, latitude=latitude, longitude=longitude
+        return Organisme.build(
+            entity_id=uuid4(),
+            nom=nom.value,
+            versant=Verse.FPT,
+            siret=siret,
+            localisation=localisation,
+            parent_id=None,
+            external_id=raw_organisme.external_id,
+            referentiel=raw_organisme.referentiel,
+            millesime=raw_organisme.millesime,
         )
+
+    def _map_localisation(
+        self, data: dict[str, Any], external_id: str
+    ) -> Optional[Localisation]:
+        localisation = None
+        try:
+            adresses = data.get("adresse") or []
+            if adresses:
+                adresse = adresses[0]
+                cog_commune = adresse.get("cogCommune")
+                department = (
+                    Department.from_commune_code(cog_commune) if cog_commune else None
+                )
+                if department is not None:
+                    latitude, longitude = self._extract_coordinates(adresse)
+                    localisation = Localisation.from_department(
+                        department, latitude=latitude, longitude=longitude
+                    )
+        except ValidationError:
+            logger.warning(
+                "RawOrganisme %s has validation errors in localisation", external_id
+            )
+        return localisation
+
+    def _map_localisation_gipcdg(
+        self, data: dict[str, Any], external_id: str
+    ) -> Optional[Localisation]:
+        localisation = None
+        cod_dep_col = data.get("cod_dep_col")
+        if cod_dep_col:
+            try:
+                department = Department.from_department_code(cod_dep_col)
+                if department is not None:
+                    localisation = Localisation.from_department(department)
+            except (ValidationError, ValueError):
+                logger.warning(
+                    "RawOrganisme %s has validation errors in localisation",
+                    external_id,
+                )
+        return localisation
 
     def _extract_coordinates(
         self, adresse: dict[str, Any]

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -158,7 +158,7 @@ class OrganismesCleaner:
                     localisation = Localisation.from_department(
                         department, latitude=latitude, longitude=longitude
                     )
-        except ValidationError:
+        except (ValidationError, ValueError):
             logger.warning(
                 "RawOrganisme %s has validation errors in localisation", external_id
             )

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -19,6 +19,8 @@ _DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
 _CATEGORIES_CSV = _DATA_DIR / "categories_entite_geographique_exercice.csv"
 
 FINESS_REFERENTIEL = "FINESS"
+GIPCDG_REFERENTIEL = "GIPCDG"
+DOM_TOM_DEPARTMENT_CODE_MIN = 971
 
 
 def _load_allowed_categories(csv_path: Path) -> set[str]:
@@ -32,9 +34,11 @@ class OrganismesCleaner:
         self._allowed_categories = _load_allowed_categories(categories_csv_path)
 
     def clean(self, raw_organisme: RawOrganisme) -> Optional[Organisme]:
-        if raw_organisme.referentiel != FINESS_REFERENTIEL:
-            return None
-        return self._clean_finess(raw_organisme)
+        if raw_organisme.referentiel == FINESS_REFERENTIEL:
+            return self._clean_finess(raw_organisme)
+        if raw_organisme.referentiel == GIPCDG_REFERENTIEL:
+            return self._clean_gipcdg(raw_organisme)
+        return None
 
     def _clean_finess(self, raw_organisme: RawOrganisme) -> Optional[Organisme]:
         if not raw_organisme.data:
@@ -54,7 +58,7 @@ class OrganismesCleaner:
             )
             return None
 
-        siret = self._map_siret(infos, raw_organisme.external_id)
+        siret = self._map_siret(infos.get("siret"), raw_organisme.external_id)
         if siret is None:
             return None
 
@@ -72,12 +76,46 @@ class OrganismesCleaner:
             millesime=raw_organisme.millesime,
         )
 
+    def _clean_gipcdg(self, raw_organisme: RawOrganisme) -> Optional[Organisme]:
+        if not raw_organisme.data:
+            return None
+
+        data = raw_organisme.data
+
+        nom = self._map_nom_gipcdg(data)
+        if not nom:
+            logger.warning(
+                "RawOrganisme %s has no nom, skipping", raw_organisme.external_id
+            )
+            return None
+
+        siret = self._map_siret(data.get("siret_col"), raw_organisme.external_id)
+        if siret is None:
+            return None
+
+        localisation = self._map_localisation_gipcdg(data)
+
+        return Organisme.build(
+            entity_id=uuid4(),
+            nom=nom,
+            versant=Verse.FPT,
+            siret=siret,
+            localisation=localisation,
+            parent_id=None,
+            external_id=raw_organisme.external_id,
+            referentiel=raw_organisme.referentiel,
+            millesime=raw_organisme.millesime,
+        )
+
     def _map_nom(self, infos: dict[str, Any]) -> Optional[str]:
         nom = infos.get("nomEgeLong") or infos.get("nomEgeCourt")
         return nom.strip() if nom else None
 
-    def _map_siret(self, infos: dict[str, Any], external_id: str) -> Optional[SIRET]:
-        siret_str = infos.get("siret")
+    def _map_nom_gipcdg(self, data: dict[str, Any]) -> Optional[str]:
+        nom = data.get("libl_col") or data.get("libc_col")
+        return nom.strip() if nom else None
+
+    def _map_siret(self, siret_str: Optional[str], external_id: str) -> Optional[SIRET]:
         if not siret_str:
             logger.warning("RawOrganisme %s has no siret, skipping", external_id)
             return None
@@ -106,6 +144,35 @@ class OrganismesCleaner:
         return Localisation.from_department(
             department, latitude=latitude, longitude=longitude
         )
+
+    def _map_localisation_gipcdg(self, data: dict[str, Any]) -> Optional[Localisation]:
+        cod_dep_col = data.get("cod_dep_col")
+        if not cod_dep_col:
+            return None
+
+        department = self._department_from_cod_dep(cod_dep_col)
+        if department is None:
+            return None
+
+        return Localisation.from_department(department)
+
+    def _department_from_cod_dep(self, cod_dep_col: str) -> Optional[Department]:
+        stripped = cod_dep_col.strip().lstrip("0")
+        if not stripped:
+            return None
+        try:
+            numero = int(stripped)
+        except ValueError:
+            return None
+        code = (
+            f"{numero:03d}"
+            if numero >= DOM_TOM_DEPARTMENT_CODE_MIN
+            else f"{numero:02d}"
+        )
+        try:
+            return Department(code=code)
+        except ValidationError:
+            return None
 
     def _extract_coordinates(
         self, adresse: dict[str, Any]

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
@@ -23,6 +24,15 @@ _CATEGORIES_CSV = _DATA_DIR / "categories_entite_geographique_exercice.csv"
 
 _MAX_LONGITUDE_DEGREES = 180
 _MAX_LATITUDE_DEGREES = 90
+
+
+def _parse_date(value: Any) -> Optional[date]:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(str(value), "%d/%m/%Y").date()
+    except ValueError:
+        return None
 
 
 def _load_allowed_categories(csv_path: Path) -> set[str]:
@@ -128,6 +138,7 @@ class OrganismesCleaner:
             external_id=raw_organisme.external_id,
             referentiel=raw_organisme.referentiel,
             millesime=raw_organisme.millesime,
+            date_creation=_parse_date(data.get("date_insert_col")),
         )
 
     def _map_localisation(

--- a/src/ingestion/tests/unit/test_gipcdg_organisme_gateway.py
+++ b/src/ingestion/tests/unit/test_gipcdg_organisme_gateway.py
@@ -1,0 +1,120 @@
+from datetime import date
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from domain.value_objects.organisme import OrganismeImportResource
+from infrastructure.exceptions.exceptions import ExternalApiError
+from infrastructure.external_gateways.gipcdg_organisme_gateway import (
+    GipcdgOrganismeGateway,
+)
+
+COLLECTIVITES_API_URL = (
+    "https://emploi-territorial.fr/api/cdg/collectivites?etab=5&limit=1000"
+)
+
+
+@pytest.fixture
+def gateway() -> GipcdgOrganismeGateway:
+    return GipcdgOrganismeGateway(
+        api_key="secret-token", collectivites_api_url=COLLECTIVITES_API_URL
+    )
+
+
+def _collectivite(id_col: int, **extra) -> dict:
+    return {"id_col": id_col, **extra}
+
+
+class TestFindResource:
+    def test_returns_fixed_url_and_today_millesime(
+        self, gateway: GipcdgOrganismeGateway
+    ):
+        resource = gateway.find_resource()
+
+        assert resource.url == COLLECTIVITES_API_URL
+        assert resource.millesime == date.today()
+
+
+class TestStreamOrganismes:
+    def test_sends_api_key_header(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 200, "success": [_collectivite(1)]},
+            match_headers={"X-API-Key": "secret-token"},
+        )
+
+        list(gateway.stream_organismes(_resource()))
+
+    def test_yields_one_organisme_per_collectivite(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={
+                "status": 200,
+                "success": [_collectivite(1), _collectivite(2)],
+            },
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert [r.external_id for r in results] == ["1", "2"]
+        assert all(r.referentiel == "GIPCDG" for r in results)
+
+    def test_skips_entries_without_id(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 200, "success": [{"libc_col": "no id"}, _collectivite(1)]},
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert [r.external_id for r in results] == ["1"]
+
+    def test_data_contains_raw_payload(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 200, "success": [_collectivite(1, libl_col="Mairie")]},
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert results[0].data["libl_col"] == "Mairie"
+
+    def test_raises_when_status_is_not_200(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 401, "status_message": "Invalid API Key"},
+        )
+
+        with pytest.raises(ExternalApiError, match="Réponse invalide"):
+            list(gateway.stream_organismes(_resource()))
+
+    def test_raises_on_http_error(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET", url=COLLECTIVITES_API_URL, status_code=500
+        )
+
+        with pytest.raises(ExternalApiError, match="Erreur lors de la récupération"):
+            list(gateway.stream_organismes(_resource()))
+
+
+def _resource() -> OrganismeImportResource:
+    return OrganismeImportResource(
+        url=COLLECTIVITES_API_URL, millesime=date(2026, 8, 20)
+    )

--- a/src/ingestion/tests/unit/test_gipcdg_organisme_gateway.py
+++ b/src/ingestion/tests/unit/test_gipcdg_organisme_gateway.py
@@ -9,9 +9,7 @@ from infrastructure.external_gateways.gipcdg_organisme_gateway import (
     GipcdgOrganismeGateway,
 )
 
-COLLECTIVITES_API_URL = (
-    "https://emploi-territorial.fr/api/cdg/collectivites?etab=5&limit=1000"
-)
+COLLECTIVITES_API_URL = "https://emploi-territorial.fr/api/cdg/collectivites?limit=1000"
 
 
 @pytest.fixture
@@ -21,8 +19,8 @@ def gateway() -> GipcdgOrganismeGateway:
     )
 
 
-def _collectivite(id_col: int, **extra) -> dict:
-    return {"id_col": id_col, **extra}
+def _collectivite(id_col: int, rank: int, total: int, **extra) -> dict:
+    return {"id_col": id_col, "_rank": rank, "_total": total, **extra}
 
 
 class TestFindResource:
@@ -41,8 +39,8 @@ class TestStreamOrganismes:
     ):
         httpx_mock.add_response(
             method="GET",
-            url=COLLECTIVITES_API_URL,
-            json={"status": 200, "success": [_collectivite(1)]},
+            url=f"{COLLECTIVITES_API_URL}&offset=0",
+            json={"status": 200, "success": [_collectivite(1, 1, 1)]},
             match_headers={"X-API-Key": "secret-token"},
         )
 
@@ -53,10 +51,10 @@ class TestStreamOrganismes:
     ):
         httpx_mock.add_response(
             method="GET",
-            url=COLLECTIVITES_API_URL,
+            url=f"{COLLECTIVITES_API_URL}&offset=0",
             json={
                 "status": 200,
-                "success": [_collectivite(1), _collectivite(2)],
+                "success": [_collectivite(1, 1, 2), _collectivite(2, 2, 2)],
             },
         )
 
@@ -70,8 +68,11 @@ class TestStreamOrganismes:
     ):
         httpx_mock.add_response(
             method="GET",
-            url=COLLECTIVITES_API_URL,
-            json={"status": 200, "success": [{"libc_col": "no id"}, _collectivite(1)]},
+            url=f"{COLLECTIVITES_API_URL}&offset=0",
+            json={
+                "status": 200,
+                "success": [{"_rank": 1, "_total": 2}, _collectivite(1, 2, 2)],
+            },
         )
 
         results = list(gateway.stream_organismes(_resource()))
@@ -83,20 +84,57 @@ class TestStreamOrganismes:
     ):
         httpx_mock.add_response(
             method="GET",
-            url=COLLECTIVITES_API_URL,
-            json={"status": 200, "success": [_collectivite(1, libl_col="Mairie")]},
+            url=f"{COLLECTIVITES_API_URL}&offset=0",
+            json={
+                "status": 200,
+                "success": [_collectivite(1, 1, 1, libl_col="Mairie")],
+            },
         )
 
         results = list(gateway.stream_organismes(_resource()))
 
         assert results[0].data["libl_col"] == "Mairie"
 
+    def test_fetches_next_page_using_offset_until_rank_reaches_total(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{COLLECTIVITES_API_URL}&offset=0",
+            json={
+                "status": 200,
+                "success": [_collectivite(1, 1, 3), _collectivite(2, 2, 3)],
+            },
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{COLLECTIVITES_API_URL}&offset=2",
+            json={"status": 200, "success": [_collectivite(3, 3, 3)]},
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert [r.external_id for r in results] == ["1", "2", "3"]
+
+    def test_stops_when_page_is_empty(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{COLLECTIVITES_API_URL}&offset=0",
+            json={"status": 200, "success": []},
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert results == []
+
     def test_raises_when_status_is_not_200(
         self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
     ):
         httpx_mock.add_response(
             method="GET",
-            url=COLLECTIVITES_API_URL,
+            url=f"{COLLECTIVITES_API_URL}&offset=0",
             json={"status": 401, "status_message": "Invalid API Key"},
         )
 
@@ -107,7 +145,7 @@ class TestStreamOrganismes:
         self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
     ):
         httpx_mock.add_response(
-            method="GET", url=COLLECTIVITES_API_URL, status_code=500
+            method="GET", url=f"{COLLECTIVITES_API_URL}&offset=0", status_code=500
         )
 
         with pytest.raises(ExternalApiError, match="Erreur lors de la récupération"):

--- a/src/ingestion/tests/unit/test_gipcdg_organisme_gateway.py
+++ b/src/ingestion/tests/unit/test_gipcdg_organisme_gateway.py
@@ -1,0 +1,115 @@
+from datetime import date
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from domain.value_objects.organisme import OrganismeImportResource
+from infrastructure.exceptions.exceptions import ExternalApiError
+from infrastructure.external_gateways.gipcdg_organisme_gateway import (
+    COLLECTIVITES_API_URL,
+    GipcdgOrganismeGateway,
+)
+
+
+@pytest.fixture
+def gateway() -> GipcdgOrganismeGateway:
+    return GipcdgOrganismeGateway(api_key="secret-token")
+
+
+def _collectivite(id_col: int, **extra) -> dict:
+    return {"id_col": id_col, **extra}
+
+
+class TestFindResource:
+    def test_returns_fixed_url_and_today_millesime(
+        self, gateway: GipcdgOrganismeGateway
+    ):
+        resource = gateway.find_resource()
+
+        assert resource.url == COLLECTIVITES_API_URL
+        assert resource.millesime == date.today()
+
+
+class TestStreamOrganismes:
+    def test_sends_api_key_header(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 200, "success": [_collectivite(1)]},
+            match_headers={"X-API-Key": "secret-token"},
+        )
+
+        list(gateway.stream_organismes(_resource()))
+
+    def test_yields_one_organisme_per_collectivite(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={
+                "status": 200,
+                "success": [_collectivite(1), _collectivite(2)],
+            },
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert [r.external_id for r in results] == ["1", "2"]
+        assert all(r.referentiel == "GIPCDG" for r in results)
+
+    def test_skips_entries_without_id(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 200, "success": [{"libc_col": "no id"}, _collectivite(1)]},
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert [r.external_id for r in results] == ["1"]
+
+    def test_data_contains_raw_payload(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 200, "success": [_collectivite(1, libl_col="Mairie")]},
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert results[0].data["libl_col"] == "Mairie"
+
+    def test_raises_when_status_is_not_200(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url=COLLECTIVITES_API_URL,
+            json={"status": 401, "status_message": "Invalid API Key"},
+        )
+
+        with pytest.raises(ExternalApiError, match="Réponse invalide"):
+            list(gateway.stream_organismes(_resource()))
+
+    def test_raises_on_http_error(
+        self, gateway: GipcdgOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET", url=COLLECTIVITES_API_URL, status_code=500
+        )
+
+        with pytest.raises(ExternalApiError, match="Erreur lors de la récupération"):
+            list(gateway.stream_organismes(_resource()))
+
+
+def _resource() -> OrganismeImportResource:
+    return OrganismeImportResource(
+        url=COLLECTIVITES_API_URL, millesime=date(2026, 8, 20)
+    )

--- a/src/ingestion/tests/unit/test_organismes_cleaner.py
+++ b/src/ingestion/tests/unit/test_organismes_cleaner.py
@@ -240,6 +240,7 @@ def _collectivite(
     siret_col: str | None = "24050043900080",
     cod_dep_col: str | None = "005",
     date_insert_col: str | None = "10/06/2014",
+    is_attached: bool = False,
 ) -> dict:
     return {
         "id_col": 10631,
@@ -248,14 +249,17 @@ def _collectivite(
         "siret_col": siret_col,
         "cod_dep_col": cod_dep_col,
         "date_insert_col": date_insert_col,
+        "is_attached": is_attached,
     }
 
 
-def _raw_organisme_gipcdg(data: dict | None) -> RawOrganisme:
+def _raw_organisme_gipcdg(
+    data: dict | None, external_id: str = "10631"
+) -> RawOrganisme:
     return RawOrganisme(
         referentiel="GIPCDG",
         millesime="2026-08-20",
-        external_id="10631",
+        external_id=external_id,
         data=data,
     )
 
@@ -314,6 +318,14 @@ def test_gipcdg_returns_none_when_no_data(cleaner: OrganismesCleaner):
     assert cleaner.clean(raw_organisme) is None
 
 
+def test_gipcdg_returns_none_when_attached_to_another_collectivite(
+    cleaner: OrganismesCleaner,
+):
+    raw_organisme = _raw_organisme_gipcdg(_collectivite(is_attached=True))
+
+    assert cleaner.clean(raw_organisme) is None
+
+
 @pytest.mark.parametrize(
     "data",
     [
@@ -343,3 +355,43 @@ def test_gipcdg_localisation_is_none(
 
     assert organisme is not None
     assert organisme.localisation is None
+
+
+def test_dedupe_by_siret_keeps_most_recently_created(cleaner: OrganismesCleaner):
+    older = cleaner.clean(
+        _raw_organisme_gipcdg(
+            _collectivite(date_insert_col="25/10/2010"), external_id="26529"
+        )
+    )
+    newer = cleaner.clean(
+        _raw_organisme_gipcdg(
+            _collectivite(date_insert_col="12/11/2021"), external_id="99819"
+        )
+    )
+    assert older is not None
+    assert newer is not None
+
+    result = cleaner.dedupe_by_siret([older, newer])
+
+    assert result == [newer]
+
+
+def test_dedupe_by_siret_falls_back_to_smallest_external_id_when_same_date(
+    cleaner: OrganismesCleaner,
+):
+    smaller = cleaner.clean(
+        _raw_organisme_gipcdg(
+            _collectivite(date_insert_col="12/11/2021"), external_id="99819"
+        )
+    )
+    bigger = cleaner.clean(
+        _raw_organisme_gipcdg(
+            _collectivite(date_insert_col="12/11/2021"), external_id="99945"
+        )
+    )
+    assert smaller is not None
+    assert bigger is not None
+
+    result = cleaner.dedupe_by_siret([bigger, smaller])
+
+    assert result == [smaller]

--- a/src/ingestion/tests/unit/test_organismes_cleaner.py
+++ b/src/ingestion/tests/unit/test_organismes_cleaner.py
@@ -2,6 +2,7 @@ import csv
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 from referentiel.value_objects.siret import SIRET
 from referentiel.value_objects.verse import Verse
 
@@ -127,22 +128,19 @@ def test_returns_none_when_no_data(cleaner: OrganismesCleaner):
     assert cleaner.clean(raw_organisme) is None
 
 
-def test_returns_none_when_missing_siret(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(siret=None))
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(_ege(siret=None), id="missing_siret"),
+        pytest.param(_ege(siret="not-a-siret"), id="invalid_siret"),
+        pytest.param(_ege(nom=""), id="missing_nom"),
+    ],
+)
+def test_finess_raises_on_invalid_data(cleaner: OrganismesCleaner, data: dict):
+    raw_organisme = _raw_organisme(data)
 
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_returns_none_when_invalid_siret(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(siret="not-a-siret"))
-
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_returns_none_when_missing_nom(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(nom=""))
-
-    assert cleaner.clean(raw_organisme) is None
+    with pytest.raises(ValidationError):
+        cleaner.clean(raw_organisme)
 
 
 def test_localisation_is_none_when_no_address(cleaner: OrganismesCleaner):
@@ -232,3 +230,94 @@ def test_dedupe_by_siret_keeps_distinct_sirets(cleaner: OrganismesCleaner):
     result = cleaner.dedupe_by_siret([first, second])
 
     assert {o.external_id for o in result} == {"123456789", "987654321"}
+
+
+def _collectivite(
+    *,
+    libl_col: str | None = "COMMUNAUTE DE COMMUNES BRIANCONNAIS",
+    libc_col: str | None = "CC BRIANCONNAIS",
+    siret_col: str | None = "24050043900080",
+    cod_dep_col: str | None = "005",
+) -> dict:
+    return {
+        "id_col": 10631,
+        "libl_col": libl_col,
+        "libc_col": libc_col,
+        "siret_col": siret_col,
+        "cod_dep_col": cod_dep_col,
+    }
+
+
+def _raw_organisme_gipcdg(data: dict | None) -> RawOrganisme:
+    return RawOrganisme(
+        referentiel="GIPCDG",
+        millesime="2026-08-20",
+        external_id="10631",
+        data=data,
+    )
+
+
+def test_cleans_valid_gipcdg_raw_organisme(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_gipcdg(_collectivite())
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.nom == "COMMUNAUTE DE COMMUNES BRIANCONNAIS"
+    assert organisme.versant == Verse.FPT
+    assert organisme.siret == SIRET(code="24050043900080")
+    assert organisme.external_id == "10631"
+    assert organisme.referentiel == "GIPCDG"
+    assert organisme.millesime == "2026-08-20"
+    assert organisme.parent_id is None
+    assert organisme.localisation is not None
+    assert organisme.localisation.department.code == "05"
+    assert organisme.localisation.region.code == "93"
+    assert organisme.localisation.latitude is None
+    assert organisme.localisation.longitude is None
+
+
+def test_gipcdg_falls_back_to_libc_col_when_no_libl_col(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_gipcdg(_collectivite(libl_col=None))
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.nom == "CC BRIANCONNAIS"
+
+
+def test_gipcdg_returns_none_when_no_data(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_gipcdg(None)
+
+    assert cleaner.clean(raw_organisme) is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(_collectivite(siret_col=None), id="missing_siret"),
+        pytest.param(_collectivite(siret_col="not-a-siret"), id="invalid_siret"),
+        pytest.param(_collectivite(libl_col=None, libc_col=""), id="missing_nom"),
+    ],
+)
+def test_gipcdg_raises_on_invalid_data(cleaner: OrganismesCleaner, data: dict | None):
+    raw_organisme = _raw_organisme_gipcdg(data)
+
+    with pytest.raises(ValidationError):
+        cleaner.clean(raw_organisme)
+
+
+@pytest.mark.parametrize(
+    "cod_dep_col",
+    [None, "999", "000", "ZZZ"],
+    ids=["missing", "unknown_department", "all_zeros", "invalid_code"],
+)
+def test_gipcdg_localisation_is_none(
+    cleaner: OrganismesCleaner, cod_dep_col: str | None
+):
+    raw_organisme = _raw_organisme_gipcdg(_collectivite(cod_dep_col=cod_dep_col))
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.localisation is None

--- a/src/ingestion/tests/unit/test_organismes_cleaner.py
+++ b/src/ingestion/tests/unit/test_organismes_cleaner.py
@@ -1,4 +1,5 @@
 import csv
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -238,6 +239,7 @@ def _collectivite(
     libc_col: str | None = "CC BRIANCONNAIS",
     siret_col: str | None = "24050043900080",
     cod_dep_col: str | None = "005",
+    date_insert_col: str | None = "10/06/2014",
 ) -> dict:
     return {
         "id_col": 10631,
@@ -245,6 +247,7 @@ def _collectivite(
         "libc_col": libc_col,
         "siret_col": siret_col,
         "cod_dep_col": cod_dep_col,
+        "date_insert_col": date_insert_col,
     }
 
 
@@ -275,6 +278,25 @@ def test_cleans_valid_gipcdg_raw_organisme(cleaner: OrganismesCleaner):
     assert organisme.localisation.region.code == "93"
     assert organisme.localisation.latitude is None
     assert organisme.localisation.longitude is None
+    assert organisme.date_creation == date(2014, 6, 10)
+
+
+@pytest.mark.parametrize(
+    "date_insert_col",
+    [None, "", "2014-06-10", "31/06/2014"],
+    ids=["missing", "empty", "iso_format", "invalid_date"],
+)
+def test_gipcdg_date_creation_is_none_when_unparseable(
+    cleaner: OrganismesCleaner, date_insert_col: str | None
+):
+    raw_organisme = _raw_organisme_gipcdg(
+        _collectivite(date_insert_col=date_insert_col)
+    )
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.date_creation is None
 
 
 def test_gipcdg_falls_back_to_libc_col_when_no_libl_col(cleaner: OrganismesCleaner):

--- a/src/ingestion/tests/unit/test_organismes_cleaner.py
+++ b/src/ingestion/tests/unit/test_organismes_cleaner.py
@@ -40,9 +40,9 @@ def _ege(
     }
 
 
-def _raw_organisme(data: dict) -> RawOrganisme:
+def _raw_organisme(data: dict | None, referentiel: str = "FINESS") -> RawOrganisme:
     return RawOrganisme(
-        referentiel="FINESS",
+        referentiel=referentiel,
         millesime="2026-08-19",
         external_id="060786738",
         data=data,
@@ -84,71 +84,34 @@ def test_cleans_valid_raw_organisme(cleaner: OrganismesCleaner):
     assert organisme.localisation.longitude == 7.254944
 
 
-def test_filters_out_non_finess_referentiel(cleaner: OrganismesCleaner):
-    raw_organisme = RawOrganisme(
-        referentiel="OTHER_REF",
-        millesime="2026-08-19",
-        external_id="1",
-        data=_ege(),
-    )
-
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_filters_out_disallowed_categorie(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(categorie="999"))
-
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_returns_none_when_no_data(cleaner: OrganismesCleaner):
-    raw_organisme = RawOrganisme(
-        referentiel="FINESS", millesime="2026-08-19", external_id="1", data=None
-    )
-
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_returns_none_when_missing_siret(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(siret=None))
-
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_returns_none_when_invalid_siret(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(siret="not-a-siret"))
-
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_returns_none_when_missing_nom(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(nom=""))
-
-    assert cleaner.clean(raw_organisme) is None
-
-
-def test_localisation_is_none_when_no_address(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(cog_commune=None))
-
-    organisme = cleaner.clean(raw_organisme)
-
-    assert organisme is not None
-    assert organisme.localisation is None
-
-
-def test_localisation_is_none_when_address_has_no_cog_commune(
-    cleaner: OrganismesCleaner,
+@pytest.mark.parametrize(
+    "referentiel,data",
+    [
+        pytest.param("OTHER_REF", _ege(), id="non_finess_referentiel"),
+        pytest.param("FINESS", _ege(categorie="999"), id="disallowed_categorie"),
+        pytest.param("FINESS", None, id="no_data"),
+        pytest.param("FINESS", _ege(siret=None), id="missing_siret"),
+        pytest.param("FINESS", _ege(siret="not-a-siret"), id="invalid_siret"),
+        pytest.param("FINESS", _ege(nom=""), id="missing_nom"),
+    ],
+)
+def test_finess_returns_none(
+    cleaner: OrganismesCleaner, referentiel: str, data: dict | None
 ):
-    raw_organisme = _raw_organisme(_ege(cog_commune=""))
+    raw_organisme = _raw_organisme(data, referentiel=referentiel)
 
-    organisme = cleaner.clean(raw_organisme)
-
-    assert organisme is not None
-    assert organisme.localisation is None
+    assert cleaner.clean(raw_organisme) is None
 
 
-def test_localisation_is_none_when_invalid_commune_code(cleaner: OrganismesCleaner):
-    raw_organisme = _raw_organisme(_ege(cog_commune="00042"))
+@pytest.mark.parametrize(
+    "cog_commune",
+    [None, "", "00042"],
+    ids=["no_address", "empty_cog_commune", "invalid_commune_code"],
+)
+def test_finess_localisation_is_none(
+    cleaner: OrganismesCleaner, cog_commune: str | None
+):
+    raw_organisme = _raw_organisme(_ege(cog_commune=cog_commune))
 
     organisme = cleaner.clean(raw_organisme)
 
@@ -165,3 +128,88 @@ def test_coordinates_are_none_when_missing(cleaner: OrganismesCleaner):
     assert organisme.localisation is not None
     assert organisme.localisation.latitude is None
     assert organisme.localisation.longitude is None
+
+
+def _collectivite(
+    *,
+    libl_col: str | None = "COMMUNAUTE DE COMMUNES BRIANCONNAIS",
+    libc_col: str | None = "CC BRIANCONNAIS",
+    siret_col: str | None = "24050043900080",
+    cod_dep_col: str | None = "005",
+) -> dict:
+    return {
+        "id_col": 10631,
+        "libl_col": libl_col,
+        "libc_col": libc_col,
+        "siret_col": siret_col,
+        "cod_dep_col": cod_dep_col,
+    }
+
+
+def _raw_organisme_gipcdg(data: dict | None) -> RawOrganisme:
+    return RawOrganisme(
+        referentiel="GIPCDG",
+        millesime="2026-08-20",
+        external_id="10631",
+        data=data,
+    )
+
+
+def test_cleans_valid_gipcdg_raw_organisme(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_gipcdg(_collectivite())
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.nom == "COMMUNAUTE DE COMMUNES BRIANCONNAIS"
+    assert organisme.versant == Verse.FPT
+    assert organisme.siret == SIRET(code="24050043900080")
+    assert organisme.external_id == "10631"
+    assert organisme.referentiel == "GIPCDG"
+    assert organisme.millesime == "2026-08-20"
+    assert organisme.parent_id is None
+    assert organisme.localisation is not None
+    assert organisme.localisation.department.code == "05"
+    assert organisme.localisation.region.code == "93"
+    assert organisme.localisation.latitude is None
+    assert organisme.localisation.longitude is None
+
+
+def test_gipcdg_falls_back_to_libc_col_when_no_libl_col(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_gipcdg(_collectivite(libl_col=None))
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.nom == "CC BRIANCONNAIS"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(None, id="no_data"),
+        pytest.param(_collectivite(siret_col=None), id="missing_siret"),
+        pytest.param(_collectivite(siret_col="not-a-siret"), id="invalid_siret"),
+        pytest.param(_collectivite(libl_col=None, libc_col=""), id="missing_nom"),
+    ],
+)
+def test_gipcdg_returns_none(cleaner: OrganismesCleaner, data: dict | None):
+    raw_organisme = _raw_organisme_gipcdg(data)
+
+    assert cleaner.clean(raw_organisme) is None
+
+
+@pytest.mark.parametrize(
+    "cod_dep_col",
+    [None, "999", "000", "02A"],
+    ids=["missing", "unknown_department", "all_zeros", "not_numeric"],
+)
+def test_gipcdg_localisation_is_none(
+    cleaner: OrganismesCleaner, cod_dep_col: str | None
+):
+    raw_organisme = _raw_organisme_gipcdg(_collectivite(cod_dep_col=cod_dep_col))
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.localisation is None

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1457,7 +1457,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1457,7 +1457,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1457,7 +1457,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.4"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1369,7 +1369,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.4"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1369,7 +1369,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1369,7 +1369,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },


### PR DESCRIPTION
## 📝 Description

Ajoute l'import des collectivités territoriales depuis le référentiel GIPCDG (`emploi-territorial.fr`), en complément de FINESS.

### Contenu

- **Nouveau gateway GIPCDG** : récupération paginée des collectivités (par lots de 1000, via `offset`/`_rank`/`_total`), authentification par clé API.
- **Nettoyage des données GIPCDG** : mapping nom/SIRET/localisation/date de création, avec levée d'erreurs de validation (plutôt qu'un échec silencieux) sur les
champs obligatoires.
- **Déduplication par SIRET** : filtre les secteurs internes rattachés à une collectivité mère (`is_attached`/`col_mere_id`, même SIRET) et, en cas de doublon
persistant, conserve la fiche la plus récemment créée.
- **Pipeline d'import unifié** (`organismes_pipeline.py`) : importe, nettoie et publie désormais FINESS *et* GIPCDG dans une même exécution.
- **Bug fix référentiel** : corrige `Department.from_commune_code`, qui levait un `TypeError` non catchable au lieu d'un `ValueError`/`ValidationError`, faisant
planter le nettoyage d'organismes sur des codes commune invalides.
- Bump de version du package `referentiel` (0.2.3 → 0.2.4) et synchronisation des lockfiles (`web`, `ingestion`).

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)

- `bin/import_organismes.py` : flag `--referentiel FINESS|GIPCDG`

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
