### PR TITLE
♻️(referentiel) convertir les enums en TextChoices Django like

### DIFF
--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "ddd",
-    "django>=6.0.1,<7.0.0",
     "pydantic>=2.0.0",
     "pydantic-extra-types>=2.0.0",
     "pycountry>=24.6.1",

--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "referentiel"
-version = "0.2.8"
+version = "0.2.9"
 description = "Cross-service objects for the CSPLab monorepo"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/referentiel/pyproject.toml
+++ b/libs/referentiel/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
     "ddd",
+    "django>=6.0.1,<7.0.0",
     "pydantic>=2.0.0",
     "pydantic-extra-types>=2.0.0",
     "pycountry>=24.6.1",

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -56,6 +65,20 @@ dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.3" },
+]
+
+[[package]]
+name = "django"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/d4/8314b5bdef20832f0ac6ae3b3e4d4924e4759fa3b4af27609dd747e7a6be/django-6.1.1.tar.gz", hash = "sha256:7ab93536d8e677aa14554c56426290c69480bf2ee68d7513d4a22f57d6bfeb84", size = 11284905, upload-time = "2026-09-02T17:20:45.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/ca/c1040a4fd15754ede7df15fd72fc2e123045b473b253ab5f5284e11c651e/django-6.1.1-py3-none-any.whl", hash = "sha256:585fb82bf15053c42cf52e67c2f1b54a032dca384759315fd6678ab1870d1d72", size = 8419512, upload-time = "2026-09-02T17:20:39.153Z" },
 ]
 
 [[package]]
@@ -193,10 +216,11 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },
+    { name = "django" },
     { name = "pycountry" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -212,6 +236,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ddd", editable = "../ddd" },
+    { name = "django", specifier = ">=6.0.1,<7.0.0" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.0.0" },
@@ -250,6 +275,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -268,4 +302,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },

--- a/libs/referentiel/uv.lock
+++ b/libs/referentiel/uv.lock
@@ -12,15 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asgiref"
-version = "3.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -65,20 +56,6 @@ dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.3" },
-]
-
-[[package]]
-name = "django"
-version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/d4/8314b5bdef20832f0ac6ae3b3e4d4924e4759fa3b4af27609dd747e7a6be/django-6.1.1.tar.gz", hash = "sha256:7ab93536d8e677aa14554c56426290c69480bf2ee68d7513d4a22f57d6bfeb84", size = 11284905, upload-time = "2026-09-02T17:20:45.621Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/ca/c1040a4fd15754ede7df15fd72fc2e123045b473b253ab5f5284e11c651e/django-6.1.1-py3-none-any.whl", hash = "sha256:585fb82bf15053c42cf52e67c2f1b54a032dca384759315fd6678ab1870d1d72", size = 8419512, upload-time = "2026-09-02T17:20:39.153Z" },
 ]
 
 [[package]]
