### PR TITLE
🎨(repo) correction de la casse des méthodes IUsecase et IAsyncUsecase

### DIFF
--- a/libs/ddd/README.md
+++ b/libs/ddd/README.md
@@ -10,7 +10,7 @@ Pure technical DDD scaffolding for the CSPLab monorepo.
 - `DomainEvent` / `DomainEventMetadata` — immutable domain event base classes
 - `Entity` — base dataclass with `entity_id: UUID`
 - `IRepository` - repositories protocols
-- `IUseCase` / `IAsyncUseCase` — use case protocols
+- `IUsecase` / `IAsyncUsecase` — use case protocols
 - `IFromDomainMapper` / `IToDomainMapper` — mapper protocols
 
 ## Dependency rules

--- a/libs/ddd/async_usecase_interface.py
+++ b/libs/ddd/async_usecase_interface.py
@@ -4,5 +4,5 @@ InputType_contra = TypeVar("InputType_contra", contravariant=True)
 OutputType_co = TypeVar("OutputType_co", covariant=True)
 
 
-class IAsyncUseCase(Protocol, Generic[InputType_contra, OutputType_co]):
+class IAsyncUsecase(Protocol, Generic[InputType_contra, OutputType_co]):
     async def execute(self, input_data: InputType_contra) -> OutputType_co: ...

--- a/libs/ddd/pyproject.toml
+++ b/libs/ddd/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ddd"
-version = "0.3.1"
+version = "0.3.2"
 description = "Pure technical DDD scaffolding — AggregateRoot, DomainEvent, Entity, decorators and interfaces"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/ddd/usecase_interface.py
+++ b/libs/ddd/usecase_interface.py
@@ -5,5 +5,5 @@ InputType_contra = TypeVar("InputType_contra", contravariant=True)
 OutputType_co = TypeVar("OutputType_co", covariant=True)
 
 
-class IUseCase(Protocol, Generic[InputType_contra, OutputType_co]):
+class IUsecase(Protocol, Generic[InputType_contra, OutputType_co]):
     def execute(self, input_data: InputType_contra) -> OutputType_co: ...

--- a/src/ingestion/application/usecases/import_organismes.py
+++ b/src/ingestion/application/usecases/import_organismes.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from ddd.async_usecase_interface import IAsyncUseCase
+from ddd.async_usecase_interface import IAsyncUsecase
 from pydantic import BaseModel, ConfigDict
 
 from domain.entities.raw_organisme import RawOrganisme
