### PR TITLE
🐛(ingestion) convert Lambert-93 coordinates from FINESS to WGS84

### DIFF
--- a/src/ingestion/infrastructure/gateways/lambert93.py
+++ b/src/ingestion/infrastructure/gateways/lambert93.py
@@ -1,0 +1,41 @@
+import math
+
+# RGF93 / Lambert-93 (EPSG:2154) projection constants, using the GRS80 ellipsoid.
+# See IGN's "Algorithmes de transformation de coordonnées" (NTG_71) for the
+# reference formulas this inverse projection implements.
+_GRS80_ECCENTRICITY = 0.08181919112823853
+_LAMBERT93_N = 0.7256077650
+_LAMBERT93_C = 11754255.426
+_LAMBERT93_XS = 700000.0
+_LAMBERT93_YS = 12655612.0499
+_LAMBERT93_LON0 = math.radians(3.0)
+_CONVERGENCE_ITERATIONS = 6
+
+
+def lambert93_to_wgs84(x: float, y: float) -> tuple[float, float]:
+    """Converts Lambert-93 (EPSG:2154) coordinates, in meters, to WGS84
+    (EPSG:4326) (latitude, longitude), in decimal degrees."""
+    dx = x - _LAMBERT93_XS
+    dy = y - _LAMBERT93_YS
+    r = math.hypot(dx, dy)
+    gamma = math.atan2(dx, -dy)
+    longitude = _LAMBERT93_LON0 + gamma / _LAMBERT93_N
+    lat_iso = -math.log(abs(r / _LAMBERT93_C)) / _LAMBERT93_N
+
+    latitude = 2 * math.atan(math.exp(lat_iso)) - math.pi / 2
+    for _ in range(_CONVERGENCE_ITERATIONS):
+        sin_latitude = math.sin(latitude)
+        latitude = (
+            2
+            * math.atan(
+                (
+                    (1 + _GRS80_ECCENTRICITY * sin_latitude)
+                    / (1 - _GRS80_ECCENTRICITY * sin_latitude)
+                )
+                ** (_GRS80_ECCENTRICITY / 2)
+                * math.exp(lat_iso)
+            )
+            - math.pi / 2
+        )
+
+    return math.degrees(latitude), math.degrees(longitude)

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -13,12 +13,16 @@ from referentiel.value_objects.verse import Verse
 
 from domain.entities.raw_organisme import RawOrganisme
 from domain.value_objects.organisme_referentiel import OrganismeReferentiel
+from infrastructure.gateways.lambert93 import lambert93_to_wgs84
 
 logger = logging.getLogger(__name__)
 
 _DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
 # From https://smt.esante.gouv.fr/fhir/CodeSystem/tre-r397-categorie-entite-geographique-exercice
 _CATEGORIES_CSV = _DATA_DIR / "categories_entite_geographique_exercice.csv"
+
+_MAX_LONGITUDE_DEGREES = 180
+_MAX_LATITUDE_DEGREES = 90
 
 
 def _load_allowed_categories(csv_path: Path) -> set[str]:
@@ -112,8 +116,14 @@ class OrganismesCleaner:
     ) -> tuple[Optional[float], Optional[float]]:
         coordinates = adresse.get("coordonneesGeographique") or {}
         try:
-            longitude = float(coordinates["coordonneeX"])
-            latitude = float(coordinates["coordonneeY"])
+            x = float(coordinates["coordonneeX"])
+            y = float(coordinates["coordonneeY"])
         except (KeyError, TypeError, ValueError):
             return None, None
-        return latitude, longitude
+
+        # FINESS sometimes publishes coordinates projected in Lambert-93
+        # (meters) instead of WGS84 decimal degrees.
+        if abs(x) > _MAX_LONGITUDE_DEGREES or abs(y) > _MAX_LATITUDE_DEGREES:
+            return lambert93_to_wgs84(x, y)
+
+        return y, x

--- a/src/ingestion/tests/unit/test_lambert93.py
+++ b/src/ingestion/tests/unit/test_lambert93.py
@@ -1,0 +1,48 @@
+import math
+
+import pytest
+
+from infrastructure.gateways.lambert93 import lambert93_to_wgs84
+
+# Forward Lambert-93 (RGF93/GRS80) projection, used only to build known test
+# vectors by round-tripping through `lambert93_to_wgs84`. Mirrors the same
+# reference constants (IGN's NTG_71 algorithm) as the inverse implementation.
+_GRS80_ECCENTRICITY = 0.08181919112823853
+_LAMBERT93_N = 0.7256077650
+_LAMBERT93_C = 11754255.426
+_LAMBERT93_XS = 700000.0
+_LAMBERT93_YS = 12655612.0499
+_LAMBERT93_LON0 = math.radians(3.0)
+
+
+def _wgs84_to_lambert93(latitude: float, longitude: float) -> tuple[float, float]:
+    phi = math.radians(latitude)
+    lam = math.radians(longitude)
+    e = _GRS80_ECCENTRICITY
+    lat_iso = math.log(math.tan(math.pi / 4 + phi / 2)) - e / 2 * math.log(
+        (1 + e * math.sin(phi)) / (1 - e * math.sin(phi))
+    )
+    r = _LAMBERT93_C * math.exp(-_LAMBERT93_N * lat_iso)
+    gamma = _LAMBERT93_N * (lam - _LAMBERT93_LON0)
+    x = _LAMBERT93_XS + r * math.sin(gamma)
+    y = _LAMBERT93_YS - r * math.cos(gamma)
+    return x, y
+
+
+@pytest.mark.parametrize(
+    "latitude,longitude",
+    [
+        (48.8566, 2.3522),  # Paris
+        (43.2965, 5.3698),  # Marseille
+        (45.7640, 4.8357),  # Lyon
+        (41.9174, 8.7386),  # Corsica (edge of metropolitan France)
+        (16.2650, -61.5510),  # Guadeloupe (overseas, negative longitude)
+    ],
+)
+def test_lambert93_to_wgs84_round_trips(latitude: float, longitude: float):
+    x, y = _wgs84_to_lambert93(latitude, longitude)
+
+    result_latitude, result_longitude = lambert93_to_wgs84(x, y)
+
+    assert result_latitude == pytest.approx(latitude, abs=1e-6)
+    assert result_longitude == pytest.approx(longitude, abs=1e-6)

--- a/src/ingestion/tests/unit/test_organismes_cleaner.py
+++ b/src/ingestion/tests/unit/test_organismes_cleaner.py
@@ -165,3 +165,18 @@ def test_coordinates_are_none_when_missing(cleaner: OrganismesCleaner):
     assert organisme.localisation is not None
     assert organisme.localisation.latitude is None
     assert organisme.localisation.longitude is None
+
+
+def test_coordinates_are_converted_from_lambert93(cleaner: OrganismesCleaner):
+    # Lambert-93 projection of Nice (43.697073, 7.254944), the WGS84 point
+    # used by the other tests in this file.
+    raw_organisme = _raw_organisme(
+        _ege(coordonnee_x="1042920.75", coordonnee_y="6297912.66")
+    )
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.localisation is not None
+    assert organisme.localisation.latitude == pytest.approx(43.697073, abs=1e-4)
+    assert organisme.localisation.longitude == pytest.approx(7.254944, abs=1e-4)


### PR DESCRIPTION
## 📝 Description

FINESS publie les coordonnées en WGS84 ou en Lambert selon les cas 🙈 En attendant que les données soient corrigées, vérifie les 2 formats.

https://github.com/ansforge/finess/issues/24

## 🏷️ Type de changement
- [x] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [ ] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
