### PR TITLE
🔒️(ci) empêcher l'injection de script via titre de PR et nom de branche

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -53,8 +53,10 @@ jobs:
         with:
           python-version-file: "./dev/.python-version"
       - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          uv run cz check --message "${{ github.event.pull_request.title }}"
+          uv run cz check --message "$PR_TITLE"
 
   lint-format:
     needs: build-dev

--- a/.github/workflows/storybook_pages.yml
+++ b/.github/workflows/storybook_pages.yml
@@ -202,8 +202,10 @@ jobs:
           ref: gh-pages
       - name: Sanitize branch name
         id: branch
+        env:
+          BRANCH_REF: ${{ github.event.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.ref }}"
+          BRANCH_NAME="$BRANCH_REF"
           SANITIZED=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-50)
           echo "name=$SANITIZED" >> $GITHUB_OUTPUT
       - name: Remove branch preview folder


### PR DESCRIPTION
## 📝 Description

Les valeurs non fiables (titre de PR, ref de branche supprimée) étaient interpolées directement dans des blocs run:, permettant l'exécution de commandes shell arbitraires. Elles passent désormais par des variables d'environnement intermédiaires, traitées comme données et non comme code.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
