### PR TITLE
♻️(ci) use mise in ingestion CI workflow

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -23,6 +23,8 @@ jobs:
           filters: |
             relevant:
               - "src/ingestion/**"
+              - "mise.toml"
+              - "mise.ci.toml"
               - ".github/workflows/ingestion.yml"
               - ".github/actions/**"
 
@@ -32,9 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-uv-python
-        with:
-          service-path: src/ingestion
+      - uses: ./.github/actions/setup-mise
+      - name: Install ingestion dependencies
+        run: mise run ingestion:install
 
   lint-ingestion:
     needs: [check-changes, build-ingestion]
@@ -54,26 +56,17 @@ jobs:
           --health-retries 10
         ports:
           - 5432:5432
-    defaults:
-      run:
-        working-directory: ./src/ingestion
-    env:
-      DATABASE_URL: postgresql+psycopg2://postgres:pass@localhost:5432/ingestion
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-uv-python
-        with:
-          service-path: src/ingestion
+      - uses: ./.github/actions/setup-mise
+      - name: Install ingestion dependencies
+        run: mise run ingestion:install
       - name: Lint with Ruff
-        run: uv run ruff check .
-      - name: Lint format with Ruff
-        run: uv run ruff format --check .
+        run: mise run ingestion:lint:ruff
       - name: Lint with MyPy
-        run: uv run mypy .
+        run: mise run ingestion:lint:mypy
       - name: Check no migrations are missing
-        run: |
-          uv run alembic upgrade head
-          uv run alembic check
+        run: mise run ingestion:lint:migrations
 
   test-ingestion:
     needs: [check-changes, build-ingestion]
@@ -93,18 +86,13 @@ jobs:
           --health-retries 10
         ports:
           - 5432:5432
-    defaults:
-      run:
-        working-directory: ./src/ingestion
-    env:
-      DATABASE_URL: postgresql+psycopg2://postgres:pass@localhost:5432/ingestion
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-uv-python
-        with:
-          service-path: src/ingestion
+      - uses: ./.github/actions/setup-mise
+      - name: Install ingestion dependencies
+        run: mise run ingestion:install
       - name: Test with pytest
-        run: uv run pytest --cov=. --cov-report=term-missing --cov-fail-under=95
+        run: mise run ingestion:test -- --cov=. --cov-report=term-missing --cov-fail-under=95
 
   deploy-ingestion:
     needs: [check-changes, lint-ingestion, test-ingestion]

--- a/docs/mise.md
+++ b/docs/mise.md
@@ -90,6 +90,6 @@ alias = "mt"
 
 ## CI
 
-Le workflow `web.yml` sélectionne l'environnement `MISE_ENV=ci`, qui charge `mise.ci.toml` par-dessus `mise.toml`, qui remplace les tâches `services:*` par des no-ops, les services étant fournis par les containers du workflow.
+Les workflows `web.yml` et `ingestion.yml` sélectionnent l'environnement `MISE_ENV=ci`, qui charge `mise.ci.toml` par-dessus `mise.toml`, qui remplace les tâches `services:*` par des no-ops, les services étant fournis par les containers du workflow. `src/ingestion/mise.ci.toml` neutralise en plus ses tâches `db:create*` et pointe `DATABASE_URL`/`TEST_DATABASE_URL` vers le service Postgres du job.
 
-`MISE_ENV=ci mise run web:test` reproduit ce contexte en local.
+`MISE_ENV=ci mise run web:test` ou `MISE_ENV=ci mise run ingestion:test` reproduisent ce contexte en local.

--- a/src/ingestion/mise.ci.toml
+++ b/src/ingestion/mise.ci.toml
@@ -1,0 +1,17 @@
+# Loaded over mise.toml (and the root mise.ci.toml) when MISE_ENV=ci: the
+# workflow provides Postgres as a service container with the "ingestion"
+# database already created, so db:create* are neutralised.
+
+[env]
+DATABASE_URL = "postgresql+psycopg2://postgres:pass@localhost:5432/ingestion"
+TEST_DATABASE_URL = "psql://postgres:pass@localhost:5432/ingestion"
+
+[tasks."db:create"]
+alias = "ingestion:db:create"
+description = "Create the ingestion database and user"
+run = "true"
+
+[tasks."db:create-test"]
+alias = "ingestion:db:create-test"
+description = "Create the ingestion_test database"
+run = "true"


### PR DESCRIPTION


## 📝 Description

Suite de #1284 : la CI ingestion exécute désormais les tâches mise, comme web. `src/ingestion/mise.ci.toml` neutralise `db:create*` (le service postgres du job fournit déjà la base "ingestion") et pointe `DATABASE_URL` / `TEST_DATABASE_URL` dessus.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
