### PR TITLE
🐛(ingestion) ne garder que les EGE FINESS actifs et porteurs

### DIFF
--- a/src/ingestion/infrastructure/external_gateways/finess_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/finess_organisme_gateway.py
@@ -106,6 +106,12 @@ class FinessOrganismeGateway(IOrganismeGateway):
             numero_finess = infos.get("numFinessEge")
             if not numero_finess:
                 continue
+            if ege.get("etatObjet") != "A":
+                continue
+            ege_id = infos.get("egeId")
+            roles_ege = ege.get("roleEge") or []
+            if not any(role.get("idEgePorteuse") == ege_id for role in roles_ege):
+                continue
             yield OrganismeData(
                 referentiel=OrganismeReferentiel.FINESS,
                 external_id=numero_finess,

--- a/src/ingestion/tests/unit/test_finess_organisme_gateway.py
+++ b/src/ingestion/tests/unit/test_finess_organisme_gateway.py
@@ -119,9 +119,7 @@ class TestStreamOrganismes:
 
         assert [r.external_id for r in results] == ["123456789"]
 
-    def test_skips_ege_with_non_active_etat_objet(
-        self, gateway, httpx_mock: HTTPXMock
-    ):
+    def test_skips_ege_with_non_active_etat_objet(self, gateway, httpx_mock: HTTPXMock):
         content = _gzipped_structures(
             [
                 {
@@ -142,9 +140,7 @@ class TestStreamOrganismes:
     def test_skips_ege_when_not_porteuse(self, gateway, httpx_mock: HTTPXMock):
         non_porteuse = _ege("123456789", ege_id="50477")
         non_porteuse["roleEge"] = [{"idEgePorteuse": "99999"}]
-        content = _gzipped_structures(
-            [{"ege": [non_porteuse, _ege("987654321")]}]
-        )
+        content = _gzipped_structures([{"ege": [non_porteuse, _ege("987654321")]}])
         httpx_mock.add_response(method="GET", url="https://x/daily", content=content)
         resource = _resource("https://x/daily")
 

--- a/src/ingestion/tests/unit/test_finess_organisme_gateway.py
+++ b/src/ingestion/tests/unit/test_finess_organisme_gateway.py
@@ -28,9 +28,17 @@ def _gzipped_structures(pmej: list[dict]) -> bytes:
     return gzip.compress(json.dumps({"pmej": pmej}).encode())
 
 
-def _ege(numero_finess: str, **extra) -> dict:
+def _ege(
+    numero_finess: str, etat_objet: str = "A", ege_id: str = "50477", **extra
+) -> dict:
     return {
-        "informationsGeneralesEGE": {"numFinessEge": numero_finess, **extra},
+        "etatObjet": etat_objet,
+        "informationsGeneralesEGE": {
+            "numFinessEge": numero_finess,
+            "egeId": ege_id,
+            **extra,
+        },
+        "roleEge": [{"idEgePorteuse": ege_id}],
     }
 
 
@@ -110,6 +118,39 @@ class TestStreamOrganismes:
         results = list(gateway.stream_organismes(resource))
 
         assert [r.external_id for r in results] == ["123456789"]
+
+    def test_skips_ege_with_non_active_etat_objet(
+        self, gateway, httpx_mock: HTTPXMock
+    ):
+        content = _gzipped_structures(
+            [
+                {
+                    "ege": [
+                        _ege("123456789", etat_objet="I"),
+                        _ege("987654321"),
+                    ]
+                }
+            ]
+        )
+        httpx_mock.add_response(method="GET", url="https://x/daily", content=content)
+        resource = _resource("https://x/daily")
+
+        results = list(gateway.stream_organismes(resource))
+
+        assert [r.external_id for r in results] == ["987654321"]
+
+    def test_skips_ege_when_not_porteuse(self, gateway, httpx_mock: HTTPXMock):
+        non_porteuse = _ege("123456789", ege_id="50477")
+        non_porteuse["roleEge"] = [{"idEgePorteuse": "99999"}]
+        content = _gzipped_structures(
+            [{"ege": [non_porteuse, _ege("987654321")]}]
+        )
+        httpx_mock.add_response(method="GET", url="https://x/daily", content=content)
+        resource = _resource("https://x/daily")
+
+        results = list(gateway.stream_organismes(resource))
+
+        assert [r.external_id for r in results] == ["987654321"]
 
     def test_pmej_without_ege_yields_nothing(self, gateway, httpx_mock: HTTPXMock):
         content = _gzipped_structures([{}])


### PR DESCRIPTION
## 📝 Description

Quand une structure possède plusieurs établissements pour le même SIRET, ne garder que l'établissement "porteur" et la structure active.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
