### PR TITLE
✨(ingestion) cibler un référentiel pour le pipeline organismes et ajoute un bin

### DIFF
--- a/src/ingestion/bin/clean_publish_organismes.py
+++ b/src/ingestion/bin/clean_publish_organismes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import argparse
+import asyncio
+import logging
+
+from application.usecases.publish_organismes import PublishOrganismesCommand
+from domain.value_objects.organisme_referentiel import OrganismeReferentiel
+from infrastructure.di.container import Container, create_container
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def _run(referentiel: OrganismeReferentiel) -> None:
+    container: Container = create_container()
+
+    organismes = await container.clean_raw_organismes_usecase().execute(referentiel)
+    if not organismes:
+        logger.info(
+            "No organismes to publish for referentiel %s, skipping publish",
+            referentiel,
+        )
+        return
+
+    await container.publish_organismes_usecase().execute(
+        PublishOrganismesCommand(organismes=organismes)
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--referentiel",
+        default=OrganismeReferentiel.FINESS,
+        type=OrganismeReferentiel,
+        choices=list(OrganismeReferentiel),
+    )
+    args = parser.parse_args()
+    asyncio.run(_run(args.referentiel))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ingestion/bin/organismes_pipeline.py
+++ b/src/ingestion/bin/organismes_pipeline.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import asyncio
 import logging
 
@@ -17,19 +18,34 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-async def _run() -> None:
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Importe et publie les organismes")
+    parser.add_argument(
+        "--referentiel",
+        type=OrganismeReferentiel,
+        choices=list(OrganismeReferentiel),
+        help="Référentiel à traiter (par défaut : tous les référentiels)",
+    )
+    return parser.parse_args()
+
+
+async def _run(referentiel: OrganismeReferentiel | None = None) -> None:
     container: Container = create_container()
 
+    referentiels = (
+        [referentiel] if referentiel is not None else list(OrganismeReferentiel)
+    )
+
     organismes: list[Organisme] = []
-    for referentiel in OrganismeReferentiel:
-        use_case = import_organismes_usecase_for(container, referentiel)
+    for current_referentiel in referentiels:
+        use_case = import_organismes_usecase_for(container, current_referentiel)
         import_result = await use_case.execute(
-            ImportOrganismesCommand(referentiel=referentiel)
+            ImportOrganismesCommand(referentiel=current_referentiel)
         )
         if import_result.referentiel is None:
             logger.info(
                 "No organismes imported for referentiel %s, skipping clean",
-                referentiel,
+                current_referentiel,
             )
             continue
 
@@ -47,7 +63,8 @@ async def _run() -> None:
 
 
 def main() -> None:
-    asyncio.run(_run())
+    args = _parse_args()
+    asyncio.run(_run(args.referentiel))
 
 
 if __name__ == "__main__":

--- a/src/ingestion/infrastructure/external_gateways/web_publish_organismes_gateway.py
+++ b/src/ingestion/infrastructure/external_gateways/web_publish_organismes_gateway.py
@@ -3,7 +3,6 @@ import logging
 from referentiel.entities.organisme import Organisme
 
 from domain.gateways.publish_organismes_gateway import IPublishOrganismesGateway
