### PR TITLE
🎨(recruteur) lever une erreur si l'agent a rattacher à l'organisme n'existe pas

### DIFF
--- a/src/web/application/recruteur/usecases/attach_organisme_agent.py
+++ b/src/web/application/recruteur/usecases/attach_organisme_agent.py
@@ -13,6 +13,7 @@ from application.recruteur.services.organisme_agent_query_service_interface impo
 )
 from domain.commons.services.audit_log_writer import AuditLogWriter
 from domain.identite.entities.utilisateurs import Utilisateur
+from domain.identite.errors.agent_errors import ProfilAgentNexistePas
 from domain.identite.repositories.agent_repository_interface import IAgentRepository
 from domain.identite.services.organisme_permission_service import (
     OrganismePermissionService,
@@ -56,8 +57,7 @@ class AttachOrganismeAgentUsecase(
             utilisateur=command.utilisateur,
         )
         if not self.agent_repository.exists(command.agent_id):
-            # TODO: create agent if not exists
-            pass
+            raise ProfilAgentNexistePas(command.agent_id)
 
         self.organisme_agent_repository.attach(
             organisme_id=command.organisme_id,

--- a/src/web/presentation/recruteur/views/organisme_agents.py
+++ b/src/web/presentation/recruteur/views/organisme_agents.py
@@ -20,6 +20,7 @@ from application.recruteur.usecases.update_organisme_agent import (
     UpdateOrganismeAgentCommand,
 )
 from domain.commons.errors.organisme_errors import OrganismeNexistePas
+from domain.identite.errors.agent_errors import ProfilAgentNexistePas
 from domain.identite.errors.organisme_permission_errors import (
     AccesOrganismeRefuse,
     OperationOrganismeRefusee,
@@ -121,10 +122,11 @@ class OrganismeAgentsView(APIView):
             )
         except (AccesOrganismeRefuse, OperationOrganismeRefusee):
             return Response({"detail": "Forbidden."}, status=status.HTTP_403_FORBIDDEN)
-        except OrganismeNexistePas:
-            return Response(
-                {"organisme_id": "Not found."}, status=status.HTTP_404_NOT_FOUND
+        except (OrganismeNexistePas, ProfilAgentNexistePas) as error:
+            field = (
+                "organisme_id" if isinstance(error, OrganismeNexistePas) else "agent_id"
             )
+            return Response({field: "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except AgentDejaRattache:
             return Response(
                 {"agent_id": "Agent already attached to this organisme."},

--- a/src/web/tests/application/recruteur/test_attach_organisme_agent.py
+++ b/src/web/tests/application/recruteur/test_attach_organisme_agent.py
@@ -8,6 +8,7 @@ from application.recruteur.usecases.attach_organisme_agent import (
 )
 from config.app_config import AppConfig
 from domain.commons.errors.organisme_errors import OrganismeNexistePas
+from domain.identite.errors.agent_errors import ProfilAgentNexistePas
 from domain.identite.errors.organisme_permission_errors import AccesOrganismeRefuse
 from domain.recruteur.errors.organisme_agent_errors import AgentDejaRattache
 from domain.recruteur.value_objects.roles import AgentOrganismeRole
@@ -149,8 +150,21 @@ def test_raises_when_agent_already_attached(db, usecase):
 
 
 def test_raises_when_agent_does_not_exist(db, usecase):
-    # TODO: implement test when usecase also updated
-    pass
+    responsable, organisme = OrganismeFactory.create_model_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
+
+    with pytest.raises(ProfilAgentNexistePas):
+        usecase.execute(
+            AttachOrganismeAgentCommand(
+                organisme_id=organisme.id,
+                agent_id=uuid4(),
+                role=AgentOrganismeRole.MEMBRE,
+                utilisateur=UtilisateurFactory.create_entity(
+                    entity_id=responsable.utilisateur_id, is_staff=False
+                ),
+            )
+        )
 
 
 def test_raises_when_organisme_does_not_exist(db, usecase):


### PR DESCRIPTION
## 📝 Description
🎸 Le endpoint `organismes/<uuid:organisme_uuid>/parametres/agents` ne gèrait pas encore le cas où l'agent à rattacher à un organisme n'existait pas.

Décision : 
1. déléguer à un autre endpoint, la gestion de la création de l'agent, sur la base du usecase `CreateAgentUsecase`
2. lever une erreur dans `AttachOrganismeAgentUsecase` si l'agent à rattacher n'existe pas 

cette PR concerne le point #2 

## 🏷️ Type de changement
- [x] 🐛 Correction de bug


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
