### PR TITLE
📝(docs) retour à Django idiomatique abandon de la clean archi stricte (ADR 009)

### DIFF
--- a/docs/ADR/ADR-001-testing-strategy.md
+++ b/docs/ADR/ADR-001-testing-strategy.md
@@ -1,12 +1,14 @@
 
 # ADR-001: Testing Strategy
 
-**Status:** Accepted
+**Status:** Accepted — Amended by ADR-009
 **Date:** 2026.03.12
 **Deciders:** Élodie R, Lucas P, Vincent P
 **Tags:** testing
 
 ---
+
+> ⚠️ **Amendée par [ADR-009](./ADR-009-idiomatic-django-switch.md)**. Voir la section « Impact sur les ADR existantes » d'ADR-009.
 
 ## Context
 
@@ -59,6 +61,9 @@ without over-engineering lower-risk areas.
   errors already covered), with **pytest**
 - Main end-to-end user stories (those executed by ~80% of users) are tested with
   **Playwright**
+
+> 🔗 The “repository/use case” breakdown above is replaced by three levels (pure functions / service+DB / view+DB)
+> see [ADR-009](./ADR-009-idiomatic-django-switch.md#impact-sur-les-adr-existantes), “Impact on Existing ADRs” table.
 
 **Non-blocking tests** — these run but do not gate merges:
 - Accessibility and keyboard navigation tests are run at the start of each sprint
@@ -142,8 +147,10 @@ without blocking daily delivery.
 ## Implementation Notes
 
 - [ ] Add tests to check that in-memory repository respect interfaces
+      _(obsolete: no more in-memory repository or interface, see ADR-009 §2)_
 - [ ] Audit existing use case tests and strip out any assertions that duplicate
       repository-level coverage
+      _(obsolete: use case → service, repository → QuerySet, see ADR-009 §1 and §2)_
 - [ ] Identify the top 80% user stories and ensure each has a Playwright e2e test
 - [ ] Set up accessibility and keyboard navigation tests in Playwright; mark them
       as non-blocking in CI configuration

--- a/docs/ADR/ADR-002-testing-strategy-and-repository-mocking.md
+++ b/docs/ADR/ADR-002-testing-strategy-and-repository-mocking.md
@@ -1,7 +1,9 @@
 # ADR-002: Testing Strategy and Repository Mocking
 
 ## Status
-Accepted
+Accepted — Amended by ADR-009
+
+> ⚠️ **Amendée par [ADR-009](./ADR-009-idiomatic-django-switch.md)**. Voir la section « Impact sur les ADR existantes » d'ADR-009.
 
 ## Context
 
@@ -24,6 +26,11 @@ We adopt a three-tier testing strategy aligned with Clean Architecture principle
 - Leverage `create_interface_aware_mock()` utility that automatically generates mocks from domain interfaces
 - Eliminates maintenance overhead of hand-written in-memory repositories
 - Ensures mocks always respect interface contracts through introspection
+
+> 🔗 **Strategy abandoned.** No more repository `Protocol` to mock: use case tests
+> become service tests against a real database — see
+> [ADR-009 §2 "The Django Model is the entity"](./ADR-009-idiomatic-django-switch.md#2-le-model-django-est-lentité)
+> and the ["Impact" table](./ADR-009-idiomatic-django-switch.md#impact-sur-les-adr-existantes).
 
 **Test Data Strategy**:
 - Use factory classes exclusively for test data creation
@@ -49,8 +56,12 @@ We adopt a three-tier testing strategy aligned with Clean Architecture principle
 - Task queues and background jobs
 - User interface behavior and validation
 - Usecase are mocked here
+  _(obsolete: no more use case/DI to mock, direct call to the service — see ADR-009 §6)_
 
 ## Rationale
+
+> 🔗 See [ADR-009 §6 "Removal of dependency injection"](./ADR-009-idiomatic-django-switch.md#6-suppression-de-linjection-de-dépendances)
+> for what replaces the interface mocking described below.
 
 ### Clean Architecture Alignment
 This strategy respects Clean Architecture's dependency inversion principle:
@@ -59,6 +70,11 @@ This strategy respects Clean Architecture's dependency inversion principle:
 - **Presentation tests** ensure the outer layer properly. Usecases are mocked here.
 
 ### Interface-Aware Mock Generation
+
+> 🔗 **Obsolete.** `create_interface_aware_mock()` is removed by
+> [ADR-009 §2](./ADR-009-idiomatic-django-switch.md#2-le-model-django-est-lentité): without
+> a repository `Protocol`, there is no interface left to introspect.
+
 Traditional in-memory repositories require significant maintenance:
 - Manual implementation of each repository interface
 - Keeping mocks synchronized with interface changes

--- a/docs/ADR/ADR-003-ddd-aggregate-root-pattern.md
+++ b/docs/ADR/ADR-003-ddd-aggregate-root-pattern.md
@@ -1,11 +1,13 @@
 # ADR-003: DDD Aggregate Root Pattern
 
-**Status:** Accepted
+**Status:** Superseded by ADR-009
 **Date:** 2026.05.28
 **Deciders:** Élodie R
 **Tags:** ddd, domain, architecture
 
 ---
+
+> ⚠️ **Remplacée par [ADR-009](./ADR-009-idiomatic-django-switch.md)**. Voir la section « Impact sur les ADR existantes » d'ADR-009.
 
 ## Context
 
@@ -54,6 +56,12 @@ Option C requires an event store — out of scope for MVP.
   still be accessed from outside
 
 ---
+
+> 🔗 **Pattern replaced.** The Django `Model` becomes the entity (no more separate
+> `AggregateRoot`), and traceability goes through an explicit call rather than domain
+> events — see [ADR-009 §2](./ADR-009-idiomatic-django-switch.md#2-le-model-django-est-lentité)
+> and [§5 "Traceability goes through an explicit call"](./ADR-009-idiomatic-django-switch.md#5-la-traçabilité-passe-par-un-appel-explicite--amende-ladr-003).
+> The rules below (Rules 1 to 7) no longer apply to new code.
 
 ## Guidelines
 
@@ -194,6 +202,9 @@ it verifies the event type, constructs the instance, and calls `add_event` autom
 ---
 
 ## Domain Building Blocks
+
+> 🔗 These files are within the removal scope of `libs/ddd` — see
+> [ADR-009, Migration section](./ADR-009-idiomatic-django-switch.md#migration).
 
 | File                           | Description                                                          |
 | ------------------------------ | -------------------------------------------------------------------- |

--- a/docs/ADR/ADR-005-business-rule-ownership-entity-vs-orm-model.md
+++ b/docs/ADR/ADR-005-business-rule-ownership-entity-vs-orm-model.md
@@ -1,7 +1,9 @@
 # ADR-005: Responsabilité des règles métier — entité de domaine vs modèle ORM
 
 ## Status
-Accepted
+Superseded by ADR-009
+
+> ⚠️ **Remplacée par [ADR-009](./ADR-009-idiomatic-django-switch.md)**. Voir la section « Impact sur les ADR existantes » d'ADR-009.
 
 ## Context
 
@@ -23,6 +25,14 @@ Deux tentations à écarter :
 La question : **qui est responsable du contrôle des règles métier, et comment garantir que ce contrôle ne soit ni dupliqué, ni contournable ?**
 
 ## Decision
+
+> 🔗 **Décision inversée par ADR-009.** Le `Model` Django devient l'entité — plus de
+> couple entité/modèle ni de passage obligé par `from_entity()`. Les invariants
+> s'encodent désormais au mécanisme le plus fort disponible (contrainte DB > méthode de
+> modèle/manager > fonction pure > garde de service) — voir
+> [ADR-009 §2](./ADR-009-idiomatic-django-switch.md#2-le-model-django-est-lentité) et
+> [§3 « Doctrine des invariants »](./ADR-009-idiomatic-django-switch.md#3-doctrine-des-invariants--remplace-ladr-005).
+> Les sections 1 à 3 ci-dessous ne s'appliquent plus au nouveau code.
 
 ### 1. L'entité de domaine est l'unique propriétaire des règles métier
 
@@ -60,6 +70,10 @@ Si l'entité est invalide, l'exception est levée **avant** toute écriture : il
 **Règle d'écriture** : le code métier (repositories, use cases, admin) ne fait jamais `Model.objects.create(...)` ni `bulk_create([...])` avec des données métier brutes. Il construit des entités validées puis appelle `from_entity()`. Le `create()`/`bulk_create()` brut reste réservé aux données purement techniques sans invariant (logs, agrégations…).
 
 ### 4. L'admin Django fait partie de la couche de présentation
+
+> 🔗 Le recours au « container DI » dans le tableau ci-dessous est obsolète — la DI est
+> supprimée par [ADR-009 §6](./ADR-009-idiomatic-django-switch.md#6-suppression-de-linjection-de-dépendances) ;
+> vues et services importent directement leurs dépendances.
 
 L'admin n'est pas un outil neutre de manipulation de la base : c'est une **interface de présentation** et il doit respecter les frontières de couches au même titre qu'une vue DRF. Pour `Source` (et tout modèle portant des invariants métier), trois niveaux selon le besoin :
 

--- a/docs/ADR/ADR-006-cqrs-query-use-cases-read-models.md
+++ b/docs/ADR/ADR-006-cqrs-query-use-cases-read-models.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Accepted — Amended by ADR-009
+
+> ⚠️ **Amendée par [ADR-009](./ADR-009-idiomatic-django-switch.md)**. Voir la section « Impact sur les ADR existantes » d'ADR-009.
 
 ## Context
 
@@ -63,6 +65,11 @@ Commande : CreerRecrutementUsecase → manipule l'aggregate Recrutement → IRec
 Requête  : ListerMesRecrutementsUsecase → interroge IRecrutementQueryService → RecrutementActifsReadModel
 ```
 
+> 🔗 **Implémentation remplacée.** Le principe lecture/écriture séparées reste, mais
+> `IRecrutementQueryService` + `RecrutementActifsReadModel` (dataclass) sont remplacés
+> par un `QuerySet` custom + `ModelSerializer` DRF — voir
+> [ADR-009 §4 « DRF est seul responsable de la sérialisation »](./ADR-009-idiomatic-django-switch.md#4-drf-est-seul-responsable-de-la-sérialisation--amende-ladr-006).
+
 ### L'Application Layer compose des DTOs pour la UI
 
 Conformément à Vaughn Vernon (*Implementing Domain-Driven Design*, Chapter 14), l'Application Layer a pour rôle de composer des données issues de différents modèles en un format cohérent pour la UI :
@@ -105,6 +112,10 @@ Il ne contient donc pas les données nécessaires à la vue (titre de l'offre, n
 2. **Charger les données manquantes dans la présentation** → N+1 queries et fuite de responsabilité
 
 ### Mapping vers la vue
+
+> 🔗 Ce mapper dédié est obsolète si la sérialisation passe directement par un
+> `ModelSerializer` sur le `QuerySet` — cf.
+> [ADR-009 §4](./ADR-009-idiomatic-django-switch.md#4-drf-est-seul-responsable-de-la-sérialisation--amende-ladr-006).
 
 La couche présentation applique une dernière transformation via des mappers dédiés (ex. `RecrutementsActifsMapper`) pour convertir les Read Models typés en dictionnaires compatibles avec les serializers DRF. Ce mapping est une **simple traduction de format**, pas une récupération de données supplémentaires.
 
@@ -187,7 +198,14 @@ Sans lui, le typage serait perdu (`list[dict]`) ou la présentation devrait impo
 
 ## Notes
 
-Cette décision ne concerne que les **queries** (lectures). Les **commandes** (écritures) continuent d'utiliser les aggregates du domaine via les repositories (`IRecrutementRepository`). Le pattern est cohérent avec les ADR précédentes :
+Cette décision ne concerne que les **queries** (lectures). Les **commandes** (écritures) continuent d'utiliser les aggregates du domaine via les repositories (`IRecrutementRepository`).
+
+> 🔗 **Obsolète.** ADR-003 et ADR-005, citées ci-dessous comme fondement, sont
+> superseded par ADR-009 : il n'y a plus d'aggregate ni de repository pour les
+> commandes non plus, cf.
+> [tableau « Impact »](./ADR-009-idiomatic-django-switch.md#impact-sur-les-adr-existantes).
+
+Le pattern est cohérent avec les ADR précédentes :
 
 - **ADR-003** (aggregate root pattern) : définit comment les aggregates protègent les invariants en écriture
 - **ADR-004** (foreign keys & error mapping) : traite des contraintes d'intégrité entre bounded contexts

--- a/docs/ADR/ADR-007-can-execute-preconditions-use-cases.md
+++ b/docs/ADR/ADR-007-can-execute-preconditions-use-cases.md
@@ -1,11 +1,13 @@
 # ADR-007 : `can_execute` — préconditions de coordination des use cases
 
-**Status:** Proposal
+**Status:** Proposal — Amended by ADR-009
 **Date:** 2026.08.18
 **Deciders:** Élodie R
 **Tags:** ddd, application, architecture
 
 ---
+
+> ⚠️ **Amendée par [ADR-009](./ADR-009-idiomatic-django-switch.md)**. Voir la section « Impact sur les ADR existantes » d'ADR-009.
 
 ## Context
 
@@ -30,6 +32,7 @@ devienne une **béquille** qui compense un invariant métier non garanti à la s
 Le use case expose une méthode unique `can_execute(command)` qui, dans l'ordre :
 
 1. charge les agrégats (via les repositories),
+   _(obsolète : accès direct via `QuerySet`, cf. [ADR-009 §1](./ADR-009-idiomatic-django-switch.md#1-le-queryset-est-le-contrat-entre-les-couches))_
 2. vérifie la **cohérence de coordination** (multi-agrégats et fail-fast),
 3. vérifie les **droits / permissions**,
 4. **lève** une erreur si une vérification échoue,
@@ -53,6 +56,11 @@ Un invariant (ex. « un organisme ATS a des étapes ») est posé **à la créat
 domaine (ADR-003 / ADR-005), déclenché par son use case dédié
 (`InitializeOrganismeStepsUsecase`). Si un `etapes is None` subsiste en aval, c'est un
 **fail-fast de cohérence applicative** (état corrompu / bug), pas une règle métier.
+
+> 🔗 Les renvois à ADR-003/ADR-005 ci-dessus et ci-dessous pointent des ADR superseded —
+> voir désormais [ADR-009 §3 « Doctrine des invariants »](./ADR-009-idiomatic-django-switch.md#3-doctrine-des-invariants--remplace-ladr-005).
+> Le principe (`can_execute` en tête de service, sans lien à `IUsecase`) reste valide,
+> cf. [tableau « Impact »](./ADR-009-idiomatic-django-switch.md#impact-sur-les-adr-existantes).
 
 ---
 

--- a/docs/ADR/ADR-009-idiomatic-django-switch.md
+++ b/docs/ADR/ADR-009-idiomatic-django-switch.md
@@ -1,0 +1,295 @@
+# ADR-009 : Retour à un Django idiomatique — abandon de la clean architecture stricte
+
+**Status:** Accepté
+**Date:** 2026.09.02
+**Deciders:** Vincent P
+**Tags:** django, architecture, refactoring, supersedes
+
+---
+
+## Context
+
+Le service `src/web` applique depuis ses débuts une clean architecture stricte : quatre
+couches (`domain`, `application`, `infrastructure`, `presentation`) adossées à une
+bibliothèque maison `libs/ddd` (`AggregateRoot`, `Entity`, `IUsecase`, `IRepository`,
+`IMapper`, `IPage`, `UnitOfWork`), avec injection de dépendances par
+`dependency-injector`.
+
+### Ce que cette architecture coûte, mesuré sur `main`
+
+| Élément | Volume |
+|---|---|
+| `domain/` | 112 fichiers / 1 979 LOC |
+| `application/` | 73 fichiers / 2 417 LOC |
+| `infrastructure/` | 290 fichiers / 14 145 LOC |
+| Interfaces de repository (`Protocol`) | 22, pour 22 implémentations uniques |
+| Mappers ORM ↔ entité | 14 |
+| Fichiers DI (containers + factories) | 11 |
+| Agrégats portant du comportement | 6, pour 11 méthodes |
+| **Dont méthodes encodant un invariant réel** | **5** |
+
+Soit environ 4 400 LOC de `domain` + `application` pour cinq règles métier. Le reste est
+de la traduction entre représentations et de la déclaration de providers.
+
+### Les symptômes
+
+1. **Revues longues.** Le layering n'est *enforced* par aucun outil — il n'existe aucun
+   contrat `import-linter` dans le dépôt. Les frontières sont tenues à la main, en revue,
+   par des humains.
+2. **Impacts nombreux.** Un endpoint touche huit artefacts dans quatre couches : entité,
+   `Protocol`, implémentation `Postgres*`, mapper, use case, provider, read model,
+   serializer.
+3. **Abstractions sans contrepartie.** Aucun des 22 `Protocol` de repository n'a jamais eu
+   deux implémentations. Une abstraction se paie par la substituabilité qu'elle procure ;
+   celle-ci n'en procure aucune.
+4. **Bus factor de 1.** Les conventions du dépôt (`@factory`, `@mutate`,
+   `__init_subclass__` policier dans `AggregateRoot`) exigent un savoir maîtrisé par une
+   seule personne, qui quitte le projet.
+
+### Le signal déjà présent dans nos propres ADR
+
+L'ADR-005 reconnaît, dans ses conséquences négatives, que sa règle centrale « toute
+écriture passe par `from_entity()` » **repose sur la convention, la revue et les tests**,
+et que « rien dans Django n'empêche techniquement un développeur d'écrire
+`Model.objects.create(...)` ».
+
+Ce coût de discipline, accepté à l'époque, est devenu le coût principal. Et
+l'accumulation de dette a produit une garantie plus faible que celle que l'ADR-004
+obtenait gratuitement avec une contrainte FK.
+
+---
+
+## Decision Drivers
+
+- Réduire le nombre d'artefacts touchés par un changement fonctionnel.
+- Rendre les frontières d'architecture vérifiables par la CI plutôt que par la revue.
+- Ne perdre aucun invariant métier, et si possible en renforcer la garantie.
+- Ramener le codebase dans un vocabulaire connu de toute l'équipe et embauchable.
+- Ne pas geler la livraison pendant la transition.
+
+---
+
+## Considered Options
+
+1. **Option A — Statu quo + montée en compétence de l'équipe.**
+   Conserve l'existant, transfère le savoir avant le départ.
+2. **Option B — Alléger le DDD.**
+   Conserver les agrégats et les read models, supprimer les `Protocol` de repository
+   et la DI.
+3. **Option C — Django idiomatique, couches conservées sans abstraction entre elles.**
+   Les `QuerySet` transitent des managers vers les vues via les services ; DRF seul
+   sérialise ; suppression de `libs/ddd`, des mappers et de la DI.
+4. **Option D — Django « plein ».**
+   Fat models et vues, suppression de la couche `application`.
+
+**Option retenue : C.**
+
+L'option A ne traite aucun des quatre symptômes : elle transforme un problème
+d'architecture en problème de recrutement. L'option B laisse en place les agrégats —
+donc les mappers, donc la moitié du coût — pour six classes dont cinq méthodes portent
+une règle. L'option D supprime la couche `application`, qui est justement le seul point
+de passage obligé pour le RBAC, la transaction et l'audit : ce serait échanger notre
+problème de verbosité contre un problème de sécurité.
+
+---
+
+## Decision
+
+### 1. Le `QuerySet` est le contrat entre les couches
+
+Les services retournent des `QuerySet[Model]`, que la vue consomme directement. On ne les
+convertit pas en liste et on ne les enveloppe pas : la pagination DRF a besoin de
+`count()` et du slicing.
+
+La construction des querysets (`select_related`, `prefetch_related`, `annotate`) vit dans
+un `QuerySet` custom sur le modèle, exposé par `objects = XQuerySet.as_manager()`. Le
+service compose deux ou trois méthodes ; il ne devient pas une usine à querysets.
+
+### 2. Le `Model` Django est l'entité
+
+Une seule représentation par notion métier. Les mappers `to_domain` / `from_domain`
+disparaissent, ainsi que la règle `from_entity()` de l'ADR-005.
+
+### 3. Doctrine des invariants — remplace l'ADR-005
+
+Un invariant est encodé au **mécanisme d'application le plus fort disponible**, dans cet
+ordre :
+
+1. **Contrainte de base de données** (`UniqueConstraint`, `CheckConstraint`,
+   `on_delete=PROTECT`) — infaillible, y compris pour `bulk_update` et l'admin.
+2. **Méthode de modèle ou de manager** — contournable par `.objects.update()`, donc
+   réservée aux règles sans équivalent en base.
+3. **Fonction pure** appelée par le service — pour les règles portant sur une collection
+   ou une séquence, qu'aucune contrainte SQL n'exprime.
+4. **Garde de service** — pour ce qui exige le contexte d'appel (permissions,
+   orchestration multi-agrégats).
+
+C'est l'inverse de l'ADR-005, qui plaçait l'entité comme propriétaire unique de tous les
+invariants. C'est en revanche la **généralisation de l'ADR-004**, qui avait déjà retenu
+la contrainte FK comme « ligne de défense la plus basse, qui s'applique même si la couche
+application faillit ».
+
+Application aux cinq invariants existants :
+
+| # | Invariant | Mécanisme cible | Statut |
+|---|---|---|---|
+| I1 | Étape non supprimable si candidatures | `on_delete=PROTECT` | déjà garanti |
+| I2 | Dossier de candidature ≥ 1 document | méthode `CandidatureModel.soumettre()` | niveau 2 |
+| I3 | Pas de double soumission | `UPDATE` conditionnel atomique, puis contrainte | à trancher, cf. Notes |
+| I4 | Déplacement confiné au recrutement | filtre de queryset sur la chaîne de FK | déjà garanti |
+| I5 | Séquence d'étapes bien formée | fonction pure `etapes_rules.py` | niveau 3 |
+
+### 4. DRF est seul responsable de la sérialisation — amende l'ADR-006
+
+Le principe de séparation lecture / écriture est conservé : les besoins d'un tableau de
+bord (compteurs agrégés, `Max(updated_at)`) ne sont pas ceux d'un agrégat. Seule
+l'implémentation change — `QuerySet` custom + `ModelSerializer` avec `source=`, au lieu
+de query service + read model dataclass.
+
+### 5. La traçabilité passe par un appel explicite — amende l'ADR-003
+
+`AuditLogWriter.log_action()` est appelé explicitement par le service après écriture. Les
+domain events et `drain_events()` sont supprimés. On n'introduit **pas** de signal Django
+en remplacement : ce serait réintroduire l'implicite qu'on cherche à retirer, et perdre
+l'identité de l'utilisateur auteur de l'action.
+
+### 6. Suppression de l'injection de dépendances
+
+Les vues et les services importent directement ce dont ils ont besoin. Les containers
+`dependency-injector` et leurs factories sont supprimés.
+
+### 7. Les frontières sont vérifiées par la CI, pas par la revue
+
+- Deux contrats `import-linter` : sens unique `presentation` → `application` →
+  `infrastructure` ; interdiction de `rest_framework` et `django.http` dans
+  `application`.
+- Un contrôle refusant `.objects.` dans `presentation/` — c'est-à-dire une vue qui
+  requête. Le *type* du modèle, lui, reste importable par la présentation : c'est la
+  contrepartie assumée du transit de queryset.
+- Un contrôle refusant `patch("presentation…")`, `patch("application…")` et
+  `patch("infrastructure.di…")` dans `tests/`.
+
+Corollaire : **ce qu'on ne peut pas outiller, on ne l'écrit pas comme règle
+d'architecture.**
+
+---
+
+## Rationale
+
+### Une abstraction se paie par la substituabilité qu'elle procure
+
+Vingt-deux `Protocol` pour vingt-deux implémentations : le prix a été payé, la
+contrepartie jamais encaissée. L'ORM Django *est* déjà la couche d'abstraction sur
+PostgreSQL ; nous en avions empilé une seconde par-dessus.
+
+### L'invariant le plus solide est celui que le code ne peut pas contourner
+
+L'ADR-005 confiait les invariants à l'entité, en reconnaissant que rien n'empêchait de
+l'esquiver. Trois de nos cinq invariants sont déjà, ou deviennent, des garanties de base
+de données — plus fortes que ce que l'agrégat offrait. Le cas d'I3 est éclairant : le
+`read-then-check` de `Candidature.soumettre_candidature()` est racé, là où un `UPDATE`
+conditionnel ne l'est pas.
+
+### Le découpage vertical faisait le gros du travail, pas le DDD
+
+La navigabilité du code et la capacité à travailler à plusieurs viennent des bounded
+contexts et des use cases nommés en français métier — pas des agrégats ni des mappers.
+Ces deux acquis sont conservés intégralement.
+
+### Le coût est déjà payé, la dette non
+
+Six agrégats, cinq règles. Un d'entre eux (`Note`) est **déjà court-circuité par son
+propre repository**, qui écrit via `.update()` sans passer par le mapper. Nous maintenons
+donc un formalisme que le code lui-même n'honore plus.
+
+---
+
+## Consequences
+
+### Positives
+
+- **Diff par changement fonctionnel divisé** : quatre artefacts au lieu de huit, dans un
+  seul bounded context.
+- **Frontières vérifiées automatiquement** : la revue se recentre sur le métier.
+- **Invariants renforcés** : trois des cinq reposent sur des garanties de base de données.
+- **Codebase embauchable** : Django/DRF plutôt qu'un dialecte DDD maison.
+- **Faux positifs de tests supprimés par construction** : sans read model intermédiaire,
+  un test de vue ne s'écrit plus qu'avec `APIClient` et une vraie base.
+- **Typage assaini** : les 23 `type: ignore[attr-defined]` actuels, presque tous liés au
+  remapping manuel d'annotations, disparaissent avec lui.
+
+### Negatives
+
+- **Perte du point d'entrée unique.** `.objects.update()` et `bulk_update()`
+  court-circuitent toute règle écrite en Python. C'est précisément le risque que
+  l'ADR-005 identifiait déjà, et la raison pour laquelle les invariants remontent vers la
+  base.
+- **Le RBAC devient le point de vigilance n°1.** `est_autorise()` était l'unique barrière,
+  au sein du use case. Il est doublé d'un scoping de queryset (`.visibles_par(user)`) pour
+  qu'un oubli dans une vue ne puisse pas ouvrir de fuite de données.
+- **Les tests reposant sur des mocks d'interfaces sont à réécrire.** Portée limitée : trois
+  fichiers utilisent `create_interface_aware_mock`.
+- **Un lot de tests de vues est à reconstruire avant migration.** Neuf fichiers de
+  `tests/presentation` patchent un container et ne constituent pas un harnais de
+  non-régression.
+- **Coût de transition non nul** : six étapes, une PR par bounded context.
+
+### Neutres
+
+- **Les couches restent.** `presentation` / `application` / `infrastructure` conservent
+  leur rôle et leur sens de dépendance. Seules les abstractions entre elles disparaissent.
+- **Les enums / value objects restent** où ils sont, déjà consommés comme `choices` par
+  les modèles Django.
+- **`libs/referentiel` n'est pas concerné** : c'est un shared kernel entre `web` et
+  `ingestion`, orthogonal à ce choix.
+
+---
+
+## Impact sur les ADR existantes
+
+Deux ADR sont remplacées, cinq sont conservées ou amendées : la présente décision
+resserre le périmètre du DDD, elle n'annule pas le travail d'architecture antérieur.
+
+| ADR | Devenir |
+|---|---|
+| ADR-001 — Testing strategy | **Amendée.** Trois niveaux (fonctions pures / service+DB / vue+DB) au lieu d'un découpage par couche. |
+| ADR-002 — Repository mocking | **Amendée.** Le découpage à trois niveaux et le principe « factories plutôt que fixtures JSON » sont conservés. Seule tombe la stratégie de mocking par interface : `create_interface_aware_mock` est supprimé, et les tests de use case deviennent des tests de service sur base réelle. |
+| ADR-003 — Aggregate root pattern | **Superseded.** |
+| ADR-004 — FK cross-BC et mapping d'erreurs | **Conservée et généralisée.** Sa doctrine (« encoder la règle au niveau le plus fiable ») devient la règle générale, section Decision §3. |
+| ADR-005 — Business rule ownership | **Superseded.** Décision inversée. |
+| ADR-006 — CQRS et read models | **Amendée.** Principe conservé, implémentation remplacée. |
+| ADR-007 — `can_execute` | **Amendée.** Les préconditions restent en tête de service ; seule la signature liée à `IUsecase` disparaît. |
+| ADR-008 — Erreurs de cohérence applicative | **Conservée.** La couche application demeure. |
+
+---
+
+## Notes
+
+### Trois points à acter
+
+1. **I3 — décision produit.** Le domaine lève
+   `CandidatureDejaSoumise(candidat_id, offre_id)` tandis que `CandidatureModel.Meta`
+   porte `UniqueConstraint(candidat_id, etape_id)`. Les deux règles se contredisent, et la
+   contradiction préexiste à cette ADR. Si la règle est « par offre », il faut dénormaliser
+   un `offre_id` sur `CandidatureModel` — une `UniqueConstraint` ne traverse pas les
+   relations.
+2. **I5 — connaissance métier.** `OrganismeRecruteur._validate()` dit *quoi* ; le *pourquoi*
+   n'est écrit nulle part, ni le comportement attendu pour les recrutements en cours
+   lorsqu'un organisme modifie sa séquence.
+3. **I1 — vérification.** `EtapeRecrutement.delete()` lève dès que
+   `_candidatures is not None`, donc y compris sur une liste vide, là où `PROTECT` ne
+   bloque que s'il existe des lignes. L'un des deux comportements est un défaut.
+
+### Migration
+
+Progressive, un bounded context par PR, jamais deux en vol : socle outillé → filet de
+tests `APIClient` + `db` **avant** migration → `recruteur` lecture → `recruteur` écriture →
+`identite` → `candidate` → `ingestion` → suppression de `libs/ddd`.
+
+Garde-fou de non-régression : le passage des read models aux serializers ne doit produire
+**aucun diff** sur `schema.yaml` et `internal-schema.yaml`, que la CI vérifie déjà.
+
+Pendant la transition, les deux styles cohabitent. Le code neuf suit la présente ADR ;
+l'ancien n'est migré que lorsque c'est le tour de son contexte, ou lorsqu'une évolution
+fonctionnelle l'impose — pas au détour d'un passage dans le fichier.
+


### PR DESCRIPTION
## 📝 Description
🎸 voir titre

## 🏷️ Type de changement
- [x] 🔧 Changement technique

## 🔧 ETAPES 
1. conserver les devs livrés dans main
2. valider/fixer les devs en review au 02.09.2026
3. les nouveaux devs suivent l'architecture de l'ADR-009
4. refactorisation raisonnée, sans opportunisme, après sécurisation des tests (non regression)


## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