@@ -30,7 +30,7 @@ class ImportOrganismesResult:
 
 
 class ImportOrganismesUsecase(
-    IAsyncUseCase[ImportOrganismesCommand, ImportOrganismesResult]
+    IAsyncUsecase[ImportOrganismesCommand, ImportOrganismesResult]
 ):
     def __init__(
         self,

--- a/src/ingestion/application/usecases/publish_organismes.py
+++ b/src/ingestion/application/usecases/publish_organismes.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 
-from ddd.async_usecase_interface import IAsyncUseCase
+from ddd.async_usecase_interface import IAsyncUsecase
 from referentiel.entities.organisme import Organisme
 
 from domain.gateways.publish_organismes_gateway import IPublishOrganismesGateway
@@ -16,7 +16,7 @@ class PublishOrganismesCommand:
     organismes: list[Organisme]
 
 
-class PublishOrganismesUsecase(IAsyncUseCase[PublishOrganismesCommand, None]):
+class PublishOrganismesUsecase(IAsyncUsecase[PublishOrganismesCommand, None]):
     def __init__(self, publish_organismes_gateway: IPublishOrganismesGateway) -> None:
         self._gateway = publish_organismes_gateway
 

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -460,7 +460,7 @@ wheels = [
 
 [[package]]
 name = "ddd"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "../../libs/ddd" }
 
 [package.metadata]

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",

--- a/src/web/application/candidate/usecases/match_cv_to_opportunities.py
+++ b/src/web/application/candidate/usecases/match_cv_to_opportunities.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 
 from asgiref.sync import async_to_sync
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.concours import Concours
 from referentiel.entities.metier import Metier
 from referentiel.entities.offer import Offer
@@ -25,7 +25,7 @@ from domain.ingestion.services.embedding_generator_interface import IEmbeddingGe
 
 
 class MatchCVToOpportunitiesUsecase(
-    IUseCase[CVMetadata, List[Tuple[Concours | Tuple[Offer, list[Metier]], float]]],
+    IUsecase[CVMetadata, List[Tuple[Concours | Tuple[Offer, list[Metier]], float]]],
 ):
     def __init__(
         self,

--- a/src/web/application/candidate/usecases/submit_application.py
+++ b/src/web/application/candidate/usecases/submit_application.py
@@ -1,5 +1,5 @@
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.candidate.commands.submit_application_command import (
     SubmitApplicationCommand,
@@ -19,7 +19,7 @@ from domain.recruteur.repositories.recrutement_repository_interface import (
 
 
 class SubmitApplicationUsecase(
-    IUseCase[SubmitApplicationCommand, Candidature],
+    IUsecase[SubmitApplicationCommand, Candidature],
 ):
     def __init__(
         self,

--- a/src/web/application/identite/usecases/create_organisme.py
+++ b/src/web/application/identite/usecases/create_organisme.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.organisme import Organisme
 from referentiel.value_objects.localisation import Localisation
 from referentiel.value_objects.siret import SIRET
@@ -27,7 +27,7 @@ class CreateOrganismeCommand:
     utilisateur: Utilisateur
 
 
-class CreateOrganismeUsecase(IUseCase[CreateOrganismeCommand, Organisme]):
+class CreateOrganismeUsecase(IUsecase[CreateOrganismeCommand, Organisme]):
     def __init__(
         self,
         organisme_repository: IOrganismeRepository,

--- a/src/web/application/identite/usecases/list_organismes.py
+++ b/src/web/application/identite/usecases/list_organismes.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.organisme import Organisme
 
 from domain.identite.entities.utilisateurs import Utilisateur
@@ -19,7 +19,7 @@ class ListOrganismesCommand:
     utilisateur: Utilisateur
 
 
-class ListOrganismesUsecase(IUseCase[ListOrganismesCommand, List[Organisme]]):
+class ListOrganismesUsecase(IUsecase[ListOrganismesCommand, List[Organisme]]):
     def __init__(
         self,
         organisme_repository: IOrganismeRepository,

--- a/src/web/application/identite/usecases/update_organisme.py
+++ b/src/web/application/identite/usecases/update_organisme.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.organisme import Organisme
 from referentiel.value_objects.verse import Verse
 
@@ -24,7 +24,7 @@ class UpdateOrganismeCommand:
     utilisateur: Utilisateur
 
 
-class UpdateOrganismeUsecase(IUseCase[UpdateOrganismeCommand, Organisme]):
+class UpdateOrganismeUsecase(IUsecase[UpdateOrganismeCommand, Organisme]):
     def __init__(
         self,
         organisme_repository: IOrganismeRepository,

--- a/src/web/application/ingestion/usecases/archive_offer_by_reference.py
+++ b/src/web/application/ingestion/usecases/archive_offer_by_reference.py
@@ -1,4 +1,4 @@
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.ingestion.interfaces.archive_offer_by_reference_input import (
     ArchiveOfferByReferenceInput,
@@ -18,7 +18,7 @@ from domain.ingestion.repositories.user_source_repository_interface import (
 from domain.ingestion.repositories.vector_repository_interface import IVectorRepository
 
 
-class ArchiveOfferByReferenceUsecase(IUseCase[ArchiveOfferByReferenceInput, None]):
+class ArchiveOfferByReferenceUsecase(IUsecase[ArchiveOfferByReferenceInput, None]):
     def __init__(
         self,
         offers_repository: IIngestionOffersRepository,

--- a/src/web/application/ingestion/usecases/clean_documents.py
+++ b/src/web/application/ingestion/usecases/clean_documents.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, cast
 
 from ddd.entity_interface import IEntity
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.types import IUpsertResult
 
 from domain.ingestion.entities.document import DocumentType
@@ -15,7 +15,7 @@ from domain.ingestion.repositories.repository_factory_interface import (
 from domain.ingestion.services.document_cleaner_interface import IDocumentCleaner
 
 
-class CleanDocumentsUsecase(IUseCase[DocumentType, Dict[str, Any]]):
+class CleanDocumentsUsecase(IUsecase[DocumentType, Dict[str, Any]]):
     def __init__(
         self,
         document_repository: IDocumentRepository,

--- a/src/web/application/ingestion/usecases/get_offer_by_reference.py
+++ b/src/web/application/ingestion/usecases/get_offer_by_reference.py
@@ -1,4 +1,4 @@
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.offer import Offer
 from referentiel.repositories.offers_repository_interface import IOffersRepository
 
@@ -7,7 +7,7 @@ from application.ingestion.interfaces.get_offer_by_reference_input import (
 )
 
 
-class GetOfferByReferenceUsecase(IUseCase[GetOfferByReferenceInput, Offer]):
+class GetOfferByReferenceUsecase(IUsecase[GetOfferByReferenceInput, Offer]):
     def __init__(
         self,
         offers_repository: IOffersRepository,

--- a/src/web/application/ingestion/usecases/get_offers_by_source.py
+++ b/src/web/application/ingestion/usecases/get_offers_by_source.py
@@ -1,5 +1,5 @@
 from ddd.page_interface import IPage
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.offer import Offer
 from referentiel.repositories.offers_repository_interface import IOffersRepository
 
@@ -17,7 +17,7 @@ from domain.ingestion.repositories.user_source_repository_interface import (
 )
 
 
-class GetOffersBySourceUsecase(IUseCase[GetOffersBySourceInput, IPage[Offer]]):
+class GetOffersBySourceUsecase(IUsecase[GetOffersBySourceInput, IPage[Offer]]):
     def __init__(
         self,
         offers_repository: IOffersRepository,

--- a/src/web/application/ingestion/usecases/list_metiers.py
+++ b/src/web/application/ingestion/usecases/list_metiers.py
@@ -1,13 +1,13 @@
 from ddd.page_interface import IPage
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.metier import Metier
 from referentiel.repositories.metier_repository_interface import IMetierRepository
 
 from application.ingestion.interfaces.list_metiers_input import GetFilteredMetiersInput
 
 
-class ListMetiersUsecase(IUseCase[GetFilteredMetiersInput, IPage[Metier]]):
+class ListMetiersUsecase(IUsecase[GetFilteredMetiersInput, IPage[Metier]]):
     def __init__(
         self,
         metiers_repository: IMetierRepository,

--- a/src/web/application/ingestion/usecases/list_offers.py
+++ b/src/web/application/ingestion/usecases/list_offers.py
@@ -1,13 +1,13 @@
 from ddd.page_interface import IPage
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.entities.offer import Offer
 from referentiel.repositories.offers_repository_interface import IOffersRepository
 
 from application.ingestion.interfaces.list_offers_input import GetFilteredOffersInput
 
 
-class ListOffersUsecase(IUseCase[GetFilteredOffersInput, IPage[Offer]]):
+class ListOffersUsecase(IUsecase[GetFilteredOffersInput, IPage[Offer]]):
     def __init__(
         self,
         offers_repository: IOffersRepository,

--- a/src/web/application/ingestion/usecases/load_documents.py
+++ b/src/web/application/ingestion/usecases/load_documents.py
@@ -1,7 +1,7 @@
 from typing import cast
 
 from asgiref.sync import sync_to_async
-from ddd.async_usecase_interface import IAsyncUseCase
+from ddd.async_usecase_interface import IAsyncUsecase
 from ddd.services.logger_interface import ILogger
 from referentiel.types import IUpsertResult
 
@@ -13,7 +13,7 @@ from domain.ingestion.repositories.document_repository_interface import (
 from infrastructure.gateways.ingestion import load_documents_strategy_factory
 
 
-class LoadDocumentsUsecase(IAsyncUseCase[LoadDocumentsInput, IUpsertResult]):
+class LoadDocumentsUsecase(IAsyncUsecase[LoadDocumentsInput, IUpsertResult]):
     def __init__(
         self,
         strategy_factory: load_documents_strategy_factory.LoadDocumentsStrategyFactory,

--- a/src/web/application/ingestion/usecases/upsert_offers.py
+++ b/src/web/application/ingestion/usecases/upsert_offers.py
@@ -1,5 +1,5 @@
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.types import IUpsertResult
 
 from application.ingestion.interfaces.upsert_offers_input import UpsertOffersInput
@@ -17,7 +17,7 @@ from domain.ingestion.repositories.user_source_repository_interface import (
 )
 
 
-class UpsertOffersUsecase(IUseCase[UpsertOffersInput, IUpsertResult]):
+class UpsertOffersUsecase(IUsecase[UpsertOffersInput, IUpsertResult]):
     def __init__(
         self,
         offers_repository: IIngestionOffersRepository,

--- a/src/web/application/ingestion/usecases/vectorize_documents.py
+++ b/src/web/application/ingestion/usecases/vectorize_documents.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Union, cast
 from asgiref.sync import async_to_sync
 from ddd.entity import Entity
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from django.db import transaction
 from referentiel.entities.concours import Concours
 from referentiel.entities.corps import Corps
@@ -21,7 +21,7 @@ from domain.ingestion.services.embedding_generator_interface import IEmbeddingGe
 from domain.ingestion.services.text_extractor_interface import ITextExtractor
 
 
-class VectorizeDocumentsUsecase(IUseCase[DocumentType, Dict[str, Any]]):
+class VectorizeDocumentsUsecase(IUsecase[DocumentType, Dict[str, Any]]):
     def __init__(
         self,
         vector_repository: IVectorRepository,

--- a/src/web/application/recruteur/usecases/changer_etape_candidatures.py
+++ b/src/web/application/recruteur/usecases/changer_etape_candidatures.py
@@ -3,7 +3,7 @@ from typing import List
 from uuid import UUID
 
 from ddd.unit_of_work import IUnitOfWork
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 from referentiel.types import IBatchUpdate
 
 from domain.commons.services.audit_log_writer import AuditLogWriter
@@ -33,7 +33,7 @@ class ChangerEtapeCandidaturesCommand:
 
 
 class ChangerEtapeCandidaturesUsecase(
-    IUseCase[
+    IUsecase[
         ChangerEtapeCandidaturesCommand,
         IBatchUpdate[CandidatureRecruteur, RecrutementError],
     ]

--- a/src/web/application/recruteur/usecases/creer_note.py
+++ b/src/web/application/recruteur/usecases/creer_note.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.errors.agent_errors import ProfilAgentNexistePas
@@ -20,7 +20,7 @@ class CreerNoteCommand:
     message: str
 
 
-class CreerNoteUsecase(IUseCase[CreerNoteCommand, Note]):
+class CreerNoteUsecase(IUsecase[CreerNoteCommand, Note]):
     def __init__(
         self,
         note_repository: INoteRepository,

--- a/src/web/application/recruteur/usecases/editer_note.py
+++ b/src/web/application/recruteur/usecases/editer_note.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.recruteur.entities.note import Note
@@ -16,7 +16,7 @@ class EditerNoteCommand:
     mis_a_jour_par_id: UUID
 
 
-class EditerNoteUsecase(IUseCase[EditerNoteCommand, Note]):
+class EditerNoteUsecase(IUsecase[EditerNoteCommand, Note]):
     def __init__(
         self,
         note_repository: INoteRepository,

--- a/src/web/application/recruteur/usecases/get_organisme_recruteur.py
+++ b/src/web/application/recruteur/usecases/get_organisme_recruteur.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from domain.identite.entities.utilisateurs import Utilisateur
 from domain.identite.services.organisme_permission_service import (
@@ -21,7 +21,7 @@ class GetOrganismeRecruteurQuery:
 
 
 class GetOrganismeRecruteurUsecase(
-    IUseCase[GetOrganismeRecruteurQuery, OrganismeRecruteur]
+    IUsecase[GetOrganismeRecruteurQuery, OrganismeRecruteur]
 ):
     def __init__(
         self,

--- a/src/web/application/recruteur/usecases/get_recrutement_detail.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_detail.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.dtos.recrutement_read_models import (
     RecrutementDetailReadModel,
@@ -21,7 +21,7 @@ class GetRecrutementDetailQuery(RecrutementRequest):
 
 
 class GetRecrutementDetailUsecase(
-    IUseCase[GetRecrutementDetailQuery, RecrutementDetailReadModel | None]
+    IUsecase[GetRecrutementDetailQuery, RecrutementDetailReadModel | None]
 ):
     def __init__(
         self,

--- a/src/web/application/recruteur/usecases/get_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_etapes.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.dtos.etape_data import EtapeData, etapes_par_defaut
 from application.recruteur.dtos.recrutement_request import RecrutementRequest
@@ -18,7 +18,7 @@ class GetRecrutementEtapesQuery(RecrutementRequest):
 # TODO: ajouter
 # - recuperer le Recrutement via IRecrutementRepository et mapper ses etapes reelles
 #   (EtapeRecrutement) vers EtapeData, au lieu du pipeline statique ci-dessous
-class GetRecrutementEtapesUsecase(IUseCase[GetRecrutementEtapesQuery, list[EtapeData]]):
+class GetRecrutementEtapesUsecase(IUsecase[GetRecrutementEtapesQuery, list[EtapeData]]):
     def __init__(
         self,
         organisme_permission_service: OrganismePermissionService,

--- a/src/web/application/recruteur/usecases/get_recrutement_kanban.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_kanban.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.dtos.recrutement_read_models import (
     RecrutementKanbanReadModel,
@@ -21,7 +21,7 @@ class GetRecrutementKanbanQuery(RecrutementRequest):
 
 
 class GetRecrutementKanbanUsecase(
-    IUseCase[GetRecrutementKanbanQuery, RecrutementKanbanReadModel | None]
+    IUsecase[GetRecrutementKanbanQuery, RecrutementKanbanReadModel | None]
 ):
     def __init__(
         self,

--- a/src/web/application/recruteur/usecases/get_recrutement_liste.py
+++ b/src/web/application/recruteur/usecases/get_recrutement_liste.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from ddd.page_interface import IPage
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.dtos.recrutement_read_models import (
     CandidatureListeReadModel,
@@ -22,7 +22,7 @@ class GetRecrutementListeQuery(RecrutementRequest):
 
 
 class GetRecrutementListeUsecase(
-    IUseCase[GetRecrutementListeQuery, IPage[CandidatureListeReadModel] | None]
+    IUsecase[GetRecrutementListeQuery, IPage[CandidatureListeReadModel] | None]
 ):
     def __init__(
         self,

--- a/src/web/application/recruteur/usecases/init_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/init_recrutement_etapes.py
@@ -1,4 +1,4 @@
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.dtos.recrutement_request import RecrutementRequest
 from application.recruteur.errors.application_errors_recruteur import (
@@ -22,7 +22,7 @@ from domain.recruteur.repositories.recrutement_repository_interface import (
 
 
 class InitRecrutementEtapesUsecase(
-    IUseCase[RecrutementRequest, tuple[EtapeRecrutement, ...]]
+    IUsecase[RecrutementRequest, tuple[EtapeRecrutement, ...]]
 ):
     def __init__(
         self,

--- a/src/web/application/recruteur/usecases/initialize_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/initialize_organisme_steps.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from domain.identite.entities.utilisateurs import Utilisateur
 from domain.identite.services.organisme_permission_service import (
@@ -21,7 +21,7 @@ class InitializeOrganismeStepsCommand:
 
 
 class InitializeOrganismeStepsUsecase(
-    IUseCase[InitializeOrganismeStepsCommand, OrganismeRecruteur]
+    IUsecase[InitializeOrganismeStepsCommand, OrganismeRecruteur]
 ):
     def __init__(
         self,

--- a/src/web/application/recruteur/usecases/lister_mes_recrutements.py
+++ b/src/web/application/recruteur/usecases/lister_mes_recrutements.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from ddd.page_interface import IPage
 from ddd.services.logger_interface import ILogger
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.services.recrutement_query_service_interface import (
     IRecrutementQueryService,
@@ -27,7 +27,7 @@ class ListerMesRecrutementsQuery:
 
 
 class ListerMesRecrutementsUsecase(
-    IUseCase[
+    IUsecase[
         ListerMesRecrutementsQuery,
         IPage[RecrutementActifsReadModel] | IPage[RecrutementArchivesReadModel],
     ]

--- a/src/web/application/recruteur/usecases/lister_notes_candidature.py
+++ b/src/web/application/recruteur/usecases/lister_notes_candidature.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.dtos.note_read_models import NoteReadModel
 from application.recruteur.services.note_query_service_interface import (
@@ -15,7 +15,7 @@ class ListerNotesCandidatureQuery:
 
 
 class ListerNotesCandidatureUsecase(
-    IUseCase[ListerNotesCandidatureQuery, list[NoteReadModel]]
+    IUsecase[ListerNotesCandidatureQuery, list[NoteReadModel]]
 ):
     def __init__(self, note_query_service: INoteQueryService):
         self.note_query_service = note_query_service

--- a/src/web/application/recruteur/usecases/supprimer_note.py
+++ b/src/web/application/recruteur/usecases/supprimer_note.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.recruteur.errors.note_errors import NoteIntrouvable
@@ -14,7 +14,7 @@ class SupprimerNoteCommand:
     supprime_par_id: UUID
 
 
-class SupprimerNoteUsecase(IUseCase[SupprimerNoteCommand, None]):
+class SupprimerNoteUsecase(IUsecase[SupprimerNoteCommand, None]):
     def __init__(
         self,
         note_repository: INoteRepository,

--- a/src/web/application/recruteur/usecases/update_organisme_steps.py
+++ b/src/web/application/recruteur/usecases/update_organisme_steps.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.entities.utilisateurs import Utilisateur
@@ -34,7 +34,7 @@ class UpdateOrganismeStepsCommand:
 
 
 class UpdateOrganismeStepsUsecase(
-    IUseCase[UpdateOrganismeStepsCommand, OrganismeRecruteur]
+    IUsecase[UpdateOrganismeStepsCommand, OrganismeRecruteur]
 ):
     def __init__(
         self,

--- a/src/web/application/recruteur/usecases/update_recrutement_etapes.py
+++ b/src/web/application/recruteur/usecases/update_recrutement_etapes.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from ddd.usecase_interface import IUseCase
+from ddd.usecase_interface import IUsecase
 
 from application.recruteur.dtos.etape_data import EtapeData
 from application.recruteur.dtos.recrutement_request import RecrutementRequest
@@ -20,7 +20,7 @@ class UpdateRecrutementEtapesCommand(RecrutementRequest):
 # - recuperer/muter le Recrutement (necessite une methode @mutate sur l'agregat)
 # - sauvegarde + emission evenement + drain par auditlog
 class UpdateRecrutementEtapesUsecase(
-    IUseCase[UpdateRecrutementEtapesCommand, list[EtapeData]]
+    IUsecase[UpdateRecrutementEtapesCommand, list[EtapeData]]
 ):
     def __init__(
         self,

--- a/src/web/infrastructure/di/ingestion/ingestion_container.py
+++ b/src/web/infrastructure/di/ingestion/ingestion_container.py
@@ -1,4 +1,4 @@
-from ddd.async_usecase_interface import IAsyncUseCase
+from ddd.async_usecase_interface import IAsyncUsecase
 from ddd.entity import Entity
 from dependency_injector import containers, providers
 from referentiel.types import IUpsertResult
@@ -118,7 +118,7 @@ class IngestionContainer(containers.DeclarativeContainer):
     )
 
     load_documents_usecase: providers.Provider[
-        IAsyncUseCase[LoadDocumentsInput, IUpsertResult]
+        IAsyncUsecase[LoadDocumentsInput, IUpsertResult]
     ] = providers.Factory(
         LoadDocumentsUsecase,
         strategy_factory=load_documents_strategy_factory,

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 3
-requires-python = "==3.12.*"
+revision = 2
+requires-python = ">=3.12.0, <3.13"
 
 [[package]]
 name = "annotated-types"

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "ddd"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "../../libs/ddd" }
 
 [package.metadata]


### PR DESCRIPTION
## 📝 Description
🎸 renommage de `IUseCase` and `IAsyncUseCase` en `IUsecase` et `IAsyncUsecase`

suite de #1235 et #1238

## 🏷️ Type de changement
- [x] ♻️ Refactorisation


## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