@@ -220,7 +197,6 @@ version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "ddd" },
-    { name = "django" },
     { name = "pycountry" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -236,7 +212,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ddd", editable = "../ddd" },
-    { name = "django", specifier = ">=6.0.1,<7.0.0" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.0.0" },
@@ -275,15 +250,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sqlparse"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -302,13 +268,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "tzdata"
-version = "2026.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]

--- a/libs/referentiel/value_objects/_choices.py
+++ b/libs/referentiel/value_objects/_choices.py
@@ -1,0 +1,62 @@
+"""Minimal reimplementation of django.db.models.TextChoices.
+
+referentiel is consumed by services that do not depend on Django (e.g.
+ingestion), so it must not import django itself. This mirrors the subset of
+Django's TextChoices API actually used across the codebase (member.label,
+Cls.choices/labels/values, str(member) == member.value) without the
+dependency.
+"""
+
+import enum
+from enum import EnumType
+from enum import property as enum_property
+
+
+class ChoicesType(EnumType):
+    """Metaclass turning ``NAME = "value", "label"`` members into a choices enum."""
+
+    def __new__(metacls, classname, bases, classdict, **kwds):
+        labels = []
+        for key in classdict._member_names:
+            value = classdict[key]
+            if isinstance(value, (list, tuple)) and len(value) > 1:
+                *value, label = value
+                value = tuple(value)
+            else:
+                label = key.replace("_", " ").title()
+            labels.append(label)
+            dict.__setitem__(classdict, key, value)
+        cls = super().__new__(metacls, classname, bases, classdict, **kwds)
+        for member, label in zip(cls.__members__.values(), labels, strict=True):
+            member._label_ = label
+        return enum.unique(cls)
+
+    @property
+    def choices(cls):
+        return [(member.value, member.label) for member in cls]
+
+    @property
+    def labels(cls):
+        return [label for _, label in cls.choices]
+
+    @property
+    def values(cls):
+        return [value for value, _ in cls.choices]
+
+
+class TextChoices(str, enum.Enum, metaclass=ChoicesType):
+    """String enum exposing ``.label`` per member and ``.choices`` on the class."""
+
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return name
+
+    @enum_property
+    def label(self):
+        return self._label_
+
+    def __str__(self):
+        return str(self.value)
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}.{self._name_}"

--- a/libs/referentiel/value_objects/_choices.py
+++ b/libs/referentiel/value_objects/_choices.py
@@ -7,29 +7,11 @@ Cls.choices/labels/values, str(member) == member.value) without the
 dependency.
 """
 
-import enum
-from enum import EnumType
-from enum import property as enum_property
+from enum import Enum, EnumType
 
 
 class ChoicesType(EnumType):
-    """Metaclass turning ``NAME = "value", "label"`` members into a choices enum."""
-
-    def __new__(metacls, classname, bases, classdict, **kwds):
-        labels = []
-        for key in classdict._member_names:
-            value = classdict[key]
-            if isinstance(value, (list, tuple)) and len(value) > 1:
-                *value, label = value
-                value = tuple(value)
-            else:
-                label = key.replace("_", " ").title()
-            labels.append(label)
-            dict.__setitem__(classdict, key, value)
-        cls = super().__new__(metacls, classname, bases, classdict, **kwds)
-        for member, label in zip(cls.__members__.values(), labels, strict=True):
-            member._label_ = label
-        return enum.unique(cls)
+    """Adds ``.choices`` / ``.labels`` / ``.values`` class-level properties."""
 
     @property
     def choices(cls):
@@ -37,23 +19,21 @@ class ChoicesType(EnumType):
 
     @property
     def labels(cls):
-        return [label for _, label in cls.choices]
+        return [member.label for member in cls]
 
     @property
     def values(cls):
-        return [value for value, _ in cls.choices]
+        return [member.value for member in cls]
 
 
-class TextChoices(str, enum.Enum, metaclass=ChoicesType):
+class TextChoices(str, Enum, metaclass=ChoicesType):
     """String enum exposing ``.label`` per member and ``.choices`` on the class."""
 
-    @staticmethod
-    def _generate_next_value_(name, start, count, last_values):
-        return name
-
-    @enum_property
-    def label(self):
-        return self._label_
+    def __new__(cls, value, label):
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.label = label
+        return obj
 
     def __str__(self):
         return str(self.value)

--- a/libs/referentiel/value_objects/access_modality.py
+++ b/libs/referentiel/value_objects/access_modality.py
@@ -1,24 +1,21 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class AccessModality(Enum):
-    CONCOURS_EXTERNE = "Concours externe"
-    TROISIEME_CONCOURS = "3ème concours"
-    TROISIEME_CONCOURS_EXCEPT = "3ème concours except"
-    CONCOURS_INTERNE = "Concours interne"
-    CONCOURS_INTERNE_EXCEPT = "Concours interne except."
-    SANS_CONCOURS = "Sans concours"
-    CONCOURS_EXTERNE_EXCEPT = "Concours externe except."
-    EXAMEN_PROFESSIONNEL = "Examen professionnel"
-    LISTE_APTITUDE = "Liste d'aptitude"
-    RECRUTEMENT_SUR_TITRE = "Recrutement sur titre"
-    PAR_VOIE_IRA = "Par voie des IRA"
-    CONCOURS_COMPLEMENTAIRE = "Concours complémentaire"
-    DEUXIEME_CONCOURS = "Deuxième concours"
-    TOUR_EXTERIEUR = "Tour extérieur"
-    CONCOURS_UNIQUE = "Concours unique"
-    CONCOURS_RESERVE = "Concours réservé"
-    AU_CHOIX = "Au choix"
-
-    def __str__(self) -> str:
-        return self.value
+class AccessModality(TextChoices):
+    CONCOURS_EXTERNE = "Concours externe", "Concours externe"
+    TROISIEME_CONCOURS = "3ème concours", "3ème concours"
+    TROISIEME_CONCOURS_EXCEPT = "3ème concours except", "3ème concours except"
+    CONCOURS_INTERNE = "Concours interne", "Concours interne"
+    CONCOURS_INTERNE_EXCEPT = "Concours interne except.", "Concours interne except."
+    SANS_CONCOURS = "Sans concours", "Sans concours"
+    CONCOURS_EXTERNE_EXCEPT = "Concours externe except.", "Concours externe except."
+    EXAMEN_PROFESSIONNEL = "Examen professionnel", "Examen professionnel"
+    LISTE_APTITUDE = "Liste d'aptitude", "Liste d'aptitude"
+    RECRUTEMENT_SUR_TITRE = "Recrutement sur titre", "Recrutement sur titre"
+    PAR_VOIE_IRA = "Par voie des IRA", "Par voie des IRA"
+    CONCOURS_COMPLEMENTAIRE = "Concours complémentaire", "Concours complémentaire"
+    DEUXIEME_CONCOURS = "Deuxième concours", "Deuxième concours"
+    TOUR_EXTERIEUR = "Tour extérieur", "Tour extérieur"
+    CONCOURS_UNIQUE = "Concours unique", "Concours unique"
+    CONCOURS_RESERVE = "Concours réservé", "Concours réservé"
+    AU_CHOIX = "Au choix", "Au choix"

--- a/libs/referentiel/value_objects/access_modality.py
+++ b/libs/referentiel/value_objects/access_modality.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class AccessModality(TextChoices):

--- a/libs/referentiel/value_objects/area.py
+++ b/libs/referentiel/value_objects/area.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class GeographicalArea(TextChoices):

--- a/libs/referentiel/value_objects/area.py
+++ b/libs/referentiel/value_objects/area.py
@@ -1,14 +1,11 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class GeographicalArea(Enum):
-    AFRIQUE = "AF"
-    EUROPE = "EU"
-    ASIE = "AS"
-    AMERIQUE = "AM"
-    OCEANIE = "OC"
-    ANTARTIQUE = "AN"
-    MOYEN_ORIENT_AFRIQUE_DU_NORD = "MO"
-
-    def __str__(self):
-        return self.value
+class GeographicalArea(TextChoices):
+    AFRIQUE = "AF", "Afrique"
+    EUROPE = "EU", "Europe"
+    ASIE = "AS", "Asie"
+    AMERIQUE = "AM", "Amérique"
+    OCEANIE = "OC", "Océanie"
+    ANTARTIQUE = "AN", "Antarctique"
+    MOYEN_ORIENT_AFRIQUE_DU_NORD = "MO", "Moyen-Orient/Afrique du Nord"

--- a/libs/referentiel/value_objects/category.py
+++ b/libs/referentiel/value_objects/category.py
@@ -1,12 +1,9 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class Category(Enum):
-    APLUS = "APLUS"
-    A = "A"
-    B = "B"
-    C = "C"
-    HORS_CATEGORIE = "HORS_CATEGORIE"
-
-    def __str__(self):
-        return self.value
+class Category(TextChoices):
+    APLUS = "APLUS", "Catégorie A+"
+    A = "A", "Catégorie A (cadre)"
+    B = "B", "Catégorie B (profession intermédiaire)"
+    C = "C", "Catégorie C (employé)"
+    HORS_CATEGORIE = "HORS_CATEGORIE", "Hors catégorie"

--- a/libs/referentiel/value_objects/category.py
+++ b/libs/referentiel/value_objects/category.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class Category(TextChoices):

--- a/libs/referentiel/value_objects/contract_type.py
+++ b/libs/referentiel/value_objects/contract_type.py
@@ -1,20 +1,20 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class ContractType(Enum):
-    TITULAIRE_CONTRACTUEL = "TITULAIRE_CONTRACTUEL"
-    CONTRACTUELS = "CONTRACTUELS"
-    TERRITORIAL = "TERRITORIAL"
+class ContractType(TextChoices):
+    TITULAIRE_CONTRACTUEL = (
+        "TITULAIRE_CONTRACTUEL",
+        "Emploi ouvert aux titulaires et aux contractuels",
+    )
+    CONTRACTUELS = "CONTRACTUELS", "Emploi ouvert uniquement aux contractuels"
+    TERRITORIAL = (
+        "TERRITORIAL",
+        "Emploi réservé aux fonctionnaires et lauréats d'un concours territorial",
+    )
 
-    def __str__(self):
-        return self.value
 
-
-class ContractKind(Enum):
-    CDD = "CDD"
-    CDI = "CDI"
-    PERMANENT = "Permanent"
-    VACATION = "Vacation"
-
-    def __str__(self):
-        return self.value
+class ContractKind(TextChoices):
+    CDD = "CDD", "CDD"
+    CDI = "CDI", "CDI"
+    PERMANENT = "Permanent", "Permanent"
+    VACATION = "Vacation", "Vacation"

--- a/libs/referentiel/value_objects/contract_type.py
+++ b/libs/referentiel/value_objects/contract_type.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class ContractType(TextChoices):

--- a/libs/referentiel/value_objects/domaine_fonctionnel.py
+++ b/libs/referentiel/value_objects/domaine_fonctionnel.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class DomaineFonctionnel(TextChoices):

--- a/libs/referentiel/value_objects/domaine_fonctionnel.py
+++ b/libs/referentiel/value_objects/domaine_fonctionnel.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class DomaineFonctionnel(Enum):
+class DomaineFonctionnel(TextChoices):
     ACHAT = ("ACH", "Achat")
     AGRICULTURE = ("AGR", "Agriculture")
     AMENAGEMENT_DEVELOPPEMENT_DURABLE_TERRITOIRE = (
@@ -43,12 +43,3 @@ class DomaineFonctionnel(Enum):
     SOCIAL_ENFANCE_FAMILLE = ("SOC", "Social, enfance et famille")
     TRANSPORTS = ("TRA", "Transports")
     RELATION_USAGER = ("USA", "Relation à l'usager")
-
-    def __new__(cls, code: str, label: str):
-        obj = object.__new__(cls)
-        obj._value_ = code
-        obj.label = label
-        return obj
-
-    def __str__(self):
-        return self.value

--- a/libs/referentiel/value_objects/experience_level.py
+++ b/libs/referentiel/value_objects/experience_level.py
@@ -1,10 +1,7 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class ExperienceLevel(Enum):
-    DEBUTANT = "Débutant"
-    CONFIRME = "Confirmé"
-    EXPERT = "Expert"
-
-    def __str__(self):
-        return self.value
+class ExperienceLevel(TextChoices):
+    DEBUTANT = "Débutant", "Débutant"
+    CONFIRME = "Confirmé", "Confirmé"
+    EXPERT = "Expert", "Expert"

--- a/libs/referentiel/value_objects/experience_level.py
+++ b/libs/referentiel/value_objects/experience_level.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class ExperienceLevel(TextChoices):

--- a/libs/referentiel/value_objects/job_family_referential.py
+++ b/libs/referentiel/value_objects/job_family_referential.py
@@ -1,8 +1,5 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class JobFamilyReferential(Enum):
-    RMFPV2 = "RMFPv2"
-
-    def __str__(self):
-        return self.value
+class JobFamilyReferential(TextChoices):
+    RMFPV2 = "RMFPv2", "RMFPv2"

--- a/libs/referentiel/value_objects/job_family_referential.py
+++ b/libs/referentiel/value_objects/job_family_referential.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class JobFamilyReferential(TextChoices):

--- a/libs/referentiel/value_objects/language_level.py
+++ b/libs/referentiel/value_objects/language_level.py
@@ -1,13 +1,10 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class LanguageLevel(Enum):
-    A1 = "A1"
-    A2 = "A2"
-    B1 = "B1"
-    B2 = "B2"
-    C1 = "C1"
-    C2 = "C2"
-
-    def __str__(self):
-        return self.value
+class LanguageLevel(TextChoices):
+    A1 = "A1", "A1"
+    A2 = "A2", "A2"
+    B1 = "B1", "B1"
+    B2 = "B2", "B2"
+    C1 = "C1", "C1"
+    C2 = "C2", "C2"

--- a/libs/referentiel/value_objects/language_level.py
+++ b/libs/referentiel/value_objects/language_level.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class LanguageLevel(TextChoices):

--- a/libs/referentiel/value_objects/ministry.py
+++ b/libs/referentiel/value_objects/ministry.py
@@ -1,28 +1,28 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class Ministry(Enum):
-    MAA = "MAA"
-    MESRI = "MESRI"
-    MEF = "MEF"
-    MEN = "MEN"
-    DGAC = "DGAC"
-    MSS = "MSS"
-    MC = "MC"
-    MJ = "MJ"
-    MI = "MI"
-    MTE = "MTE"
-    MEAE = "MEAE"
-    METEO_FRANCE = "Météo France"
-    MTEI = "MTEI"
-    CONSEIL_ETAT = "CONSEIL ETAT"
-    COUR_COMPTES = "COUR COMPTES"
-    INTERMINISTERIEL = "INTERMINISTERIEL"
-    PREMIER_MINISTRE = "PREMIER MINISTRE"
-    CAISSE_DES_DEPOTS_ET_CONSIGNATIONS = "CAISSE DES DEPOTS ET CONSIGNATIONS"
-    CESE = "CESE"
-    VNF = "VNF"
-    IGN = "IGN"
-
-    def __str__(self):
-        return self.value
+class Ministry(TextChoices):
+    MAA = "MAA", "Ministère de l'Agriculture et de la Souveraineté alimentaire"
+    MESRI = "MESRI", "Ministère de l'Enseignement supérieur et de la Recherche"
+    MEF = "MEF", "Ministère de l'Économie et des Finances"
+    MEN = "MEN", "Ministère de l'Éducation nationale"
+    DGAC = "DGAC", "Direction générale de l'Aviation civile"
+    MSS = "MSS", "Ministère de la Santé et des Solidarités"
+    MC = "MC", "Ministère de la Culture"
+    MJ = "MJ", "Ministère de la Justice"
+    MI = "MI", "Ministère de l'Intérieur"
+    MTE = "MTE", "Ministère de la Transition écologique"
+    MEAE = "MEAE", "Ministère de l'Europe et des Affaires étrangères"
+    METEO_FRANCE = "Météo France", "Météo-France"
+    MTEI = "MTEI", "Ministère du Travail, de l'Emploi et de l'Insertion"
+    CONSEIL_ETAT = "CONSEIL ETAT", "Conseil d'État"
+    COUR_COMPTES = "COUR COMPTES", "Cour des comptes"
+    INTERMINISTERIEL = "INTERMINISTERIEL", "Interministériel"
+    PREMIER_MINISTRE = "PREMIER MINISTRE", "Services du Premier ministre"
+    CAISSE_DES_DEPOTS_ET_CONSIGNATIONS = (
+        "CAISSE DES DEPOTS ET CONSIGNATIONS",
+        "Caisse des Dépôts et Consignations",
+    )
+    CESE = "CESE", "Conseil économique, social et environnemental"
+    VNF = "VNF", "Voies navigables de France"
+    IGN = "IGN", "Institut national de l'information géographique et forestière"

--- a/libs/referentiel/value_objects/ministry.py
+++ b/libs/referentiel/value_objects/ministry.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class Ministry(TextChoices):

--- a/libs/referentiel/value_objects/offer_conditions.py
+++ b/libs/referentiel/value_objects/offer_conditions.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class Management(TextChoices):

--- a/libs/referentiel/value_objects/offer_conditions.py
+++ b/libs/referentiel/value_objects/offer_conditions.py
@@ -1,43 +1,28 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class Management(Enum):
-    SANS = "Sans management"
-    AVEC = "Avec management"
-
-    def __str__(self):
-        return self.value
+class Management(TextChoices):
+    SANS = "Sans management", "Sans management"
+    AVEC = "Avec management", "Avec management"
 
 
-class WorkingPlace(Enum):
-    NON_DEFINI = "Non défini"
-    SUR_SITE = "Sur site"
-    TELETRAVAIL = "Télétravail"
-
-    def __str__(self):
-        return self.value
+class WorkingPlace(TextChoices):
+    NON_DEFINI = "Non défini", "Non défini"
+    SUR_SITE = "Sur site", "Sur site"
+    TELETRAVAIL = "Télétravail", "Télétravail"
 
 
-class OpenToMilitary(Enum):
-    NON = "Non"
-    OUI = "Oui"
-
-    def __str__(self):
-        return self.value
+class OpenToMilitary(TextChoices):
+    NON = "Non", "Non"
+    OUI = "Oui", "Oui"
 
 
-class WorkingTime(Enum):
-    NON_DEFINI = "Non défini"
-    TEMPS_PLEIN = "Temps plein"
-    TEMPS_PARTIEL = "Temps incomplet"
-
-    def __str__(self):
-        return self.value
+class WorkingTime(TextChoices):
+    NON_DEFINI = "Non défini", "Non défini"
+    TEMPS_PLEIN = "Temps plein", "Temps plein"
+    TEMPS_PARTIEL = "Temps incomplet", "Temps incomplet"
 
 
-class JobVacancy(Enum):
-    OUI = "Poste vacant"
-    NON = "Poste susceptible d'être vacant"
-
-    def __str__(self):
-        return self.value
+class JobVacancy(TextChoices):
+    OUI = "Poste vacant", "Poste vacant"
+    NON = "Poste susceptible d'être vacant", "Poste susceptible d'être vacant"

--- a/libs/referentiel/value_objects/source_type.py
+++ b/libs/referentiel/value_objects/source_type.py
@@ -1,9 +1,6 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class SourceType(Enum):
-    TALENTSOFT = "talentsoft"
-    API = "api"
-
-    def __str__(self) -> str:
-        return self.value
+class SourceType(TextChoices):
+    TALENTSOFT = "talentsoft", "talentsoft"
+    API = "api", "api"

--- a/libs/referentiel/value_objects/source_type.py
+++ b/libs/referentiel/value_objects/source_type.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class SourceType(TextChoices):

--- a/libs/referentiel/value_objects/type_competence.py
+++ b/libs/referentiel/value_objects/type_competence.py
@@ -1,10 +1,7 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class TypeCompetence(Enum):
-    SAVOIR_FAIRE = "SAVOIR_FAIRE"
-    SAVOIR_ETRE = "SAVOIR_ETRE"
-    CONNAISSANCE = "CONNAISSANCE"
-
-    def __str__(self):
-        return self.value
+class TypeCompetence(TextChoices):
+    SAVOIR_FAIRE = "SAVOIR_FAIRE", "SAVOIR_FAIRE"
+    SAVOIR_ETRE = "SAVOIR_ETRE", "SAVOIR_ETRE"
+    CONNAISSANCE = "CONNAISSANCE", "CONNAISSANCE"

--- a/libs/referentiel/value_objects/type_competence.py
+++ b/libs/referentiel/value_objects/type_competence.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class TypeCompetence(TextChoices):

--- a/libs/referentiel/value_objects/verse.py
+++ b/libs/referentiel/value_objects/verse.py
@@ -1,10 +1,7 @@
-from enum import Enum
+from django.db.models import TextChoices
 
 
-class Verse(Enum):
-    FPT = "FPT"
-    FPE = "FPE"
-    FPH = "FPH"
-
-    def __str__(self):
-        return self.value
+class Verse(TextChoices):
+    FPT = "FPT", "Fonction publique Territoriale"
+    FPE = "FPE", "Fonction publique de l'État"
+    FPH = "FPH", "Fonction publique Hospitalière"

--- a/libs/referentiel/value_objects/verse.py
+++ b/libs/referentiel/value_objects/verse.py
@@ -1,4 +1,4 @@
-from django.db.models import TextChoices
+from referentiel.value_objects._choices import TextChoices
 
 
 class Verse(TextChoices):

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -64,15 +64,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asgiref"
-version = "3.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
-]
-
-[[package]]
 name = "ast-serialize"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -497,20 +488,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/ef/d715f4cd2e947fddc4c8763be1c4099793caf38aa1a099b6d621ecfeb768/dependency_injector-4.49.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ba7e94e4323219c93dac35aabba7efa4e91c9afeac044b1d50bdc66a00a07238", size = 1845636, upload-time = "2026-06-18T17:51:07.023Z" },
     { url = "https://files.pythonhosted.org/packages/e7/32/03d1e5e0c6b79eaabf2ed4155302df05832e54789cc9f670cc62af20897b/dependency_injector-4.49.1-cp310-abi3-win32.whl", hash = "sha256:5a6e3a0df8cff636da3d7212473e30dff897c5bdbca2dd3049b5363012a495fa", size = 1548655, upload-time = "2026-06-18T17:51:08.721Z" },
     { url = "https://files.pythonhosted.org/packages/93/51/ce3ca96314f93f44358523cb8cdf81c8c1e002b4e097141e460bc598c87f/dependency_injector-4.49.1-cp310-abi3-win_amd64.whl", hash = "sha256:153f6b8d1db35d1fc9b001e41564a47ab2a7708038fecefadf3afada8ec7f814", size = 1676934, upload-time = "2026-06-18T17:51:10.465Z" },
-]
-
-[[package]]
-name = "django"
-version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/d4/8314b5bdef20832f0ac6ae3b3e4d4924e4759fa3b4af27609dd747e7a6be/django-6.1.1.tar.gz", hash = "sha256:7ab93536d8e677aa14554c56426290c69480bf2ee68d7513d4a22f57d6bfeb84", size = 11284905, upload-time = "2026-09-02T17:20:45.621Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/ca/c1040a4fd15754ede7df15fd72fc2e123045b473b253ab5f5284e11c651e/django-6.1.1-py3-none-any.whl", hash = "sha256:585fb82bf15053c42cf52e67c2f1b54a032dca384759315fd6678ab1870d1d72", size = 8419512, upload-time = "2026-09-02T17:20:39.153Z" },
 ]
 
 [[package]]
@@ -1484,7 +1461,6 @@ version = "0.2.9"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },
-    { name = "django" },
     { name = "pycountry" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -1493,7 +1469,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "ddd", editable = "../../libs/ddd" },
-    { name = "django", specifier = ">=6.0.1,<7.0.0" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.0.0" },
@@ -1672,15 +1647,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/ee/22a0559283c3cf6048678e787ed5d4959dcd00dedd8ba4567eeae684eeb1/sqlmodel-0.0.39.tar.gz", hash = "sha256:23d8e50a8d8ee936032ed79c55023a5d618dd6bc3c510bbf4909d1a7a605a570", size = 91057, upload-time = "2026-06-25T13:01:38.475Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/7d/b9813a582d4eb310be35e1fc7dfaae71207d7b62e9e53be314ebd251b53b/sqlmodel-0.0.39-py3-none-any.whl", hash = "sha256:90ebe92ce5cc11d7fff8dc7cb594790a102333c8fe7c14865254f6fc5c939795", size = 29680, upload-time = "2026-06-25T13:01:37.494Z" },
-]
-
-[[package]]
-name = "sqlparse"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -64,6 +64,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +497,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/ef/d715f4cd2e947fddc4c8763be1c4099793caf38aa1a099b6d621ecfeb768/dependency_injector-4.49.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ba7e94e4323219c93dac35aabba7efa4e91c9afeac044b1d50bdc66a00a07238", size = 1845636, upload-time = "2026-06-18T17:51:07.023Z" },
     { url = "https://files.pythonhosted.org/packages/e7/32/03d1e5e0c6b79eaabf2ed4155302df05832e54789cc9f670cc62af20897b/dependency_injector-4.49.1-cp310-abi3-win32.whl", hash = "sha256:5a6e3a0df8cff636da3d7212473e30dff897c5bdbca2dd3049b5363012a495fa", size = 1548655, upload-time = "2026-06-18T17:51:08.721Z" },
     { url = "https://files.pythonhosted.org/packages/93/51/ce3ca96314f93f44358523cb8cdf81c8c1e002b4e097141e460bc598c87f/dependency_injector-4.49.1-cp310-abi3-win_amd64.whl", hash = "sha256:153f6b8d1db35d1fc9b001e41564a47ab2a7708038fecefadf3afada8ec7f814", size = 1676934, upload-time = "2026-06-18T17:51:10.465Z" },
+]
+
+[[package]]
+name = "django"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/d4/8314b5bdef20832f0ac6ae3b3e4d4924e4759fa3b4af27609dd747e7a6be/django-6.1.1.tar.gz", hash = "sha256:7ab93536d8e677aa14554c56426290c69480bf2ee68d7513d4a22f57d6bfeb84", size = 11284905, upload-time = "2026-09-02T17:20:45.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/ca/c1040a4fd15754ede7df15fd72fc2e123045b473b253ab5f5284e11c651e/django-6.1.1-py3-none-any.whl", hash = "sha256:585fb82bf15053c42cf52e67c2f1b54a032dca384759315fd6678ab1870d1d72", size = 8419512, upload-time = "2026-09-02T17:20:39.153Z" },
 ]
 
 [[package]]
@@ -1461,6 +1484,7 @@ version = "0.2.8"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },
+    { name = "django" },
     { name = "pycountry" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -1469,6 +1493,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "ddd", editable = "../../libs/ddd" },
+    { name = "django", specifier = ">=6.0.1,<7.0.0" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.0.0" },
@@ -1647,6 +1672,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/ee/22a0559283c3cf6048678e787ed5d4959dcd00dedd8ba4567eeae684eeb1/sqlmodel-0.0.39.tar.gz", hash = "sha256:23d8e50a8d8ee936032ed79c55023a5d618dd6bc3c510bbf4909d1a7a605a570", size = 91057, upload-time = "2026-06-25T13:01:38.475Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/7d/b9813a582d4eb310be35e1fc7dfaae71207d7b62e9e53be314ebd251b53b/sqlmodel-0.0.39-py3-none-any.whl", hash = "sha256:90ebe92ce5cc11d7fff8dc7cb594790a102333c8fe7c14865254f6fc5c939795", size = 29680, upload-time = "2026-06-25T13:01:37.494Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1480,7 +1480,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1369,7 +1369,7 @@ wheels = [
 
 [[package]]
 name = "referentiel"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1373,6 +1373,7 @@ version = "0.2.8"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },
+    { name = "django" },
     { name = "pycountry" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -1381,6 +1382,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "ddd", editable = "../../libs/ddd" },
+    { name = "django", specifier = ">=6.0.1,<7.0.0" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.0.0" },

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1373,7 +1373,6 @@ version = "0.2.9"
 source = { editable = "../../libs/referentiel" }
 dependencies = [
     { name = "ddd" },
-    { name = "django" },
     { name = "pycountry" },
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
@@ -1382,7 +1381,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "ddd", editable = "../../libs/ddd" },
-    { name = "django", specifier = ">=6.0.1,<7.0.0" },
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.0.0" },


### PR DESCRIPTION
## 📝 Description

Permet d'exposer les référentiels (choix + libellés) de manière homogène côté API et admin Django, sans dupliquer les libellés ailleurs dans le code.

## 🏷️ Type de changement
- [x] ♻️ Refactorisation

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
