### PR TITLE
💎(ats-presentation) improve table based pages styling

### DIFF
--- a/src/web/presentation/frontend/src/components/base/CspDataTable/CspDataTable.vue
+++ b/src/web/presentation/frontend/src/components/base/CspDataTable/CspDataTable.vue
@@ -59,7 +59,7 @@ const tableColumns = computed(() =>
     columnHelper.accessor((row: TRow) => col.accessor?.(row) ?? '', {
       id: col.id,
       enableSorting: col.sortable ?? false,
-      meta: { align: col.align, width: col.width, label: col.header, cellComponent: col.cellComponent },
+      meta: { align: col.align, width: col.width, wrapHeader: col.wrapHeader, label: col.header, cellComponent: col.cellComponent },
     }),
   ),
 )
@@ -285,7 +285,7 @@ function onActivate(id: string): void {
               :key="header.id"
               scope="col"
               class="csp-table__th"
-              :class="alignClass(columnAlign(header.column), 'th')"
+              :class="[alignClass(columnAlign(header.column), 'th'), { 'csp-table__th--wrap': header.column.columnDef.meta?.wrapHeader }]"
               :aria-sort="header.column.getCanSort() ? ariaSort(header.column) : undefined"
               :style="columnWidth(header.column) ? { width: columnWidth(header.column) } : undefined"
             >
@@ -475,6 +475,10 @@ function onActivate(id: string): void {
 
 .csp-table__th--center {
   text-align: center;
+}
+
+.csp-table__th--wrap {
+  white-space: normal;
 }
 
 .csp-table__th--end {

--- a/src/web/presentation/frontend/src/components/base/CspDataTable/table.ts
+++ b/src/web/presentation/frontend/src/components/base/CspDataTable/table.ts
@@ -11,6 +11,7 @@ export interface CspColumnDef<TRow> {
   sortable?: boolean
   align?: CspTableAlign
   width?: string
+  wrapHeader?: boolean
   accessor?: (row: TRow) => CspTableCellValue
   cellComponent?: Component
 }
@@ -21,6 +22,7 @@ declare module '@tanstack/vue-table' {
     _value?: TValue
     align?: CspTableAlign
     width?: string
+    wrapHeader?: boolean
     label?: string
     cellComponent?: Component
   }

--- a/src/web/presentation/frontend/src/components/base/CspTableToolbar/CspTableToolbar.stories.ts
+++ b/src/web/presentation/frontend/src/components/base/CspTableToolbar/CspTableToolbar.stories.ts
@@ -1,0 +1,80 @@
+import type { ComponentPropsAndSlots, StoryObj } from '@storybook/vue3-vite'
+import CspButton from '@/components/base/CspButton/CspButton.vue'
+import CspInput from '@/components/base/CspInput/CspInput.vue'
+import CspTableToolbar from '@/components/base/CspTableToolbar/CspTableToolbar.vue'
+
+type CspTableToolbarProps = ComponentPropsAndSlots<typeof CspTableToolbar>
+
+const meta = {
+  title: 'Éléments/Génériques/CspTableToolbar',
+  component: CspTableToolbar,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: 'Barre d\'outils à placer immédiatement au-dessus d\'une table : compteur à gauche, recherche et actions à droite. Quand `selectionCount` est renseigné, la barre bascule en mode sélection et affiche le slot `selection-actions` pour les actions en lot.',
+      },
+    },
+  },
+  argTypes: {
+    count: {
+      control: { type: 'text' },
+      description: 'Libellé du compteur affiché à gauche (remplaçable par le slot `status`).',
+      table: { type: { summary: 'string' } },
+    },
+    selectionCount: {
+      control: { type: 'number' },
+      description: 'Nombre d\'éléments sélectionnés ; au-dessus de zéro, la barre passe en mode sélection.',
+      table: { type: { summary: 'number' }, defaultValue: { summary: '0' } },
+    },
+    bordered: {
+      control: { type: 'boolean' },
+      description: 'Bordure haute de séparation ; à désactiver quand la barre suit immédiatement une autre bordure (p. ex. la barre d\'onglets).',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'true' } },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<CspTableToolbarProps>
+
+export const ParDefaut: Story = {
+  args: {
+    count: '12 éléments',
+  },
+  render: args => ({
+    components: { CspTableToolbar, CspButton, CspInput },
+    setup: () => ({ args }),
+    template: `
+      <CspTableToolbar v-bind="args">
+        <CspInput
+          type="search"
+          aria-label="Rechercher un élément"
+          placeholder="Rechercher un élément"
+          style="min-width: 20rem"
+        />
+        <CspButton label="Ajouter" icon="ri:add-line" is-icon-left />
+      </CspTableToolbar>
+    `,
+  }),
+}
+
+export const ModeSelection: Story = {
+  args: {
+    count: '12 éléments',
+    selectionCount: 3,
+  },
+  render: args => ({
+    components: { CspTableToolbar, CspButton },
+    setup: () => ({ args }),
+    template: `
+      <CspTableToolbar v-bind="args">
+        <template #selection-actions>
+          <CspButton label="Exporter" variant="secondary" />
+          <CspButton label="Supprimer" variant="secondary" icon="ri:delete-bin-line" is-icon-left />
+        </template>
+      </CspTableToolbar>
+    `,
+  }),
+}

--- a/src/web/presentation/frontend/src/components/base/CspTableToolbar/CspTableToolbar.vue
+++ b/src/web/presentation/frontend/src/components/base/CspTableToolbar/CspTableToolbar.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { pluralize } from '@/utils/format'
+
+withDefaults(defineProps<{
+  count?: string
+  selectionCount?: number
+  bordered?: boolean
+}>(), {
+  count: undefined,
+  selectionCount: 0,
+  bordered: true,
+})
+</script>
+
+<template>
+  <div
+    class="csp-table-toolbar"
+    :class="{
+      'csp-table-toolbar--selection': selectionCount > 0,
+      'csp-table-toolbar--bordered': bordered,
+    }"
+  >
+    <template v-if="selectionCount > 0">
+      <p class="csp-table-toolbar__count">
+        {{ selectionCount }} {{ pluralize(selectionCount, 'sélectionné') }}
+      </p>
+      <div class="csp-table-toolbar__actions">
+        <slot name="selection-actions" />
+      </div>
+    </template>
+    <template v-else>
+      <slot name="status">
+        <p class="csp-table-toolbar__count">
+          {{ count }}
+        </p>
+      </slot>
+      <div class="csp-table-toolbar__actions">
+        <slot />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.csp-table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--csp-space-4);
+  padding: var(--csp-space-3) 0;
+}
+
+.csp-table-toolbar--bordered {
+  border-top: 1px solid var(--border-default-grey);
+}
+
+.csp-table-toolbar__count {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--text-mention-grey);
+}
+
+.csp-table-toolbar--selection .csp-table-toolbar__count {
+  color: var(--text-default-grey);
+  font-weight: 500;
+}
+
+.csp-table-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--csp-space-3);
+}
+</style>

