### PR TITLE
♻️(tooling) Centralise node and pnpm version

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yml
+++ b/.github/actions/setup-pnpm-node/action.yml
@@ -2,9 +2,6 @@ name: Set up pnpm and Node.js
 description: Install pnpm and Node.js with dependency caching.
 
 inputs:
-  node-version:
-    description: Node.js version to install
-    default: "24"
   lock-file-path:
     description: Path to the pnpm lock file for caching
     required: true
@@ -14,9 +11,11 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v6
+      with:
+        package_json_file: src/web/package.json
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version-file: src/web/package.json
         cache: pnpm
         cache-dependency-path: ${{ inputs.lock-file-path }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,7 @@
 # Tâches mise : surcouche d'ergonomie optionnelle pour le dev front par-dessus le Makefile
 
 [tools]
-node = "24"        # engines.node (src/web/package.json)
-pnpm = "11.23"    # packageManager (src/web/package.json)
+node = "24"
 
 # ── Frontend (node seul, aucun service back requis) ──────────────────────────
 [tasks.sb]

--- a/package.json
+++ b/package.json
@@ -1,3 +1,0 @@
-{
-  "packageManager": "pnpm@11.1.3"
-}

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "csplab-web",
   "private": true,
+  "packageManager": "pnpm@11.23.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## 📝 Description
Les versions de Node et pnpm étaient déclarées à plusieurs endroits (mise.toml, packageManager, CI)

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
Une seule source par outil, dans src/web/package.json :

- packageManager: "pnpm@11.23.0" => désormais lu par pnpm en local (auto-switch), par la CI (package_json_file) et par le buildpack de prod
- engines.node: "24.x" => désormais lu par la CI (node-version-file) et par le buildpack de prod
- mise.toml ne garde que node = "24" pour le provisionnement local (aucun outil ne peut lire engines.node pour s'auto-installer). 
- Le pin pnpm de mise.toml est supprimé : corepack (embarqué dans Node 24) suffit à amorcer un premier binaire pnpm, qui bascule ensuite sur la version de packageManager.

Le fichier package.json racine, devenu vide de sens, est supprimé.

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
