### PR TITLE
🎨(web) correction des noms des usecases

### DIFF
--- a/src/web/application/commons/usecases/calculate_daily_stats.py
+++ b/src/web/application/commons/usecases/calculate_daily_stats.py
@@ -7,7 +7,7 @@ from domain.commons.services.stat_snapshot_writer_interface import IStatSnapshot
 from domain.commons.value_objects.stat_snapshot import StatSnapshot
 
 
-class CalculateDailyStatsUseCase:
+class CalculateDailyStatsUsecase:
     def __init__(
         self,
         offer_stats_query_service: IOfferStatsQueryService,

--- a/src/web/application/identite/usecases/get_utilisateur_details.py
+++ b/src/web/application/identite/usecases/get_utilisateur_details.py
@@ -6,7 +6,7 @@ from domain.identite.repositories.utilisateur_repository_interface import (
 )
 
 
-class GetUtilisateurDetailUsecase:
+class GetUtilisateurDetailsUsecase:
     def __init__(self, utilisateur_repository: IUtilisateurRepository):
         self.utilisateur_repository = utilisateur_repository
 

--- a/src/web/application/identite/usecases/list_organismes.py
+++ b/src/web/application/identite/usecases/list_organismes.py
@@ -18,7 +18,7 @@ class ListOrganismesCommand:
     user_id: UUID
 
 
-class ListOrganismeUsecase(IUseCase[ListOrganismesCommand, List[Organisme]]):
+class ListOrganismesUsecase(IUseCase[ListOrganismesCommand, List[Organisme]]):
     def __init__(
         self,
         organisme_repository: IOrganismeRepository,

--- a/src/web/application/ingestion/usecases/archive_offer_by_reference.py
+++ b/src/web/application/ingestion/usecases/archive_offer_by_reference.py
@@ -18,7 +18,7 @@ from domain.ingestion.repositories.user_source_repository_interface import (
 from domain.ingestion.repositories.vector_repository_interface import IVectorRepository
 
 
-class ArchiveOfferByReferenceUseCase(IUseCase[ArchiveOfferByReferenceInput, None]):
+class ArchiveOfferByReferenceUsecase(IUseCase[ArchiveOfferByReferenceInput, None]):
     def __init__(
         self,
         offers_repository: IIngestionOffersRepository,

--- a/src/web/application/ingestion/usecases/get_offer_by_reference.py
+++ b/src/web/application/ingestion/usecases/get_offer_by_reference.py
@@ -7,7 +7,7 @@ from application.ingestion.interfaces.get_offer_by_reference_input import (
 )
 
 
-class GetOfferByReferenceUseCase(IUseCase[GetOfferByReferenceInput, Offer]):
+class GetOfferByReferenceUsecase(IUseCase[GetOfferByReferenceInput, Offer]):
     def __init__(
         self,
         offers_repository: IOffersRepository,

--- a/src/web/application/ingestion/usecases/get_offers_by_source.py
+++ b/src/web/application/ingestion/usecases/get_offers_by_source.py
@@ -17,7 +17,7 @@ from domain.ingestion.repositories.user_source_repository_interface import (
 )
 
 
-class GetOffersBySourceUseCase(IUseCase[GetOffersBySourceInput, IPage[Offer]]):
+class GetOffersBySourceUsecase(IUseCase[GetOffersBySourceInput, IPage[Offer]]):
     def __init__(
         self,
         offers_repository: IOffersRepository,

--- a/src/web/application/ingestion/usecases/list_metiers.py
+++ b/src/web/application/ingestion/usecases/list_metiers.py
@@ -7,7 +7,7 @@ from referentiel.repositories.metier_repository_interface import IMetierReposito
 from application.ingestion.interfaces.list_metiers_input import GetFilteredMetiersInput
 
 
-class ListMetiersUseCase(IUseCase[GetFilteredMetiersInput, IPage[Metier]]):
+class ListMetiersUsecase(IUseCase[GetFilteredMetiersInput, IPage[Metier]]):
     def __init__(
         self,
         metiers_repository: IMetierRepository,

--- a/src/web/application/ingestion/usecases/list_offers.py
+++ b/src/web/application/ingestion/usecases/list_offers.py
@@ -7,7 +7,7 @@ from referentiel.repositories.offers_repository_interface import IOffersReposito
 from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
 
 
-class ListOffersUseCase(IUseCase[GetFilteredOffersInput, IPage[Offer]]):
+class ListOffersUsecase(IUseCase[GetFilteredOffersInput, IPage[Offer]]):
     def __init__(
         self,
         offers_repository: IOffersRepository,

--- a/src/web/application/ingestion/usecases/list_sources.py
+++ b/src/web/application/ingestion/usecases/list_sources.py
@@ -5,7 +5,7 @@ from referentiel.entities.source import Source
 from domain.ingestion.repositories.source_repository_interface import ISourceRepository
 
 
-class ListSourcesUseCase:
+class ListSourcesUsecase:
     def __init__(self, source_repository: ISourceRepository):
         self.source_repository = source_repository
 

--- a/src/web/application/ingestion/usecases/upsert_offers.py
+++ b/src/web/application/ingestion/usecases/upsert_offers.py
@@ -17,7 +17,7 @@ from domain.ingestion.repositories.user_source_repository_interface import (
 )
 
 
-class UpsertOffersUseCase(IUseCase[UpsertOffersInput, IUpsertResult]):
+class UpsertOffersUsecase(IUseCase[UpsertOffersInput, IUpsertResult]):
     def __init__(
         self,
         offers_repository: IIngestionOffersRepository,

--- a/src/web/infrastructure/di/identite/identite_container.py
+++ b/src/web/infrastructure/di/identite/identite_container.py
@@ -4,9 +4,9 @@ from application.identite.usecases.create_agent import CreateAgentUsecase
 from application.identite.usecases.create_candidat import CreateCandidatUsecase
 from application.identite.usecases.create_organisme import CreateOrganismeUsecase
 from application.identite.usecases.get_utilisateur_details import (
-    GetUtilisateurDetailUsecase,
+    GetUtilisateurDetailsUsecase,
 )
-from application.identite.usecases.list_organismes import ListOrganismeUsecase
+from application.identite.usecases.list_organismes import ListOrganismesUsecase
 from application.identite.usecases.log_utilisateur_connexion import (
     LogUtilisateurConnexionUsecase,
 )
@@ -48,7 +48,7 @@ class IdentiteContainer(containers.DeclarativeContainer):
     postgres_organisme_repository = providers.Singleton(PostgresOrganismeRepository)
 
     get_utilisateur_details_usecase = providers.Factory(
-        GetUtilisateurDetailUsecase,
+        GetUtilisateurDetailsUsecase,
         utilisateur_repository=postgres_utilisateur_repository,
     )
 
@@ -79,7 +79,7 @@ class IdentiteContainer(containers.DeclarativeContainer):
     )
 
     list_organismes_usecase = providers.Factory(
-        ListOrganismeUsecase,
+        ListOrganismesUsecase,
         organisme_repository=postgres_organisme_repository,
         permission_service=organisme_creation_permission_service,
     )

--- a/src/web/infrastructure/di/ingestion/ingestion_container.py
+++ b/src/web/infrastructure/di/ingestion/ingestion_container.py
@@ -4,24 +4,24 @@ from dependency_injector import containers, providers
 from referentiel.types import IUpsertResult
 
 from application.commons.usecases.calculate_daily_stats import (
-    CalculateDailyStatsUseCase,
+    CalculateDailyStatsUsecase,
 )
 from application.ingestion.interfaces.load_documents_input import LoadDocumentsInput
 from application.ingestion.usecases.archive_offer_by_reference import (
-    ArchiveOfferByReferenceUseCase,
+    ArchiveOfferByReferenceUsecase,
 )
 from application.ingestion.usecases.clean_documents import CleanDocumentsUsecase
 from application.ingestion.usecases.get_offer_by_reference import (
-    GetOfferByReferenceUseCase,
+    GetOfferByReferenceUsecase,
 )
 from application.ingestion.usecases.get_offers_by_source import (
-    GetOffersBySourceUseCase,
+    GetOffersBySourceUsecase,
 )
-from application.ingestion.usecases.list_metiers import ListMetiersUseCase
-from application.ingestion.usecases.list_offers import ListOffersUseCase
-from application.ingestion.usecases.list_sources import ListSourcesUseCase
+from application.ingestion.usecases.list_metiers import ListMetiersUsecase
+from application.ingestion.usecases.list_offers import ListOffersUsecase
+from application.ingestion.usecases.list_sources import ListSourcesUsecase
 from application.ingestion.usecases.load_documents import LoadDocumentsUsecase
-from application.ingestion.usecases.upsert_offers import UpsertOffersUseCase
+from application.ingestion.usecases.upsert_offers import UpsertOffersUsecase
 from application.ingestion.usecases.vectorize_documents import VectorizeDocumentsUsecase
 from domain.ingestion.services.document_cleaner_interface import IDocumentCleaner
 from infrastructure.external_gateways import (
@@ -144,24 +144,24 @@ class IngestionContainer(containers.DeclarativeContainer):
     )
 
     list_offers_usecase = providers.Factory(
-        ListOffersUseCase,
+        ListOffersUsecase,
         offers_repository=offers_repository,
         logger=logger_service,
     )
 
     get_offer_by_reference_usecase = providers.Factory(
-        GetOfferByReferenceUseCase,
+        GetOfferByReferenceUsecase,
         offers_repository=offers_repository,
     )
 
     list_metiers_usecase = providers.Factory(
-        ListMetiersUseCase,
+        ListMetiersUsecase,
         metiers_repository=metiers_repository,
         logger=logger_service,
     )
 
     archive_offer_by_reference_usecase = providers.Factory(
-        ArchiveOfferByReferenceUseCase,
+        ArchiveOfferByReferenceUsecase,
         offers_repository=offers_repository,
         vector_repository=vector_repository,
         user_source_repository=user_source_repository,
@@ -169,7 +169,7 @@ class IngestionContainer(containers.DeclarativeContainer):
     )
 
     upsert_offers_usecase = providers.Factory(
-        UpsertOffersUseCase,
+        UpsertOffersUsecase,
         offers_repository=offers_repository,
         logger=logger_service,
         user_source_repository=user_source_repository,
@@ -177,19 +177,19 @@ class IngestionContainer(containers.DeclarativeContainer):
     )
 
     list_sources_usecase = providers.Factory(
-        ListSourcesUseCase,
+        ListSourcesUsecase,
         source_repository=source_repository,
     )
 
     get_offers_by_source_usecase = providers.Factory(
-        GetOffersBySourceUseCase,
+        GetOffersBySourceUsecase,
         offers_repository=offers_repository,
         user_source_repository=user_source_repository,
         utilisateur_repository=utilisateur_repository,
     )
 
     calculate_daily_stats_usecase = providers.Factory(
-        CalculateDailyStatsUseCase,
+        CalculateDailyStatsUsecase,
         offer_stats_query_service=shared_container.offer_stats_query_service,
         stat_snapshot_writer=shared_container.stat_snapshot_writer,
     )

--- a/src/web/tests/infrastructure/ingestion/test_archive_offer_by_reference.py
+++ b/src/web/tests/infrastructure/ingestion/test_archive_offer_by_reference.py
@@ -55,7 +55,7 @@ def use_case(db, vector_repository):
     return container.archive_offer_by_reference_usecase()
 
 
-class TestArchiveOfferByReferenceUseCase:
+class TestArchiveOfferByReferenceUsecase:
     def test_archives_offer_by_reference(self, db, use_case, offers_repository):
         OfferFactory.create_model(reference=REFERENCE, source_id=SOURCE_ID)
         use_case.execute(

--- a/src/web/tests/infrastructure/ingestion/test_load_documents.py
+++ b/src/web/tests/infrastructure/ingestion/test_load_documents.py
@@ -46,7 +46,7 @@ def load_documents_usecase(documents_ingestion_container):
     return documents_ingestion_container.load_documents_usecase()
 
 
-class TestIntegrationCorpsLoadDocumentsUseCase:
+class TestIntegrationCorpsLoadDocumentsUsecase:
     async def test_execute_returns_zero_when_no_documents(
         self, db, load_documents_usecase, test_app_config, httpx_mock
     ):

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -29,18 +29,18 @@ from application.candidate.usecases.match_cv_to_opportunities import (
 )
 from application.candidate.usecases.process_uploaded_cv import ProcessUploadedCVUsecase
 from application.commons.usecases.calculate_daily_stats import (
-    CalculateDailyStatsUseCase,
+    CalculateDailyStatsUsecase,
 )
 from application.identite.usecases.create_agent import CreateAgentUsecase
 from application.identite.usecases.create_organisme import CreateOrganismeUsecase
 from application.ingestion.usecases.clean_documents import CleanDocumentsUsecase
 from application.ingestion.usecases.get_offers_by_source import (
-    GetOffersBySourceUseCase,
+    GetOffersBySourceUsecase,
 )
-from application.ingestion.usecases.list_offers import ListOffersUseCase
-from application.ingestion.usecases.list_sources import ListSourcesUseCase
+from application.ingestion.usecases.list_offers import ListOffersUsecase
+from application.ingestion.usecases.list_sources import ListSourcesUsecase
 from application.ingestion.usecases.load_documents import LoadDocumentsUsecase
-from application.ingestion.usecases.upsert_offers import UpsertOffersUseCase
+from application.ingestion.usecases.upsert_offers import UpsertOffersUsecase
 from application.ingestion.usecases.vectorize_documents import VectorizeDocumentsUsecase
 from application.recruteur.usecases.get_organisme_recruteur import (
     GetOrganismeRecruteurUsecase,
@@ -395,7 +395,7 @@ def list_offers_usecase():
         IOffersRepository, create_interface_aware_mock(IOffersRepository)
     )
 
-    return ListOffersUseCase(
+    return ListOffersUsecase(
         offers_repository=offers_repo,
         logger=logger,
     )
@@ -415,7 +415,7 @@ def upsert_offers_usecase():
         IUtilisateurRepository, create_interface_aware_mock(IUtilisateurRepository)
     )
 
-    return UpsertOffersUseCase(
+    return UpsertOffersUsecase(
         offers_repository=offers_repo,
         logger=logger,
         user_source_repository=user_source_repo,
@@ -435,7 +435,7 @@ def get_offers_by_source_usecase():
         IUtilisateurRepository, create_interface_aware_mock(IUtilisateurRepository)
     )
 
-    return GetOffersBySourceUseCase(
+    return GetOffersBySourceUsecase(
         offers_repository=offers_repo,
         user_source_repository=user_source_repo,
         utilisateur_repository=utilisateur_repo,
@@ -448,7 +448,7 @@ def list_sources_usecase():
         ISourceRepository, create_interface_aware_mock(ISourceRepository)
     )
 
-    return ListSourcesUseCase(
+    return ListSourcesUsecase(
         source_repository=source_repo,
     )
 
@@ -533,7 +533,7 @@ def calculate_daily_stats_usecase():
         IStatSnapshotWriter,
         create_interface_aware_mock(IStatSnapshotWriter),
     )
-    return CalculateDailyStatsUseCase(
+    return CalculateDailyStatsUsecase(
         offer_stats_query_service=offer_stats_query_service,
         stat_snapshot_writer=stat_snapshot_writer,
     )


### PR DESCRIPTION
## 📝 Description
🎸 conventions majoritaires dans `src/web` : 
1. ListNotesUsecase > list_notes_usecase
2. pluriel pour les listes d'objets

📢 Les usecases contenant l'abbréviation `CV` n'ont pas été mis à jour pour le moment
📢 `src/ingestion` suit une règle différente : ListNotesUseCase > list_notes_use_case
📢 `IUseCase` et `IAsyncUseCase` non renommés pour le moment car vivent dans`libs/ddd` et `src/ingestion`

## 🏷️ Type de changement
- [x] 🔧 Changement technique

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
