### PR TITLE
🔧(tooling) éviter de lancer les tests e2e avec un build du front obsolète

### DIFF
--- a/src/web/tests/presentation/ats/e2e/conftest.py
+++ b/src/web/tests/presentation/ats/e2e/conftest.py
@@ -18,6 +18,23 @@ def require_frontend_build() -> None:
             "Run `make frontend-build` first."
         )
 
+    frontend_src = Path(django_settings.BASE_DIR) / "presentation" / "frontend" / "src"
+    manifest_mtime = manifest.stat().st_mtime
+    stale_sources = [
+        path
+        for path in frontend_src.rglob("*")
+        if path.is_file() and path.stat().st_mtime > manifest_mtime
+    ]
+    if stale_sources:
+        newest = max(stale_sources, key=lambda path: path.stat().st_mtime)
+        pytest.fail(
+            "Frontend build is stale: "
+            f"{newest.relative_to(frontend_src)} was modified after the last "
+            "`make frontend-build`. The e2e tests serve the built SPA, so a stale "
+            "bundle can silently miss recent markup (e.g. a data-testid) without "
+            "any obviously related error. Rebuild it first."
+        )
+
 
 @pytest.fixture(autouse=True)
 def insecure_cookies(settings) -> None:


### PR DESCRIPTION
## 📝 Description
🎸 Cette PR fait échouer les tests e2e immédiatement, avec un message clair, si le build est périmé.

## 🏷️ Type de changement
- [x] 🔧 Changement technique



🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
1. `make frontend-build && make test-e2e` : doit passer normalement
3. `touch src/web/presentation/frontend/src/main.ts` puis relancer `make test-e2e` : doit échouer immédiatement avec le message "Frontend build is stale: ...", avant même de lancer un navigateur


## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
