### PR TITLE
🔧(tooling) renforcer les possibilités de diagnostic pour les tests e2e de l'ATS sous playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,9 @@ coverage/
 tests/cov.md
 cov.md
 
+# Playwright failure artifacts (traces, screenshots)
+src/web/test-results/
+
 # Docker Compose local overrides
 docker-compose.override.yml
 

--- a/src/web/pyproject.toml
+++ b/src/web/pyproject.toml
@@ -95,6 +95,10 @@ omit = [
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings.test"
 asyncio_mode = "auto"
+addopts = [
+    "--tracing=retain-on-failure",
+    "--screenshot=only-on-failure",
+]
 python_files = [
     "test_*.py",
     "tests.py",


### PR DESCRIPTION
## 📝 Description
🎸 Les tests e2e ATS (`test_smoke.py`) flakent parfois sans qu'aucune trace ne permette de comprendre pourquoi. Cette PR active la capture de diagnostics Playwright (trace + screenshot) à l'échec, pour pouvoir enfin investiguer la prochaine occurrence au lieu de deviner.

## 🏷️ Type de changement
- [z] 🔧 Changement technique

## 🔧 Modifications
- Config / CI : activation de `--tracing=retain-on-failure` et `--screenshot=only-on-failure` (pytest-playwright) dans `[tool.pytest.ini_options]` de `src/web/pyproject.toml`
- `.gitignore` : exclusion de `src/web/test-results/` (artefacts Playwright générés à l'échec)

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
En cas de tests flaky, executer la suite de tests jusqu'à échec du test
```bash
while pytest --numprocesses=logical --create-db; do :; done
```

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