-from infrastructure.exceptions.exceptions import ExternalApiError
 from infrastructure.external_gateways.base_web_gateway import BaseWebGateway
 from infrastructure.external_gateways.dtos.organisme_upsert_payload import (
     OrganismeUpsertPayload,
@@ -22,13 +21,8 @@ class WebPublishOrganismesGateway(BaseWebGateway, IPublishOrganismesGateway):
         if errors:
             logger.error(
                 "WebPublishOrganismesGateway: publish failed for %d organismes: %s",
-                len(organismes),
+                len(errors),
                 errors,
-            )
-            raise ExternalApiError(
-                "Failed to publish organismes",
-                api_name="web",
-                details={"errors": errors},
             )
 
     def _serialize(self, organisme: Organisme) -> dict:

--- a/src/ingestion/tests/integration/test_publish_organismes_usecase.py
+++ b/src/ingestion/tests/integration/test_publish_organismes_usecase.py
@@ -18,7 +18,6 @@ from application.usecases.publish_organismes import (
     PublishOrganismesCommand,
     PublishOrganismesUsecase,
 )
-from infrastructure.exceptions.exceptions import ExternalApiError
 from tests.conftest import PUBLISH_ORGANISMES_URL as PUBLISH_URL
 from tests.conftest import WEB_API_KEY as API_KEY
 
@@ -193,7 +192,7 @@ async def test_execute_raises_on_bad_request(
 
 
 @pytest.mark.asyncio
-async def test_execute_raises_and_logs_error_when_response_contains_errors(
+async def test_execute_logs_error_when_response_contains_errors(
     publish_organismes_usecase: PublishOrganismesUsecase,
     httpx_mock: HTTPXMock,
     caplog,
@@ -209,7 +208,7 @@ async def test_execute_raises_and_logs_error_when_response_contains_errors(
         },
     )
 
-    with caplog.at_level("ERROR"), pytest.raises(ExternalApiError):
+    with caplog.at_level("ERROR"):
         await publish_organismes_usecase.execute(
             PublishOrganismesCommand(organismes=[MINIMAL_ORGANISME])
         )

--- a/src/ingestion/tests/unit/bin/test_organismes_pipeline.py
+++ b/src/ingestion/tests/unit/bin/test_organismes_pipeline.py
@@ -1,0 +1,65 @@
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from application.usecases.import_organismes import ImportOrganismesResult
+from bin.organismes_pipeline import _run
+from domain.value_objects.organisme_referentiel import OrganismeReferentiel
+
+
+def _make_container():
+    container = MagicMock()
+    container.clean_raw_organismes_usecase.return_value.execute = AsyncMock(
+        return_value=[]
+    )
+    container.publish_organismes_usecase.return_value.execute = AsyncMock()
+    return container
+
+
+def _make_import_usecase(referentiel: OrganismeReferentiel | None):
+    usecase = MagicMock()
+    usecase.execute = AsyncMock(
+        return_value=ImportOrganismesResult(
+            referentiel=referentiel,
+            millesime="millesime",
+            total_imported=0,
+            total_deleted=0,
+        )
+    )
+    return usecase
+
+
+@pytest.mark.asyncio
+@patch("bin.organismes_pipeline.import_organismes_usecase_for")
+@patch("bin.organismes_pipeline.create_container")
+async def test_run_with_referentiel_only_imports_that_referentiel(
+    mock_create_container, mock_import_organismes_usecase_for
+):
+    container = _make_container()
+    mock_create_container.return_value = container
+    use_case = _make_import_usecase(OrganismeReferentiel.DILA)
+    mock_import_organismes_usecase_for.return_value = use_case
+
+    await _run(OrganismeReferentiel.DILA)
+
+    mock_import_organismes_usecase_for.assert_called_once_with(
+        container, OrganismeReferentiel.DILA
+    )
+    use_case.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("bin.organismes_pipeline.import_organismes_usecase_for")
+@patch("bin.organismes_pipeline.create_container")
+async def test_run_without_referentiel_imports_all_referentiels(
+    mock_create_container, mock_import_organismes_usecase_for
+):
+    container = _make_container()
+    mock_create_container.return_value = container
+    mock_import_organismes_usecase_for.return_value = _make_import_usecase(None)
+
+    await _run(None)
+
+    assert mock_import_organismes_usecase_for.call_args_list == [
+        call(container, referentiel) for referentiel in OrganismeReferentiel
+    ]


### PR DESCRIPTION
## 📝 Description

- Ajoute `--referentiel` à `organismes_pipeline.py` pour traiter un seul référentiel au lieu de tous, et un nouveau bin `clean_publish_organismes.py` pour nettoyer/publier un référentiel déjà importé sans relancer l'import.
- Les erreurs de publication par organisme sont désormais journalisées sans interrompre le script.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
