### PR TITLE
🔧(tooling) add native mise tasks for front checks and e2e

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -92,7 +92,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           make lint-frontend-types WEB_INTERNAL_API_UV="cd src/web && DJANGO_SETTINGS_MODULE=config.settings.schema_internal uv run" || \
-            (echo "::error::Le schéma OpenAPI interne ou les types TypeScript ne sont pas synchronisés avec le schéma OpenAPI. Lancez 'make frontend-types' et committez." && exit 1)
+            (echo "::error::Le schéma OpenAPI interne ou les types TypeScript ne sont pas synchronisés avec le schéma OpenAPI. Lancez 'mise run front:types' et committez." && exit 1)
 
   test-web:
     needs: [check-changes, build-web]

--- a/Makefile
+++ b/Makefile
@@ -191,52 +191,13 @@ sass-watch: ## watch and compile SCSS files on changes
 .PHONY: sass-watch
 
 ### FRONTEND (Vue/Vite)
-frontend-install: ## install frontend dependencies (pnpm)
+frontend-install:
 	$(WEB_PNPM) install
 .PHONY: frontend-install
 
-frontend-dev: ## run frontend dev server (Vite HMR)
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) dev
-.PHONY: frontend-dev
-
-frontend-build: ## build frontend for production
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) build
-.PHONY: frontend-build
-
-frontend-lint: ## lint frontend sources
+frontend-lint:
 	$(WEB_PNPM) --filter $(FRONTEND_FILTER) lint
 .PHONY: frontend-lint
-
-frontend-lint-fix: ## lint and fix frontend sources
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) lint:fix
-.PHONY: frontend-lint-fix
-
-frontend-test: ## run frontend tests (Vitest)
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) test:run
-.PHONY: frontend-test
-
-frontend-typecheck: ## run TypeScript type checking
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) typecheck
-.PHONY: frontend-typecheck
-
-frontend-check: ## run all frontend checks (lint + typecheck + tests)
-	make frontend-lint
-	make frontend-typecheck
-	make frontend-test
-.PHONY: frontend-check-all
-
-storybook: ## run Storybook dev server (port 6006)
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) storybook
-.PHONY: storybook
-
-storybook-build: ## build Storybook static output
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) build-storybook
-.PHONY: storybook-build
-
-frontend-types: ## generate TypeScript types from OpenAPI schema
-	$(WEB_INTERNAL_API_UV) python manage.py spectacular --file presentation/static/api/internal-schema.yaml --validate
-	$(WEB_PNPM) --filter $(FRONTEND_FILTER) generate-types
-.PHONY: frontend-types
 
 ### RUN
 run-notebook: ## run the notebook service

--- a/docs/frontend_vue.md
+++ b/docs/frontend_vue.md
@@ -43,7 +43,7 @@ src/web/presentation/
 ### Installation
 
 ```bash
-make frontend-install
+mise run install:js
 ```
 
 ### Run the dev server
@@ -55,7 +55,7 @@ Two terminals required:
 make run-web
 
 # Terminal 2: Vite (HMR)
-make frontend-dev
+mise run front:dev
 ```
 
 Open http://localhost:8000/ats/
@@ -81,7 +81,7 @@ port then drive the HMR client; Django's CSP follows the same variable.
 ## Production Build
 
 ```bash
-make frontend-build
+mise run front:build
 ```
 
 Outputs assets to `presentation/static/frontend/` with cache-busting (hashed filenames).
@@ -89,8 +89,8 @@ Outputs assets to `presentation/static/frontend/` with cache-busting (hashed fil
 ## Lint & TypeScript
 
 ```bash