--- a/src/web/presentation/frontend/src/components/layout/CspPageContainer/CspPageContainer.stories.ts
+++ b/src/web/presentation/frontend/src/components/layout/CspPageContainer/CspPageContainer.stories.ts
@@ -21,11 +21,11 @@ const meta = {
   argTypes: {
     width: {
       control: { type: 'select' },
-      options: ['reading', 'wide', 'full'],
+      options: ['reading', 'wide', 'large', 'full'],
       description: 'Largeur du contenu.',
       table: {
         type: {
-          summary: '\'reading\' | \'wide\' | \'full\'',
+          summary: '\'reading\' | \'wide\' | \'large\' | \'full\'',
         },
         defaultValue: {
           summary: '\'wide\'',
@@ -46,7 +46,7 @@ export const Widths: Story = {
   render: (args: CspPageContainerProps) => ({
     components: { CspPageContainer },
     setup() {
-      const widths = ['reading', 'wide', 'full'] as const
+      const widths = ['reading', 'wide', 'large', 'full'] as const
       return { args, widths }
     },
     template: `

--- a/src/web/presentation/frontend/src/components/layout/CspPageContainer/CspPageContainer.vue
+++ b/src/web/presentation/frontend/src/components/layout/CspPageContainer/CspPageContainer.vue
@@ -6,7 +6,7 @@ import CspTabsPanels from '@/components/base/CspTabs/CspTabsPanels.vue'
 
 withDefaults(defineProps<{
   fill?: boolean
-  width?: 'reading' | 'wide' | 'full'
+  width?: 'reading' | 'wide' | 'large' | 'full'
   tabs?: CspTabItem<T>[]
 }>(), {
   fill: false,
@@ -23,6 +23,7 @@ const activeTab = defineModel<T>('activeTab')
       'csp-page-container--fill': fill,
       'csp-page-container--reading': width === 'reading',
       'csp-page-container--wide': width === 'wide',
+      'csp-page-container--large': width === 'large',
     }"
   >
     <CspTabs
@@ -104,6 +105,11 @@ const activeTab = defineModel<T>('activeTab')
 .csp-page-container--wide .csp-page-container__content,
 .csp-page-container--wide .csp-page-container__shared {
   max-width: var(--csp-page-container-wide-width);
+}
+
+.csp-page-container--large .csp-page-container__content,
+.csp-page-container--large .csp-page-container__shared {
+  max-width: var(--csp-page-container-large-width);
 }
 
 .csp-page-container--fill .csp-page-container__content--with-tabs {

--- a/src/web/presentation/frontend/src/features/organismes/columns.ts
+++ b/src/web/presentation/frontend/src/features/organismes/columns.ts
@@ -20,11 +20,11 @@ export const ORGANISMES_LIST_COLUMNS: CspColumnDef<OrganismesList>[] = [
 ]
 
 export const ORGANISME_AGENTS_COLUMNS: CspColumnDef<AgentOrganisme>[] = [
-  { id: 'agent', header: 'Membre', sortable: true, accessor: row => formatAgentNameAlphabetical(row) },
-  { id: 'role', header: 'Rôle', accessor: row => formatAgentRole(row.role) },
+  { id: 'agent', header: 'Membre', sortable: true, width: '13rem', accessor: row => formatAgentNameAlphabetical(row) },
+  { id: 'role', header: 'Rôle', width: '8rem', accessor: row => formatAgentRole(row.role) },
   { id: 'poste', header: 'Poste', accessor: row => row.poste },
   { id: 'email', header: 'Courriel', accessor: row => row.email },
   { id: 'date_derniere_activite', header: 'Dernière activité', sortable: true, width: '9.5rem', wrapHeader: true, accessor: row => row.date_derniere_activite, cellComponent: ElapsedDaysCell },
-  { id: 'date_creation_compte', header: 'Création de compte', accessor: row => shortDate.format(new Date(row.date_creation_compte)) },
+  { id: 'date_creation_compte', header: 'Création de compte', width: '9.5rem', wrapHeader: true, accessor: row => shortDate.format(new Date(row.date_creation_compte)) },
   { id: 'actions', header: '', align: 'end', width: '3.5rem', cellComponent: AgentActionsCell },
 ]

--- a/src/web/presentation/frontend/src/features/organismes/columns.ts
+++ b/src/web/presentation/frontend/src/features/organismes/columns.ts
@@ -10,12 +10,12 @@ import { formatAgentNameAlphabetical, formatAgentRole } from './format'
 
 export const ORGANISMES_LIST_COLUMNS: CspColumnDef<OrganismesList>[] = [
   { id: 'nom', header: 'Nom organisme', sortable: true, accessor: row => row.nom, cellComponent: OrganismeNomCell },
-  { id: 'siret', header: 'SIRET', accessor: row => row.siret },
-  { id: 'gestionnaire', header: 'Gestionnaire', sortable: true, accessor: row => row.gestionnaire },
-  { id: 'gestion_ats', header: 'Recrutements sur l\'outil', accessor: row => row.gestion_ats ? 'Oui' : 'Non' },
-  { id: 'date_derniere_activite', header: 'Dernière activité', sortable: true, accessor: row => row.date_derniere_activite, cellComponent: ElapsedDaysCell },
-  { id: 'nombre_agents', header: 'Nombre d\'agents', accessor: row => row.nombre_agents },
-  { id: 'nombre_offres_publiees', header: 'Nombre de recrutements', accessor: row => row.nombre_offres_publiees },
+  { id: 'siret', header: 'SIRET', width: '9.5rem', accessor: row => row.siret },
+  { id: 'gestionnaire', header: 'Gestionnaire', sortable: true, width: '11rem', accessor: row => row.gestionnaire },
+  { id: 'gestion_ats', header: 'Recrutements sur l\'outil', width: '8.5rem', wrapHeader: true, accessor: row => row.gestion_ats ? 'Oui' : 'Non' },
+  { id: 'date_derniere_activite', header: 'Dernière activité', sortable: true, width: '9.5rem', wrapHeader: true, accessor: row => row.date_derniere_activite, cellComponent: ElapsedDaysCell },
+  { id: 'nombre_agents', header: 'Nombre d\'agents', align: 'end', width: '7rem', wrapHeader: true, accessor: row => row.nombre_agents },
+  { id: 'nombre_offres_publiees', header: 'Nombre de recrutements', align: 'end', width: '8.5rem', wrapHeader: true, accessor: row => row.nombre_offres_publiees },
   { id: 'actions', header: '', align: 'end', width: '3.5rem', cellComponent: OrganismeActionsCell },
 ]
 
@@ -24,7 +24,7 @@ export const ORGANISME_AGENTS_COLUMNS: CspColumnDef<AgentOrganisme>[] = [
   { id: 'role', header: 'Rôle', accessor: row => formatAgentRole(row.role) },
   { id: 'poste', header: 'Poste', accessor: row => row.poste },
   { id: 'email', header: 'Courriel', accessor: row => row.email },
-  { id: 'date_derniere_activite', header: 'Dernière activité', sortable: true, accessor: row => row.date_derniere_activite, cellComponent: ElapsedDaysCell },
+  { id: 'date_derniere_activite', header: 'Dernière activité', sortable: true, width: '9.5rem', wrapHeader: true, accessor: row => row.date_derniere_activite, cellComponent: ElapsedDaysCell },
   { id: 'date_creation_compte', header: 'Création de compte', accessor: row => shortDate.format(new Date(row.date_creation_compte)) },
   { id: 'actions', header: '', align: 'end', width: '3.5rem', cellComponent: AgentActionsCell },
 ]

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismeAgentsSection.vue
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismeAgentsSection.vue
@@ -6,6 +6,7 @@ import CspDataTable from '@/components/base/CspDataTable/CspDataTable.vue'
 import CspDialog from '@/components/base/CspDialog/CspDialog.vue'
 import CspInput from '@/components/base/CspInput/CspInput.vue'
 import CspSkeletonTable from '@/components/base/CspSkeleton/CspSkeletonTable.vue'
+import CspTableToolbar from '@/components/base/CspTableToolbar/CspTableToolbar.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
 import { useTextSearch } from '@/composables/data/useTextSearch'
 import { useToast } from '@/composables/ui/useToast'
@@ -121,10 +122,7 @@ async function handleRevocation(): Promise<void> {
         />
       </template>
 
-      <div class="organisme-agents-section__header">
-        <p class="organisme-agents-section__count">
-          {{ countLabel }}
-        </p>
+      <CspTableToolbar :count="countLabel">
         <CspInput
           v-model="search"
           type="search"
@@ -132,16 +130,30 @@ async function handleRevocation(): Promise<void> {
           placeholder="Rechercher un membre, un courriel"
           class="organisme-agents-section__search"
         />
-      </div>
+      </CspTableToolbar>
       <CspDataTable
         v-model:page="page"
         :rows="filtered"
         :columns="ORGANISME_AGENTS_COLUMNS"
         :row-key="row => row.agent_id"
         caption="Membres de l'organisme"
-        empty-label="Aucun membre"
         :page-size="PAGE_SIZE"
-      />
+      >
+        <template #empty>
+          <div class="organisme-agents-section__empty">
+            <template v-if="search">
+              <p class="organisme-agents-section__empty-title">
+                Aucun membre ne correspond à votre recherche.
+              </p>
+            </template>
+            <template v-else>
+              <p class="organisme-agents-section__empty-title">
+                Aucun membre pour l'instant.
+              </p>
+            </template>
+          </div>
+        </template>
+      </CspDataTable>
     </CspAsyncSection>
 
     <CspDialog
@@ -175,7 +187,7 @@ async function handleRevocation(): Promise<void> {
 
 <style scoped lang="scss">
 .organisme-agents-section__intro {
-  margin-bottom: var(--csp-space-6);
+  margin-bottom: var(--csp-space-5);
 }
 
 .organisme-agents-section__title {
@@ -188,24 +200,23 @@ async function handleRevocation(): Promise<void> {
   margin: 0;
   color: var(--text-mention-grey);
   font-size: 0.875rem;
-}
-
-.organisme-agents-section__header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: var(--csp-space-4);
-}
-
-.organisme-agents-section__count {
-  margin: 0 0 var(--csp-space-4);
-  font-size: 0.9375rem;
-  color: var(--text-mention-grey);
+  max-width: 65ch;
 }
 
 .organisme-agents-section__search {
   min-width: 20rem;
-  margin-bottom: var(--csp-space-4);
+}
+
+.organisme-agents-section__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--csp-space-4);
+  padding: var(--csp-space-6) 0;
+}
+
+.organisme-agents-section__empty-title {
+  margin: 0;
 }
 
 .organisme-agents-section__dialog-actions {

--- a/src/web/presentation/frontend/src/features/organismes/components/OrganismesSection.vue
+++ b/src/web/presentation/frontend/src/features/organismes/components/OrganismesSection.vue
@@ -7,6 +7,7 @@ import CspButton from '@/components/base/CspButton/CspButton.vue'
 import CspDataTable from '@/components/base/CspDataTable/CspDataTable.vue'
 import CspInput from '@/components/base/CspInput/CspInput.vue'
 import CspSkeletonTable from '@/components/base/CspSkeleton/CspSkeletonTable.vue'
+import CspTableToolbar from '@/components/base/CspTableToolbar/CspTableToolbar.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
 import { useTextSearch } from '@/composables/data/useTextSearch'
 import { useToast } from '@/composables/ui/useToast'
@@ -87,21 +88,13 @@ async function handleUpdate(payload: UpdateOrganismePayload): Promise<void> {
 <template>
   <section class="organismes-section">
     <div class="organismes-section__intro">
-      <div>
-        <h2 class="organismes-section__title">
-          Gestion des organismes
-        </h2>
-        <p class="organismes-section__description">
-          Les organismes permettent d'organiser les recrutements. Chaque organisme
-          dispose de ses propres utilisateurs, offres et paramètres.
-        </p>
-      </div>
-      <CspButton
-        label="Ajouter un organisme"
-        icon="ri:add-line"
-        is-icon-left
-        @click="creationOpen = true"
-      />
+      <h2 class="organismes-section__title">
+        Gestion des organismes
+      </h2>
+      <p class="organismes-section__description">
+        Les organismes permettent d'organiser les recrutements. Chaque organisme
+        dispose de ses propres utilisateurs, offres et paramètres.
+      </p>
     </div>
 
     <CspAsyncSection
@@ -118,20 +111,21 @@ async function handleUpdate(payload: UpdateOrganismePayload): Promise<void> {
         />
       </template>
 
-      <div class="organismes-section__header">
-        <p class="organismes-section__count">
-          {{ countLabel }}
-        </p>
-        <div class="organismes-section__actions">
-          <CspInput
-            v-model="search"
-            type="search"
-            aria-label="Rechercher un organisme, un siret"
-            placeholder="Rechercher un organisme, un siret"
-            class="organismes-section__search"
-          />
-        </div>
-      </div>
+      <CspTableToolbar :count="countLabel">
+        <CspInput
+          v-model="search"
+          type="search"
+          aria-label="Rechercher un organisme, un siret"
+          placeholder="Rechercher un organisme, un siret"
+          class="organismes-section__search"
+        />
+        <CspButton
+          label="Ajouter un organisme"
+          icon="ri:add-line"
+          is-icon-left
+          @click="creationOpen = true"
+        />
+      </CspTableToolbar>
       <CspDataTable
         v-model:page="page"
         :rows="filtered"
@@ -156,11 +150,7 @@ async function handleUpdate(payload: UpdateOrganismePayload): Promise<void> {
 
 <style scoped lang="scss">
 .organismes-section__intro {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--csp-space-6);
-  margin-bottom: var(--csp-space-6);
+  margin-bottom: var(--csp-space-5);
 }
 
 .organismes-section__title {
@@ -173,27 +163,7 @@ async function handleUpdate(payload: UpdateOrganismePayload): Promise<void> {
   margin: 0;
   color: var(--text-mention-grey);
   font-size: 0.875rem;
-}
-
-.organismes-section__header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: var(--csp-space-4);
-}
-
-.organismes-section__count {
-  margin: 0 0 var(--csp-space-4);
-  font-size: 0.9375rem;
-  color: var(--text-mention-grey);
-}
-
-.organismes-section__actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 0.75rem;
-  margin-bottom: var(--csp-space-4);
+  max-width: 65ch;
 }
 
 .organismes-section__search {

--- a/src/web/presentation/frontend/src/features/organismes/views/GestionOrganismesView.vue
+++ b/src/web/presentation/frontend/src/features/organismes/views/GestionOrganismesView.vue
@@ -15,7 +15,7 @@ const breadcrumb: CspBreadcrumbItem[] = [
     :breadcrumb="breadcrumb"
     title="Gestion des organismes"
   />
-  <CspPageContainer width="full">
+  <CspPageContainer width="large">
     <OrganismesSection />
   </CspPageContainer>
 </template>

--- a/src/web/presentation/frontend/src/features/organismes/views/GestionOrganismesView.vue
+++ b/src/web/presentation/frontend/src/features/organismes/views/GestionOrganismesView.vue
@@ -15,7 +15,7 @@ const breadcrumb: CspBreadcrumbItem[] = [
     :breadcrumb="breadcrumb"
     title="Gestion des organismes"
   />
-  <CspPageContainer width="reading">
+  <CspPageContainer width="full">
     <OrganismesSection />
   </CspPageContainer>
 </template>

--- a/src/web/presentation/frontend/src/features/organismes/views/OrganismeView.vue
+++ b/src/web/presentation/frontend/src/features/organismes/views/OrganismeView.vue
@@ -75,7 +75,6 @@ const metaItems = computed<CspMetaItem[]>(() =>
   </CspPageHeader>
   <CspPageContainer
     v-model:active-tab="activeTab"
-    width="reading"
     :tabs="tabs"
   >
     <template #tab-membres>

--- a/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
+++ b/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
@@ -13,6 +13,7 @@ import CspErrorState from '@/components/base/CspErrorState/CspErrorState.vue'
 import CspInput from '@/components/base/CspInput/CspInput.vue'
 import CspSkeleton from '@/components/base/CspSkeleton/CspSkeleton.vue'
 import CspSkeletonTable from '@/components/base/CspSkeleton/CspSkeletonTable.vue'
+import CspTableToolbar from '@/components/base/CspTableToolbar/CspTableToolbar.vue'
 import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContainer.vue'
 import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
@@ -135,36 +136,35 @@ const archivesCountLabel = computed(() => {
       v-if="!recrutementsError"
       #tab-actifs
     >
-      <div class="mes-recrutement-view__toolbar">
-        <CspSkeleton
-          v-if="showActifsSkeleton"
-          class="mes-recrutement-view__count-skeleton"
-          width="12rem"
-          height="0.9375rem"
+      <CspTableToolbar :bordered="false">
+        <template #status>
+          <CspSkeleton
+            v-if="showActifsSkeleton"
+            width="12rem"
+            height="0.9375rem"
+          />
+          <p
+            v-else
+            class="mes-recrutement-view__count"
+          >
+            {{ actifsCountLabel }}
+          </p>
+        </template>
+        <CspInput
+          v-model="actifsFilters.search.value"
+          type="search"
+          aria-label="Rechercher un recrutement"
+          placeholder="Rechercher une offre, une référence,…"
+          class="mes-recrutement-view__search"
         />
-        <p
-          v-else
-          class="mes-recrutement-view__count"
-        >
-          {{ actifsCountLabel }}
-        </p>
-        <div class="mes-recrutement-view__actions">
-          <CspInput
-            v-model="actifsFilters.search.value"
-            type="search"
-            aria-label="Rechercher un recrutement"
-            placeholder="Rechercher une offre, une référence,…"
-            class="mes-recrutement-view__search"
-          />
-          <CspButton
-            :label="actifsFilters.activeFiltersCount.value ? `Filtres (${actifsFilters.activeFiltersCount.value})` : 'Filtres'"
-            variant="tertiary"
-            icon="ri:filter-line"
-            is-icon-left
-            @click="openActifsFilters"
-          />
-        </div>
-      </div>
+        <CspButton
+          :label="actifsFilters.activeFiltersCount.value ? `Filtres (${actifsFilters.activeFiltersCount.value})` : 'Filtres'"
+          variant="tertiary"
+          icon="ri:filter-line"
+          is-icon-left
+          @click="openActifsFilters"
+        />
+      </CspTableToolbar>
       <RecrutementsActifsFiltersDrawer
         v-model:open="actifsFiltersDrawer.isOpen.value"
         v-model:responsable="actifsFilters.draft.responsable"
@@ -210,36 +210,35 @@ const archivesCountLabel = computed(() => {
       v-if="!recrutementsError"
       #tab-archives
     >
-      <div class="mes-recrutement-view__toolbar">
-        <CspSkeleton
-          v-if="showArchivesSkeleton"
-          class="mes-recrutement-view__count-skeleton"
-          width="12rem"
-          height="0.9375rem"
+      <CspTableToolbar :bordered="false">
+        <template #status>
+          <CspSkeleton
+            v-if="showArchivesSkeleton"
+            width="12rem"
+            height="0.9375rem"
+          />
+          <p
+            v-else
+            class="mes-recrutement-view__count"
+          >
+            {{ archivesCountLabel }}
+          </p>
+        </template>
+        <CspInput
+          v-model="archivesFilters.search.value"
+          type="search"
+          aria-label="Rechercher un recrutement"
+          placeholder="Rechercher une offre, une référence,…"
+          class="mes-recrutement-view__search"
         />
-        <p
-          v-else
-          class="mes-recrutement-view__count"
-        >
-          {{ archivesCountLabel }}
-        </p>
-        <div class="mes-recrutement-view__actions">
-          <CspInput
-            v-model="archivesFilters.search.value"
-            type="search"
-            aria-label="Rechercher un recrutement"
-            placeholder="Rechercher une offre, une référence,…"
-            class="mes-recrutement-view__search"
-          />
-          <CspButton
-            :label="archivesFilters.activeFiltersCount.value ? `Filtres (${archivesFilters.activeFiltersCount.value})` : 'Filtres'"
-            variant="tertiary"
-            icon="ri:filter-line"
-            is-icon-left
-            @click="openArchivesFilters"
-          />
-        </div>
-      </div>
+        <CspButton
+          :label="archivesFilters.activeFiltersCount.value ? `Filtres (${archivesFilters.activeFiltersCount.value})` : 'Filtres'"
+          variant="tertiary"
+          icon="ri:filter-line"
+          is-icon-left
+          @click="openArchivesFilters"
+        />
+      </CspTableToolbar>
       <RecrutementsArchivesFiltersDrawer
         v-model:open="archivesFiltersDrawer.isOpen.value"
         v-model:responsable="archivesFilters.draft.responsable"
@@ -282,30 +281,10 @@ const archivesCountLabel = computed(() => {
   color: var(--text-mention-grey);
 }
 
-.mes-recrutement-view__toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: var(--csp-page-content-padding-block);
-}
-
 .mes-recrutement-view__count {
   margin: 0;
   font-size: 0.9375rem;
   color: var(--text-mention-grey);
-}
-
-.mes-recrutement-view__count-skeleton {
-  margin: 0.15rem 0;
-}
-
-.mes-recrutement-view__actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 0.75rem;
 }
 
 .mes-recrutement-view__search {

--- a/src/web/presentation/frontend/src/styles/csp-variables.css
+++ b/src/web/presentation/frontend/src/styles/csp-variables.css
@@ -54,6 +54,7 @@
   --csp-page-container-padding-inline: clamp(1.5rem, 1rem + 2.5vw, 3rem);
   --csp-page-container-reading-width: 68rem;
   --csp-page-container-wide-width: 90rem;
+  --csp-page-container-large-width: 110rem;
   --csp-page-content-padding-block: 1.5rem;
 }
 


### PR DESCRIPTION
## 📝 Description
🎸 Améliorations des styles de l'ats :
- permet d'avoir des titres de header de table sur deux lignes
- ajoute un composant partagé pour la toolbar des composants type datatable
- règle la largeur des tables existantes

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique