### PR TITLE
✨(ingestion) importe les organismes de la DILA pour le versant FPE

### DIFF
--- a/src/ingestion/api/config.py
+++ b/src/ingestion/api/config.py
@@ -26,6 +26,12 @@ class Settings(BaseSettings):
         "https://emploi-territorial.fr/api/cdg/collectivites?limit=1000"
     )
 
+    # https://api-lannuaire.service-public.fr/api/explore/v2.1/console
+    dila_export_url: HttpUrl = HttpUrl(
+        "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/"
+        "api-lannuaire-administration/exports/csv"
+    )
+
     web_base_url: str | None = None
     web_api_key: str | None = None
 

--- a/src/ingestion/domain/value_objects/organisme_referentiel.py
+++ b/src/ingestion/domain/value_objects/organisme_referentiel.py
@@ -4,3 +4,4 @@ from enum import StrEnum
 class OrganismeReferentiel(StrEnum):
     FINESS = "FINESS"
     GIPCDG = "GIPCDG"
+    DILA = "DILA"

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -35,6 +35,9 @@ from domain.value_objects.talentsoft_credential import TalentsoftCredential
 from infrastructure.credentials_store import CredentialsStore
 from infrastructure.database import make_engine
 from infrastructure.external_gateways.base_web_gateway import WebGatewayCredentials
+from infrastructure.external_gateways.dila_organisme_gateway import (
+    DilaOrganismeGateway,
+)
 from infrastructure.external_gateways.finess_organisme_gateway import (
     FinessOrganismeGateway,
 )
@@ -165,6 +168,18 @@ class Container(containers.DeclarativeContainer):
         )
     )
 
+    dila_organisme_gateway: providers.Provider[IOrganismeGateway] = providers.Singleton(
+        DilaOrganismeGateway
+    )
+
+    import_organismes_dila_usecase: providers.Provider[ImportOrganismesUsecase] = (
+        providers.Factory(
+            ImportOrganismesUsecase,
+            organisme_gateway=dila_organisme_gateway,
+            raw_organisme_repository=raw_organisme_repository,
+        )
+    )
+
     organismes_cleaner: providers.Provider[IOrganismesCleaner] = providers.Singleton(
         OrganismesCleaner
     )
@@ -290,6 +305,8 @@ def import_organismes_usecase_for(
 ) -> ImportOrganismesUsecase:
     if referentiel == OrganismeReferentiel.GIPCDG:
         return container.import_organismes_gipcdg_usecase()
+    if referentiel == OrganismeReferentiel.DILA:
+        return container.import_organismes_dila_usecase()
     return container.import_organismes_usecase()
 
 

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -169,7 +169,8 @@ class Container(containers.DeclarativeContainer):
     )
 
     dila_organisme_gateway: providers.Provider[IOrganismeGateway] = providers.Singleton(
-        DilaOrganismeGateway
+        DilaOrganismeGateway,
+        export_url=config.dila_export_url,
     )
 
     import_organismes_dila_usecase: providers.Provider[ImportOrganismesUsecase] = (
@@ -321,6 +322,7 @@ def create_container() -> Container:
     container.config.gipcdg_collectivites_api_url.from_value(
         str(settings.gipcdg_collectivites_api_url)
     )
+    container.config.dila_export_url.from_value(str(settings.dila_export_url))
 
     _logger = logging.getLogger(__name__)
     register_talentsoft_front_clients(

--- a/src/ingestion/infrastructure/external_gateways/dila_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/dila_organisme_gateway.py
@@ -11,21 +11,17 @@ from domain.value_objects.organisme import OrganismeData, OrganismeImportResourc
 from domain.value_objects.organisme_referentiel import OrganismeReferentiel
 from infrastructure.exceptions.exceptions import ExternalApiError
 
-# https://api-lannuaire.service-public.fr/api/explore/v2.1/console
-DILA_EXPORT_URL = (
-    "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/"
-    "api-lannuaire-administration/exports/csv"
-)
 # Catégorie DILA correspondant aux services de l'État (versant FPE).
 CATEGORIE_FPE = "SI"
 
 
 class DilaOrganismeGateway(IOrganismeGateway):
-    def __init__(self, timeout: int = 120):
+    def __init__(self, export_url: str, timeout: int = 120):
+        self.export_url = export_url
         self.timeout = timeout
 
     def find_resource(self) -> OrganismeImportResource:
-        return OrganismeImportResource(url=DILA_EXPORT_URL, millesime=date.today())
+        return OrganismeImportResource(url=self.export_url, millesime=date.today())
 
     def stream_organismes(
         self, resource: OrganismeImportResource

--- a/src/ingestion/infrastructure/external_gateways/dila_organisme_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/dila_organisme_gateway.py
@@ -1,0 +1,86 @@
+import csv
+import io
+import json
+from datetime import date
+from typing import Iterator
+
+import httpx
+
+from domain.gateways.organisme_gateway import IOrganismeGateway
+from domain.value_objects.organisme import OrganismeData, OrganismeImportResource
+from domain.value_objects.organisme_referentiel import OrganismeReferentiel
+from infrastructure.exceptions.exceptions import ExternalApiError
+
+# https://api-lannuaire.service-public.fr/api/explore/v2.1/console
+DILA_EXPORT_URL = (
+    "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/"
+    "api-lannuaire-administration/exports/csv"
+)
+# Catégorie DILA correspondant aux services de l'État (versant FPE).
+CATEGORIE_FPE = "SI"
+
+
+class DilaOrganismeGateway(IOrganismeGateway):
+    def __init__(self, timeout: int = 120):
+        self.timeout = timeout
+
+    def find_resource(self) -> OrganismeImportResource:
+        return OrganismeImportResource(url=DILA_EXPORT_URL, millesime=date.today())
+
+    def stream_organismes(
+        self, resource: OrganismeImportResource
+    ) -> Iterator[OrganismeData]:
+        rows = self._fetch_rows(resource.url)
+        parent_of = self._build_parent_of(rows)
+
+        for row in rows:
+            if row.get("categorie") != CATEGORIE_FPE:
+                continue
+            external_id = row.get("id")
+            if not external_id:
+                continue
+            data = dict(row)
+            data["parent_id"] = parent_of.get(external_id, "")
+            yield OrganismeData(
+                referentiel=OrganismeReferentiel.DILA,
+                external_id=external_id,
+                data=data,
+            )
+
+    @staticmethod
+    def _build_parent_of(rows: list[dict]) -> dict[str, str]:
+        # Le champ "hierarchie" d'un service liste ses propres enfants
+        # ("Service Fils") : on reconstruit donc la relation inverse
+        # enfant -> parent.
+        parent_of: dict[str, str] = {}
+        for row in rows:
+            row_id = row.get("id")
+            hierarchie = row.get("hierarchie")
+            if not row_id or not hierarchie:
+                continue
+            try:
+                items = json.loads(hierarchie)
+            except (TypeError, ValueError):
+                continue
+            for item in items:
+                service = item.get("service")
+                if service:
+                    parent_of[service] = row_id
+        return parent_of
+
+    def _fetch_rows(self, url: str) -> list[dict]:
+        try:
+            response = httpx.get(
+                url,
+                params={"lang": "fr", "timezone": "Europe/Paris", "delimiter": ";"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as err:
+            raise ExternalApiError(
+                "Erreur lors du téléchargement de l'annuaire DILA",
+                details={"url": url, "error": str(err)},
+            ) from err
+
+        reader = csv.DictReader(io.StringIO(response.text), delimiter=";")
+        return list(reader)

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -1,9 +1,10 @@
 import csv
+import json
 import logging
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Optional
-from uuid import uuid4
+from uuid import UUID, uuid4, uuid5
 
 from pydantic import BaseModel, ValidationError, field_validator
 from referentiel.entities.organisme import Organisme
@@ -25,12 +26,30 @@ _CATEGORIES_CSV = _DATA_DIR / "categories_entite_geographique_exercice.csv"
 _MAX_LONGITUDE_DEGREES = 180
 _MAX_LATITUDE_DEGREES = 90
 
+# Namespace utilisé pour dériver un entity_id stable à partir de l'external_id
+# DILA, afin que le parent_id reconstruit à l'import référence le même UUID
+# que celui utilisé pour construire l'organisme parent.
+_DILA_NAMESPACE = uuid5(UUID(int=0), "csplab.ingestion.dila.organisme")
+
+
+def _dila_entity_id(external_id: str) -> UUID:
+    return uuid5(_DILA_NAMESPACE, external_id)
+
 
 def _parse_date(value: Any) -> Optional[date]:
     if not value:
         return None
     try:
         return datetime.strptime(str(value), "%d/%m/%Y").date()
+    except ValueError:
+        return None
+
+
+def _parse_iso_date(value: Any) -> Optional[date]:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
     except ValueError:
         return None
 
@@ -62,6 +81,8 @@ class OrganismesCleaner:
             return self._clean_finess(raw_organisme)
         if raw_organisme.referentiel == OrganismeReferentiel.GIPCDG:
             return self._clean_gipcdg(raw_organisme)
+        if raw_organisme.referentiel == OrganismeReferentiel.DILA:
+            return self._clean_dila(raw_organisme)
         return None
 
     def dedupe_by_siret(self, organismes: list[Organisme]) -> list[Organisme]:
@@ -157,6 +178,69 @@ class OrganismesCleaner:
             millesime=raw_organisme.millesime,
             date_creation=_parse_date(data.get("date_insert_col")),
         )
+
+    def _clean_dila(self, raw_organisme: RawOrganisme) -> Optional[Organisme]:
+        if not raw_organisme.data:
+            return None
+
+        data = raw_organisme.data
+        nom = Nom(value=data.get("nom") or "")
+        siret = SIRET(code=data.get("siret") or "")
+        localisation = self._map_localisation_dila(data, raw_organisme.external_id)
+
+        parent_external_id = data.get("parent_id") or None
+
+        return Organisme.build(
+            entity_id=_dila_entity_id(raw_organisme.external_id),
+            nom=nom.value,
+            versant=Verse.FPE,
+            siret=siret,
+            localisation=localisation,
+            parent_id=_dila_entity_id(parent_external_id)
+            if parent_external_id
+            else None,
+            external_id=raw_organisme.external_id,
+            referentiel=raw_organisme.referentiel,
+            millesime=raw_organisme.millesime,
+            date_creation=_parse_iso_date(data.get("date_creation_datetime")),
+        )
+
+    def _map_localisation_dila(
+        self, data: dict[str, Any], external_id: str
+    ) -> Optional[Localisation]:
+        localisation = None
+        code_insee_commune = data.get("code_insee_commune")
+        if code_insee_commune:
+            try:
+                department = Department.from_commune_code(code_insee_commune)
+                latitude, longitude = self._extract_coordinates_dila(data)
+                localisation = Localisation.from_department(
+                    department, latitude=latitude, longitude=longitude
+                )
+            except (ValidationError, ValueError):
+                logger.warning(
+                    "RawOrganisme %s has validation errors in localisation",
+                    external_id,
+                )
+        return localisation
+
+    @staticmethod
+    def _extract_coordinates_dila(
+        data: dict[str, Any],
+    ) -> tuple[Optional[float], Optional[float]]:
+        try:
+            adresses = json.loads(data.get("adresse") or "[]")
+        except (TypeError, ValueError):
+            return None, None
+
+        for adresse in adresses:
+            try:
+                longitude = float(adresse.get("longitude"))
+                latitude = float(adresse.get("latitude"))
+            except (TypeError, ValueError):
+                continue
+            return latitude, longitude
+        return None, None
 
     def _map_localisation(
         self, data: dict[str, Any], external_id: str

--- a/src/ingestion/tests/unit/test_dila_organisme_gateway.py
+++ b/src/ingestion/tests/unit/test_dila_organisme_gateway.py
@@ -1,0 +1,136 @@
+import json
+from datetime import date
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from domain.value_objects.organisme import OrganismeImportResource
+from infrastructure.exceptions.exceptions import ExternalApiError
+from infrastructure.external_gateways.dila_organisme_gateway import (
+    DILA_EXPORT_URL,
+    DilaOrganismeGateway,
+)
+
+CSV_HEADER = "id;nom;categorie;hierarchie"
+
+
+@pytest.fixture
+def gateway() -> DilaOrganismeGateway:
+    return DilaOrganismeGateway()
+
+
+def _csv_row(*values: str) -> str:
+    return ";".join(values)
+
+
+DILA_EXPORT_URL_WITH_PARAMS = (
+    f"{DILA_EXPORT_URL}?lang=fr&timezone=Europe%2FParis&delimiter=%3B"
+)
+
+
+def _mock_csv_response(httpx_mock: HTTPXMock, rows: list[str]) -> None:
+    body = "\n".join([CSV_HEADER, *rows])
+    httpx_mock.add_response(method="GET", url=DILA_EXPORT_URL_WITH_PARAMS, text=body)
+
+
+class TestFindResource:
+    def test_returns_fixed_url_and_today_millesime(self, gateway: DilaOrganismeGateway):
+        resource = gateway.find_resource()
+
+        assert resource.url == DILA_EXPORT_URL
+        assert resource.millesime == date.today()
+
+
+class TestStreamOrganismes:
+    def test_yields_only_fpe_categorie(
+        self, gateway: DilaOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        _mock_csv_response(
+            httpx_mock,
+            [
+                _csv_row("id-1", "Ministère 1", "SI", ""),
+                _csv_row("id-2", "Mairie 1", "COL", ""),
+            ],
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert [r.external_id for r in results] == ["id-1"]
+        assert all(r.referentiel == "DILA" for r in results)
+
+    def test_skips_rows_without_id(
+        self, gateway: DilaOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        _mock_csv_response(
+            httpx_mock,
+            [
+                _csv_row("", "Ministère 1", "SI", ""),
+                _csv_row("id-2", "Ministère 2", "SI", ""),
+            ],
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert [r.external_id for r in results] == ["id-2"]
+
+    def test_reconstructs_parent_id_from_hierarchie(
+        self, gateway: DilaOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        hierarchie = json.dumps(
+            [{"type_hierarchie": "Service Fils", "service": "child-id"}]
+        )
+        _mock_csv_response(
+            httpx_mock,
+            [
+                _csv_row("parent-id", "Parent", "SI", hierarchie),
+                _csv_row("child-id", "Enfant", "SI", ""),
+            ],
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+        by_id = {r.external_id: r for r in results}
+
+        assert by_id["parent-id"].data["parent_id"] == ""
+        assert by_id["child-id"].data["parent_id"] == "parent-id"
+
+    def test_parent_id_is_empty_string_when_no_parent(
+        self, gateway: DilaOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        _mock_csv_response(httpx_mock, [_csv_row("id-1", "Ministère 1", "SI", "")])
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert results[0].data["parent_id"] == ""
+
+    def test_parent_lookup_uses_full_dataset_not_only_fpe(
+        self, gateway: DilaOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        hierarchie = json.dumps(
+            [{"type_hierarchie": "Service Fils", "service": "child-id"}]
+        )
+        _mock_csv_response(
+            httpx_mock,
+            [
+                _csv_row("parent-id", "Parent non-SI", "COL", hierarchie),
+                _csv_row("child-id", "Enfant", "SI", ""),
+            ],
+        )
+
+        results = list(gateway.stream_organismes(_resource()))
+
+        assert results[0].external_id == "child-id"
+        assert results[0].data["parent_id"] == "parent-id"
+
+    def test_raises_on_http_error(
+        self, gateway: DilaOrganismeGateway, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET", url=DILA_EXPORT_URL_WITH_PARAMS, status_code=500
+        )
+
+        with pytest.raises(ExternalApiError, match="Erreur lors du téléchargement"):
+            list(gateway.stream_organismes(_resource()))
+
+
+def _resource() -> OrganismeImportResource:
+    return OrganismeImportResource(url=DILA_EXPORT_URL, millesime=date.today())

--- a/src/ingestion/tests/unit/test_dila_organisme_gateway.py
+++ b/src/ingestion/tests/unit/test_dila_organisme_gateway.py
@@ -7,16 +7,20 @@ from pytest_httpx import HTTPXMock
 from domain.value_objects.organisme import OrganismeImportResource
 from infrastructure.exceptions.exceptions import ExternalApiError
 from infrastructure.external_gateways.dila_organisme_gateway import (
-    DILA_EXPORT_URL,
     DilaOrganismeGateway,
 )
 
 CSV_HEADER = "id;nom;categorie;hierarchie"
 
+DILA_EXPORT_URL = (
+    "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/"
+    "api-lannuaire-administration/exports/csv"
+)
+
 
 @pytest.fixture
 def gateway() -> DilaOrganismeGateway:
-    return DilaOrganismeGateway()
+    return DilaOrganismeGateway(export_url=DILA_EXPORT_URL)
 
 
 def _csv_row(*values: str) -> str:

--- a/src/ingestion/tests/unit/test_organismes_cleaner.py
+++ b/src/ingestion/tests/unit/test_organismes_cleaner.py
@@ -395,3 +395,151 @@ def test_dedupe_by_siret_falls_back_to_smallest_external_id_when_same_date(
     result = cleaner.dedupe_by_siret([bigger, smaller])
 
     assert result == [smaller]
+
+
+DILA_SIRET_VALUE = "26060047300342"
+
+
+def _dila_service(
+    *,
+    nom: str | None = "Ministère de l'Intérieur",
+    siret: str | None = DILA_SIRET_VALUE,
+    code_insee_commune: str | None = "75101",
+    adresse: str | None = '[{"longitude": "2.309103", "latitude": "48.852116"}]',
+    date_creation_datetime: str | None = "2008-06-30T00:00:00+00:00",
+    parent_id: str | None = "",
+) -> dict:
+    return {
+        "nom": nom,
+        "siret": siret,
+        "code_insee_commune": code_insee_commune,
+        "adresse": adresse,
+        "date_creation_datetime": date_creation_datetime,
+        "parent_id": parent_id,
+    }
+
+
+def _raw_organisme_dila(data: dict | None, external_id: str = "dila-1") -> RawOrganisme:
+    return RawOrganisme(
+        referentiel="DILA",
+        millesime="2026-08-26",
+        external_id=external_id,
+        data=data,
+    )
+
+
+def test_cleans_valid_dila_raw_organisme(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_dila(_dila_service())
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.nom == "Ministère de l'Intérieur"
+    assert organisme.versant == Verse.FPE
+    assert organisme.siret == SIRET(code=DILA_SIRET_VALUE)
+    assert organisme.external_id == "dila-1"
+    assert organisme.referentiel == "DILA"
+    assert organisme.millesime == "2026-08-26"
+    assert organisme.parent_id is None
+    assert organisme.localisation is not None
+    assert organisme.localisation.department.code == "75"
+    assert organisme.localisation.region.code == "11"
+    assert organisme.localisation.latitude == 48.852116
+    assert organisme.localisation.longitude == 2.309103
+    assert organisme.date_creation == date(2008, 6, 30)
+
+
+def test_dila_returns_none_when_no_data(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_dila(None)
+
+    assert cleaner.clean(raw_organisme) is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(_dila_service(siret=None), id="missing_siret"),
+        pytest.param(_dila_service(siret="not-a-siret"), id="invalid_siret"),
+        pytest.param(_dila_service(nom=""), id="missing_nom"),
+    ],
+)
+def test_dila_raises_on_invalid_data(cleaner: OrganismesCleaner, data: dict):
+    raw_organisme = _raw_organisme_dila(data)
+
+    with pytest.raises(ValidationError):
+        cleaner.clean(raw_organisme)
+
+
+def test_dila_parent_id_is_derived_deterministically_from_parent_external_id(
+    cleaner: OrganismesCleaner,
+):
+    parent = cleaner.clean(
+        _raw_organisme_dila(_dila_service(), external_id="parent-id")
+    )
+    child = cleaner.clean(
+        _raw_organisme_dila(
+            _dila_service(parent_id="parent-id"), external_id="child-id"
+        )
+    )
+
+    assert parent is not None
+    assert child is not None
+    assert child.parent_id == parent.entity_id
+
+
+def test_dila_parent_id_is_none_when_no_parent(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_dila(_dila_service(parent_id=""))
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.parent_id is None
+
+
+def test_dila_entity_id_is_stable_across_cleans(cleaner: OrganismesCleaner):
+    first = cleaner.clean(_raw_organisme_dila(_dila_service(), external_id="dila-42"))
+    second = cleaner.clean(_raw_organisme_dila(_dila_service(), external_id="dila-42"))
+
+    assert first is not None
+    assert second is not None
+    assert first.entity_id == second.entity_id
+
+
+@pytest.mark.parametrize(
+    "code_insee_commune",
+    [None, "", "00042"],
+    ids=["missing", "empty", "invalid_commune_code"],
+)
+def test_dila_localisation_is_none(
+    cleaner: OrganismesCleaner, code_insee_commune: str | None
+):
+    raw_organisme = _raw_organisme_dila(
+        _dila_service(code_insee_commune=code_insee_commune)
+    )
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.localisation is None
+
+
+def test_dila_coordinates_are_none_when_no_adresse(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_dila(_dila_service(adresse=None))
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.localisation is not None
+    assert organisme.localisation.latitude is None
+    assert organisme.localisation.longitude is None
+
+
+def test_dila_date_creation_is_none_when_unparseable(cleaner: OrganismesCleaner):
+    raw_organisme = _raw_organisme_dila(
+        _dila_service(date_creation_datetime="not-a-date")
+    )
+
+    organisme = cleaner.clean(raw_organisme)
+
+    assert organisme is not None
+    assert organisme.date_creation is None


### PR DESCRIPTION
## 📝 Description

Ajoute le référentiel DILA (annuaire des services publics) : la gateway télécharge l'export CSV complet, reconstruit le parent_id à partir du champ `hierarchie` (qui ne liste que les enfants de chaque service), puis ne conserve que la catégorie `SI` (FPE). Le nettoyage dérive un `entity_id` stable par uuid5 sur l'`external_id` afin que le `parent_id` d'un organisme référence le même UUID que celui utilisé pour construire son parent.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