-make frontend-lint      # Check
-make frontend-lint-fix  # Auto-fix
+mise run front:lint       # Check
+mise run front:lint:fix   # Auto-fix
 ```
 
 The build includes a TypeScript check (`vue-tsc --noEmit`).

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,9 @@
 node = "24"
 uv = "0.9"
 
+[settings]
+node.corepack = true
+
 # ── Frontend (node seul, aucun service back requis) ──────────────────────────
 [tasks.sb]
 description = "Storybook front"

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 
 [tools]
 node = "24"
+uv = "0.9"
 
 # ── Frontend (node seul, aucun service back requis) ──────────────────────────
 [tasks.sb]
@@ -12,9 +13,31 @@ run = "make storybook"
 description = "Vite HMR front"
 run = "make frontend-dev"
 
-[tasks.check]
-description = "Front : lint + typecheck + tests"
-run = "make frontend-check"
+[tasks."front:lint"]
+description = "Lint du frontend (eslint)"
+dir = "src/web/presentation/frontend"
+run = "pnpm run lint"
+
+[tasks."front:typecheck"]
+description = "Typecheck du frontend (vue-tsc)"
+dir = "src/web/presentation/frontend"
+run = "pnpm run typecheck"
+
+[tasks."front:test"]
+description = "Tests du frontend (vitest)"
+dir = "src/web/presentation/frontend"
+run = "pnpm run test:run"
+
+[tasks."front:build"]
+description = "Build de prod du frontend, incrémental (skip si les sources n'ont pas changé)"
+dir = "src/web/presentation/frontend"
+sources = ["src/**/*", "package.json", "tsconfig*.json", "vite.config.*", "../../pnpm-lock.yaml"]
+outputs = ["../static/frontend/manifest.json"]
+run = "pnpm run build"
+
+[tasks."front:check"]
+description = "Front : lint + typecheck + tests en parallèle"
+depends = ["front:lint", "front:typecheck", "front:test"]
 
 # ── Install & migrations ─────────────────────────────────────────────────────
 [tasks."install:py"]
@@ -58,6 +81,17 @@ run = "make dev"
 description = "Applique les migrations Django"
 depends = ["services:ats"]
 run = "make migrate"
+
+[tasks."test:e2e"]
+description = "E2e ATS en vrai navigateur (rebuild le front seulement si nécessaire)"
+depends = ["front:build", "services:ats"]
+dir = "src/web"
+run = "direnv exec . pytest -m e2e --no-cov"
+
+[tasks."db:restore"]
+description = "Restaure la base web depuis un dump Scalingo (dernier dump de dumps/ par défaut)"
+confirm = "Écraser la base web locale ?"
+run = "make restore-web-db"
 
 [tasks."open:ats"]
 description = "Ouvre http://localhost:8000/ats/ quand le back répond"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,3 @@
-# Tâches mise : surcouche d'ergonomie optionnelle pour le dev front par-dessus le Makefile
-
 [tools]
 node = "24"
 uv = "0.9"
@@ -7,16 +5,28 @@ uv = "0.9"
 # ── Frontend (node seul, aucun service back requis) ──────────────────────────
 [tasks.sb]
 description = "Storybook front"
-run = "make storybook"
+dir = "src/web/presentation/frontend"
+run = "pnpm run storybook"
+
+[tasks."sb:build"]
+description = "Build statique du Storybook"
+dir = "src/web/presentation/frontend"
+run = "pnpm run build-storybook"
 
 [tasks."front:dev"]
 description = "Vite HMR front"
-run = "make frontend-dev"
+dir = "src/web/presentation/frontend"
+run = "pnpm run dev"
 
 [tasks."front:lint"]
 description = "Lint du frontend (eslint)"
 dir = "src/web/presentation/frontend"
 run = "pnpm run lint"
+
+[tasks."front:lint:fix"]
+description = "Lint du frontend avec auto-correction"
+dir = "src/web/presentation/frontend"
+run = "pnpm run lint:fix"
 
 [tasks."front:typecheck"]
 description = "Typecheck du frontend (vue-tsc)"
@@ -39,6 +49,14 @@ run = "pnpm run build"
 description = "Front : lint + typecheck + tests en parallèle"
 depends = ["front:lint", "front:typecheck", "front:test"]
 
+[tasks."front:types"]
+description = "Régénère le schéma OpenAPI interne et les types TypeScript du front"
+dir = "src/web"
+run = [
+  "DJANGO_SETTINGS_MODULE=config.settings.schema_internal direnv exec . python manage.py spectacular --file presentation/static/api/internal-schema.yaml --validate",
+  "pnpm --filter csplab-frontend generate-types",
+]
+
 # ── Install & migrations ─────────────────────────────────────────────────────
 [tasks."install:py"]
 description = "Dépendances Python du back (uv : web + ddd + referentiel)"
@@ -46,7 +64,8 @@ run = "make build-web"
 
 [tasks."install:js"]
 description = "Dépendances frontend (pnpm)"
-run = "make frontend-install"
+dir = "src/web"
+run = "pnpm install"
 
 [tasks.install]
 description = "Installe les dépendances ATS (Python + frontend)"

--- a/src/web/README.md
+++ b/src/web/README.md
@@ -59,9 +59,9 @@ bin/manage seed_recruteur_datas
 Le service web inclut un frontend Vue.js pour l'ATS (Applicant Tracking System).
 
 ```bash
-make frontend-install   # Installer les dépendances
-make frontend-dev       # Lancer Vite dev server (HMR)
-make frontend-build     # Build production
+mise run install:js    # Installer les dépendances
+mise run front:dev     # Lancer Vite dev server (HMR)
+mise run front:build   # Build production
 ```
 
 Documentation : [docs/frontend_vue.md](../../docs/frontend_vue.md)


### PR DESCRIPTION
## 📝 Description
🎸 Implémente les premières propositions non breaking de #1214 :
- tâches`front:lint`, `front:typecheck`, `front:test` directement dans mise
- `front:check` lance ces tâches en parallèle
- `front:build` seulement si les sources on changé
- `test:e2e` (build + postgres en dépendances)
- `db:restore` demande une confirmation
- `uv` pinné.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [x] 🔧 Changement technique

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
