### PR TITLE
✨(ats-presentation) add organisme creation from the admin list

### DIFF
--- a/src/web/presentation/frontend/src/features/organismes/api.ts
+++ b/src/web/presentation/frontend/src/features/organismes/api.ts
@@ -1,7 +1,12 @@
-import type { OrganismesList } from './types'
+import type { CreateOrganismePayload, OrganismeDetail, OrganismesList } from './types'
 import { api } from '@/api/client'
 
 export async function getOrganismesList(): Promise<OrganismesList[]> {
   const { data } = await api.GET('/recruteur/organismes')
+  return data!
+}
+
+export async function createOrganisme(payload: CreateOrganismePayload): Promise<OrganismeDetail> {
+  const { data } = await api.POST('/recruteur/organismes', { body: payload })
   return data!
 }

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.test.ts
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.test.ts
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import OrganismeFormDrawer from './OrganismeFormDrawer.vue'
+
+function mountDrawer() {
+  return mount(OrganismeFormDrawer, {
+    props: {
+      open: true,
+    },
+    attachTo: document.body,
+  })
+}
+
+function submitButton() {
+  return document.querySelector<HTMLButtonElement>('button[type="submit"]')!
+}
+
+async function fill(selector: string, value: string) {
+  const input = document.querySelector<HTMLInputElement>(selector)!
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+  await nextTick()
+}
+
+async function pickVersant(value: string) {
+  const radio = document.querySelector<HTMLElement>(`button[value="${value}"], [role="radio"][value="${value}"]`)
+  radio?.click()
+  await nextTick()
+}
+
+describe('organismeFormDrawer', () => {
+  it('keeps the submit button disabled until required fields are filled', async () => {
+    const wrapper = mountDrawer()
+    await nextTick()
+    expect(submitButton().disabled).toBe(true)
+
+    await fill('input[name="nom"]', 'Nouvel organisme')
+    await fill('input[name="siret"]', '12345678901234')
+    expect(submitButton().disabled).toBe(true)
+
+    await pickVersant('FPE')
+    expect(submitButton().disabled).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('keeps submit disabled for a malformed siret without showing an error', async () => {
+    const wrapper = mountDrawer()
+    await nextTick()
+    await fill('input[name="nom"]', 'Nouvel organisme')
+    await fill('input[name="siret"]', '123')
+    await pickVersant('FPE')
+    expect(submitButton().disabled).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('emits the payload on submit', async () => {
+    const wrapper = mountDrawer()
+    await nextTick()
+    await fill('input[name="nom"]', 'Nouvel organisme')
+    await fill('input[name="siret"]', '12345678901234')
+    await pickVersant('FPT')
+    submitButton().click()
+    await nextTick()
+
+    const emitted = wrapper.emitted('submit')
+    expect(emitted).toHaveLength(1)
+    expect(emitted![0][0]).toEqual({
+      nom: 'Nouvel organisme',
+      siret: '12345678901234',
+      versant: 'FPT',
+      gestion_ats: true,
+    })
+    wrapper.unmount()
+  })
+
+  it('surfaces a siret conflict on the siret field', async () => {
+    const wrapper = mountDrawer()
+    await nextTick()
+    wrapper.vm.setSiretError('Ce SIRET est déjà utilisé par un autre organisme')
+    await nextTick()
+    expect(document.body.textContent).toContain('Ce SIRET est déjà utilisé')
+    wrapper.unmount()
+  })
+})

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.test.ts
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.test.ts
@@ -58,7 +58,7 @@ describe('organismeFormDrawer', () => {
     const wrapper = mountDrawer()
     await nextTick()
     await fill('input[name="nom"]', 'Nouvel organisme')
-    await fill('input[name="siret"]', '12345678901234')
+    await fill('input[name="siret"]', '11004601800021')
     await pickVersant('FPT')
     submitButton().click()
     await nextTick()
@@ -67,10 +67,26 @@ describe('organismeFormDrawer', () => {
     expect(emitted).toHaveLength(1)
     expect(emitted![0][0]).toEqual({
       nom: 'Nouvel organisme',
-      siret: '12345678901234',
+      siret: '11004601800021',
       versant: 'FPT',
       gestion_ats: true,
     })
+    wrapper.unmount()
+  })
+
+  it('rejects an invalid checksum on submit without emitting', async () => {
+    const wrapper = mountDrawer()
+    await nextTick()
+    await fill('input[name="nom"]', 'Nouvel organisme')
+    await fill('input[name="siret"]', '12345671234567')
+    await pickVersant('FPT')
+    submitButton().click()
+    await nextTick()
+
+    expect(wrapper.emitted('submit')).toBeUndefined()
+    expect(document.body.textContent).toContain(
+      'Ce SIRET n\'est pas valide, vérifiez votre saisie.',
+    )
     wrapper.unmount()
   })
 

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.test.ts
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.test.ts
@@ -36,7 +36,7 @@ describe('organismeFormDrawer', () => {
     expect(submitButton().disabled).toBe(true)
 
     await fill('input[name="nom"]', 'Nouvel organisme')
-    await fill('input[name="siret"]', '12345678901234')
+    await fill('input[name="siret"]', '123')
     expect(submitButton().disabled).toBe(true)
 
     await pickVersant('FPE')
@@ -44,13 +44,33 @@ describe('organismeFormDrawer', () => {
     wrapper.unmount()
   })
 
-  it('keeps submit disabled for a malformed siret without showing an error', async () => {
+  it('surfaces a length error on submit without emitting', async () => {
     const wrapper = mountDrawer()
     await nextTick()
     await fill('input[name="nom"]', 'Nouvel organisme')
     await fill('input[name="siret"]', '123')
     await pickVersant('FPE')
-    expect(submitButton().disabled).toBe(true)
+    submitButton().click()
+    await nextTick()
+
+    expect(wrapper.emitted('submit')).toBeUndefined()
+    expect(document.body.textContent).toContain('Le SIRET doit comporter 14 chiffres.')
+    wrapper.unmount()
+  })
+
+  it('strips non digit characters from a pasted siret', async () => {
+    const wrapper = mountDrawer()
+    await nextTick()
+    await fill('input[name="nom"]', 'Nouvel organisme')
+    await fill('input[name="siret"]', '110 046 018 00021')
+    await pickVersant('FPT')
+    await nextTick()
+    submitButton().click()
+    await nextTick()
+
+    const emitted = wrapper.emitted('submit')
+    expect(emitted).toHaveLength(1)
+    expect((emitted![0][0] as { siret: string }).siret).toBe('11004601800021')
     wrapper.unmount()
   })
 

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.vue
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import type { CreateOrganismePayload, Versant } from '../types'
+import { computed, ref, watch } from 'vue'
+import CspButton from '@/components/base/CspButton/CspButton.vue'
+import CspDrawer from '@/components/base/CspDrawer/CspDrawer.vue'
+import CspInput from '@/components/base/CspInput/CspInput.vue'
+import CspRadioGroup from '@/components/base/CspRadioGroup/CspRadioGroup.vue'
+import { SIRET_LENGTH, VERSANT_LABELS } from '../constants/organisme'
+
+const props = defineProps<{
+  saving?: boolean
+}>()
+
+const emit = defineEmits<{
+  submit: [payload: CreateOrganismePayload]
+}>()
+
+const open = defineModel<boolean>('open', { required: true })
+
+const nom = ref('')
+const siret = ref('')
+const versant = ref<string>('')
+const gestionAts = ref<'oui' | 'non'>('oui')
+const siretError = ref<string | null>(null)
+
+watch(open, (isOpen) => {
+  if (!isOpen)
+    return
+  nom.value = ''
+  siret.value = ''
+  versant.value = ''
+  gestionAts.value = 'oui'
+  siretError.value = null
+}, { immediate: true })
+
+watch(siret, () => {
+  siretError.value = null
+})
+
+const VERSANT_OPTIONS = Object.entries(VERSANT_LABELS).map(
+  ([value, label]) => ({ value, label }),
+)
+
+const GESTION_OPTIONS = [
+  { value: 'oui', label: 'Oui' },
+  { value: 'non', label: 'Non' },
+]
+
+const siretValid = computed(() =>
+  new RegExp(`^\\d{${SIRET_LENGTH}}$`).test(siret.value),
+)
+
+const canSubmit = computed(() =>
+  nom.value.trim().length > 0
+  && siretValid.value
+  && versant.value !== '',
+)
+
+function handleSubmit(): void {
+  if (!canSubmit.value || props.saving)
+    return
+  emit('submit', {
+    nom: nom.value.trim(),
+    siret: siret.value,
+    versant: versant.value as Versant,
+    gestion_ats: gestionAts.value === 'oui',
+  })
+}
+
+function setSiretError(message: string): void {
+  siretError.value = message
+}
+
+defineExpose({ setSiretError })
+</script>
+
+<template>
+  <CspDrawer
+    v-model:open="open"
+    title="Ajouter un organisme"
+    size="md"
+  >
+    <form
+      class="organisme-form"
+      @submit.prevent="handleSubmit"
+    >
+      <p class="organisme-form__section-title">
+        Détail de l'organisme
+        <span class="organisme-form__required-hint">Champs obligatoires</span>
+      </p>
+
+      <CspInput
+        v-model="nom"
+        label="Nom de l'organisme"
+        name="nom"
+      />
+
+      <CspInput
+        v-model="siret"
+        label="SIRET de l'organisme"
+        name="siret"
+        :error="Boolean(siretError)"
+        :error-message="siretError ?? undefined"
+      />
+
+      <CspRadioGroup
+        v-model="versant"
+        label="Versant"
+        name="versant"
+        :options="VERSANT_OPTIONS"
+      />
+
+      <div>
+        <CspRadioGroup
+          v-model="gestionAts"
+          label="Gestion des candidatures sur l'outil"
+          name="gestion_ats"
+          :options="GESTION_OPTIONS"
+        />
+        <p class="organisme-form__hint">
+          L'organisme reçoit ses candidatures et traite ses recrutements sur l'outil
+        </p>
+      </div>
+
+      <div class="organisme-form__actions">
+        <CspButton
+          type="submit"
+          label="Créer l'organisme"
+          icon="ri:add-line"
+          is-icon-left
+          :disabled="!canSubmit || saving"
+        />
+        <CspButton
+          variant="secondary"
+          type="button"
+          label="Annuler"
+          @click="open = false"
+        />
+      </div>
+    </form>
+  </CspDrawer>
+</template>
+
+<style scoped lang="scss">
+.organisme-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--csp-space-5);
+  height: 100%;
+}
+
+.organisme-form__section-title {
+  margin: 0;
+  font-weight: 700;
+  display: flex;
+  align-items: baseline;
+  gap: var(--csp-space-3);
+}
+
+.organisme-form__required-hint {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--text-mention-grey);
+}
+
+.organisme-form__hint {
+  margin: var(--csp-space-1) 0 0;
+  font-size: 0.75rem;
+  color: var(--text-mention-grey);
+}
+
+.organisme-form__actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--csp-space-3);
+  padding-top: var(--csp-space-4);
+  border-top: 1px solid var(--border-default-grey);
+}
+</style>

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.vue
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.vue
@@ -34,8 +34,11 @@ watch(open, (isOpen) => {
   siretError.value = null
 }, { immediate: true })
 
-watch(siret, () => {
+watch(siret, (value) => {
   siretError.value = null
+  const digits = value.replace(/\D/g, '')
+  if (digits !== value)
+    siret.value = digits
 })
 
 const VERSANT_OPTIONS = Object.entries(VERSANT_LABELS).map(
@@ -47,19 +50,19 @@ const GESTION_OPTIONS = [
   { value: 'non', label: 'Non' },
 ]
 
-const siretValid = computed(() =>
-  new RegExp(`^\\d{${SIRET_LENGTH}}$`).test(siret.value),
-)
-
 const canSubmit = computed(() =>
   nom.value.trim().length > 0
-  && siretValid.value
+  && siret.value.length > 0
   && versant.value !== '',
 )
 
 function handleSubmit(): void {
   if (!canSubmit.value || props.saving)
     return
+  if (siret.value.length !== SIRET_LENGTH) {
+    siretError.value = `Le SIRET doit comporter ${SIRET_LENGTH} chiffres.`
+    return
+  }
   if (!isSiretValid(siret.value)) {
     siretError.value = 'Ce SIRET n\'est pas valide, vérifiez votre saisie.'
     return

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.vue
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismeFormDrawer.vue
@@ -6,6 +6,7 @@ import CspDrawer from '@/components/base/CspDrawer/CspDrawer.vue'
 import CspInput from '@/components/base/CspInput/CspInput.vue'
 import CspRadioGroup from '@/components/base/CspRadioGroup/CspRadioGroup.vue'
 import { SIRET_LENGTH, VERSANT_LABELS } from '../constants/organisme'
+import { isSiretValid } from '../siret'
 
 const props = defineProps<{
   saving?: boolean
@@ -59,6 +60,10 @@ const canSubmit = computed(() =>
 function handleSubmit(): void {
   if (!canSubmit.value || props.saving)
     return
+  if (!isSiretValid(siret.value)) {
+    siretError.value = 'Ce SIRET n\'est pas valide, vérifiez votre saisie.'
+    return
+  }
   emit('submit', {
     nom: nom.value.trim(),
     siret: siret.value,

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismesSection.vue
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismesSection.vue
@@ -49,8 +49,7 @@ async function handleSubmit(payload: CreateOrganismePayload): Promise<void> {
   }
   catch (submitError) {
     if (submitError instanceof ValidationError) {
-      const data = submitError.data as { error?: string } | undefined
-      formDrawer.value?.setSiretError(data?.error ?? 'Ce SIRET ne peut pas être utilisé')
+      formDrawer.value?.setSiretError('Ce SIRET est déjà utilisé ou n\'est pas valide.')
       return
     }
     addToast({ variant: 'error', title: 'La création de l\'organisme a échoué' })

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismesSection.vue
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismesSection.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import type { CreateOrganismePayload } from '../types'
+import { computed, ref, useTemplateRef, watch } from 'vue'
+import { ValidationError } from '@/api/errors'
 import CspAsyncSection from '@/components/base/CspAsyncSection/CspAsyncSection.vue'
 import CspButton from '@/components/base/CspButton/CspButton.vue'
 import CspDataTable from '@/components/base/CspDataTable/CspDataTable.vue'
@@ -7,17 +9,22 @@ import CspInput from '@/components/base/CspInput/CspInput.vue'
 import CspSkeletonTable from '@/components/base/CspSkeleton/CspSkeletonTable.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
 import { useTextSearch } from '@/composables/data/useTextSearch'
+import { useToast } from '@/composables/ui/useToast'
 import { pluralize } from '@/utils/format'
 import { ORGANISMES_LIST_COLUMNS } from '../columns'
 import { useOrganismes } from '../composables/useOrganismes'
+import OrganismeFormDrawer from './OrganismeFormDrawer.vue'
 
 const PAGE_SIZE = 8
 
-const { organismesList, pending, error } = useOrganismes()
+const { organismesList, pending, error, create, creating } = useOrganismes()
 
 const showSkeleton = useMinimumPending(pending)
 
 const page = ref(1)
+const drawerOpen = ref(false)
+
+const formDrawer = useTemplateRef('formDrawer')
 
 const rows = computed(() => organismesList.value ?? [])
 
@@ -31,6 +38,24 @@ const countLabel = computed(() => {
   const count = filtered.value.length
   return `${count} ${pluralize(count, 'organisme')}`
 })
+
+const { addToast } = useToast()
+
+async function handleSubmit(payload: CreateOrganismePayload): Promise<void> {
+  try {
+    await create(payload)
+    addToast({ variant: 'success', title: 'Organisme créé' })
+    drawerOpen.value = false
+  }
+  catch (submitError) {
+    if (submitError instanceof ValidationError) {
+      const data = submitError.data as { error?: string } | undefined
+      formDrawer.value?.setSiretError(data?.error ?? 'Ce SIRET ne peut pas être utilisé')
+      return
+    }
+    addToast({ variant: 'error', title: 'La création de l\'organisme a échoué' })
+  }
+}
 </script>
 
 <template>
@@ -49,7 +74,7 @@ const countLabel = computed(() => {
         label="Ajouter un organisme"
         icon="ri:add-line"
         is-icon-left
-        disabled
+        @click="drawerOpen = true"
       />
     </div>
 
@@ -91,6 +116,13 @@ const countLabel = computed(() => {
         :page-size="PAGE_SIZE"
       />
     </CspAsyncSection>
+
+    <OrganismeFormDrawer
+      ref="formDrawer"
+      v-model:open="drawerOpen"
+      :saving="creating"
+      @submit="handleSubmit"
+    />
   </section>
 </template>
 

--- a/src/web/presentation/frontend/src/features/organismes/composables/useOrganismes.test.ts
+++ b/src/web/presentation/frontend/src/features/organismes/composables/useOrganismes.test.ts
@@ -1,4 +1,4 @@
-import type { OrganismesList } from '../types'
+import type { OrganismeDetail, OrganismesList } from '../types'
 import { PiniaColada } from '@pinia/colada'
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
@@ -6,10 +6,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { useOrganismes } from './useOrganismes'
 
-const mockGetOrganismes = vi.fn()
+const mockGetOrganismesList = vi.fn()
+const mockCreateOrganisme = vi.fn()
 
 vi.mock('../api', () => ({
-  getOrganismesList: (...args: unknown[]) => mockGetOrganismes(...args),
+  getOrganismesList: (...args: unknown[]) => mockGetOrganismesList(...args),
+  createOrganisme: (...args: unknown[]) => mockCreateOrganisme(...args),
 }))
 
 const ORGANISMES: OrganismesList[] = [
@@ -62,7 +64,7 @@ function mountOrganismes() {
 describe('useOrganismes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetOrganismes.mockResolvedValue(ORGANISMES)
+    mockGetOrganismesList.mockResolvedValue(ORGANISMES)
   })
 
   it('exposes the organismes list', async () => {
@@ -71,5 +73,50 @@ describe('useOrganismes', () => {
     await flush()
     expect(pending.value).toBe(false)
     expect(organismesList.value).toEqual(ORGANISMES)
+  })
+
+  it('creates an organisme and refetches the list', async () => {
+    const created: OrganismeDetail = {
+      organisme_uuid: '33333333-3333-3333-3333-333333333333',
+      nom: 'Organisme 3',
+      siret: '33333333333333',
+      gestionnaire: null,
+      gestion_ats: true,
+      date_derniere_activite: '2026-08-19T00:00:00Z',
+      date_creation: '2026-08-19T00:00:00Z',
+      versant: 'FPH',
+    }
+    mockCreateOrganisme.mockResolvedValue(created)
+    const { create } = mountOrganismes()
+    await flush()
+
+    await create({
+      nom: 'Organisme 3',
+      siret: '33333333333333',
+      versant: 'FPH',
+      gestion_ats: true,
+    })
+    await flush()
+
+    expect(mockCreateOrganisme).toHaveBeenCalledWith({
+      nom: 'Organisme 3',
+      siret: '33333333333333',
+      versant: 'FPH',
+      gestion_ats: true,
+    })
+    expect(mockGetOrganismesList).toHaveBeenCalledTimes(2)
+  })
+
+  it('propagates creation errors to the caller', async () => {
+    mockCreateOrganisme.mockRejectedValue(new Error('boom'))
+    const { create } = mountOrganismes()
+    await flush()
+
+    await expect(create({
+      nom: 'X',
+      siret: '44444444444444',
+      versant: 'FPE',
+      gestion_ats: true,
+    })).rejects.toThrow('boom')
   })
 })

--- a/src/web/presentation/frontend/src/features/organismes/composables/useOrganismes.ts
+++ b/src/web/presentation/frontend/src/features/organismes/composables/useOrganismes.ts
@@ -1,12 +1,26 @@
-import { useQuery } from '@pinia/colada'
-import { organismesListQuery } from '../queries'
+import type { CreateOrganismePayload } from '../types'
+import { useMutation, useQuery, useQueryCache } from '@pinia/colada'
+import { createOrganisme } from '../api'
+import { ORGANISMES_QUERY_KEYS, organismesListQuery } from '../queries'
 
 export function useOrganismes() {
+  const queryCache = useQueryCache()
   const query = useQuery(organismesListQuery)
+
+  function invalidate() {
+    return queryCache.invalidateQueries({ key: ORGANISMES_QUERY_KEYS.root })
+  }
+
+  const createMutation = useMutation({
+    mutation: (payload: CreateOrganismePayload) => createOrganisme(payload),
+    onSettled: invalidate,
+  })
 
   return {
     organismesList: query.data,
     pending: query.isPending,
     error: query.error,
+    create: createMutation.mutateAsync,
+    creating: createMutation.isLoading,
   }
 }

--- a/src/web/presentation/frontend/src/features/organismes/constants/organisme.ts
+++ b/src/web/presentation/frontend/src/features/organismes/constants/organisme.ts
@@ -1,0 +1,9 @@
+import type { Versant } from '../types'
+
+export const VERSANT_LABELS: Record<Versant, string> = {
+  FPE: 'Fonction Publique d\'État',
+  FPT: 'Fonction Publique Territoriale',
+  FPH: 'Fonction Publique Hospitalière',
+}
+
+export const SIRET_LENGTH = 14

--- a/src/web/presentation/frontend/src/features/organismes/siret.test.ts
+++ b/src/web/presentation/frontend/src/features/organismes/siret.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isSiretValid } from './siret'
+
+describe('isSiretValid', () => {
+  it('accepts a siret with a valid checksum', () => {
+    expect(isSiretValid('11004601800021')).toBe(true)
+  })
+
+  it('accepts a La Poste siret despite its invalid checksum', () => {
+    expect(isSiretValid('35600000012345')).toBe(true)
+  })
+
+  it('rejects a siret with an invalid checksum', () => {
+    expect(isSiretValid('12345671234567')).toBe(false)
+  })
+
+  it('rejects a siret with a wrong length or non-digit characters', () => {
+    expect(isSiretValid('123456712')).toBe(false)
+    expect(isSiretValid('1100460180001a')).toBe(false)
+  })
+})

--- a/src/web/presentation/frontend/src/features/organismes/siret.ts
+++ b/src/web/presentation/frontend/src/features/organismes/siret.ts
@@ -1,0 +1,27 @@
+import { SIRET_LENGTH } from './constants/organisme'
+
+const LUHN_DIGIT_OVERFLOW_THRESHOLD = 9
+
+// La Poste's SIREN predates the INSEE Luhn check and is exempt from it,
+// mirroring the backend SIRET value object.
+const LA_POSTE_SIREN = '356000000'
+
+function isLuhnValid(digits: string): boolean {
+  let total = 0
+  for (const [index, char] of [...digits].reverse().entries()) {
+    let digit = Number(char)
+    if (index % 2 === 1) {
+      digit *= 2
+      if (digit > LUHN_DIGIT_OVERFLOW_THRESHOLD)
+        digit -= LUHN_DIGIT_OVERFLOW_THRESHOLD
+    }
+    total += digit
+  }
+  return total % 10 === 0
+}
+
+export function isSiretValid(value: string): boolean {
+  if (value.length !== SIRET_LENGTH || !/^\d+$/.test(value))
+    return false
+  return value.startsWith(LA_POSTE_SIREN) || isLuhnValid(value)
+}

--- a/src/web/presentation/frontend/src/features/organismes/types.ts
+++ b/src/web/presentation/frontend/src/features/organismes/types.ts
@@ -1,3 +1,9 @@
 import type { components } from '@/types/api'
 
 export type OrganismesList = components['schemas']['OrganismesList']
+
+export type OrganismeDetail = components['schemas']['OrganismeDetail']
+
+export type CreateOrganismePayload = components['schemas']['CreateOrganisme']
+
+export type Versant = components['schemas']['VersantEnum']


### PR DESCRIPTION
## 📝 Description
🎸 Permet de créer un organisme depuis la vue de liste côté admin (le usecase n'est pas intégré, il faut l'attendre pour voir la liste se mettre à jour à l'issue de la création)

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 📸 Captures d’écran (si applicable)
<img width="1704" height="954" alt="Capture d’écran 2026-08-21 à 13 08 28" src="https://github.com/user-attachments/assets/18e8bfff-0cbf-4998-af88-e0f46edf0188" />

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
