### PR TITLE
♻️(tooling) inject scaleway secrets from the mise env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Le monorepo est organisé en services :
 
 - [mise](https://mise.jdx.dev/getting-started.html) : lanceur de tâches du repo ([docs/mise.md](docs/mise.md)), il installe et épingle lui-même les outils (node, pnpm, uv).
 - Docker + Docker Compose (Colima, Docker Desktop, OrbStack…)
+- [scw](https://www.scaleway.com/en/docs/scaleway-cli/quickstart/) : les secrets des services sont lus dans Scaleway Secret Manager. `scw init` enregistre une [clé d'API](https://www.scaleway.com/en/docs/iam/how-to/create-api-keys/) et le projet CSPLab (identifiants fournis par l'équipe) dans `~/.config/scw/config.yaml`.
 - [poppler](https://poppler.freedesktop.org/) : requis pour le service OCR en local (géré automatiquement en production via l'`Aptfile`)
 - [tesseract](https://tesseract-ocr.github.io/tessdoc/Installation.html) avec le pack de langue française (`tesseract-lang` sur macOS, `tesseract-ocr-fra` sur Linux) — requis pour le service OCR en local (géré automatiquement en production via l'`Aptfile`)
 
@@ -42,7 +43,7 @@ Pour repartir de zéro sur une machine existante (fichiers d'env réinitialisés
 
 ### Configuration
 
-Après l'installation, complétez si besoin les fichiers `env.d/*` avec vos vraies valeurs (clés API, etc.).
+Les fichiers `env.d/*`, créés depuis les exemples, portent la configuration locale (ports, bases Docker, `SCALEWAY_ENV=dev`). Les secrets viennent de Scaleway Secret Manager et sont injectés par mise à chaque tâche : `mise run secrets:check` vérifie l'accès et liste ce qui est disponible. Détail dans [docs/mise.md](docs/mise.md), section Secrets.
 
 Pour personnaliser Docker Compose (ex : changer les ports), voir [docs/docker_compose_override.md](docs/docker_compose_override.md).
 

--- a/docs/mise.md
+++ b/docs/mise.md
@@ -62,6 +62,8 @@ Prérequis, une fois par machine : `scw init` avec le projet et la région CSPLa
 
 `mise run secrets:check` vérifie l'accès et liste les noms des secrets de chaque service.
 
+Les tâches de test chargent `env.test` (valeurs factices, versionnées) et tournent sans accès à Scaleway. `mise.ci.toml` charge le même fichier.
+
 ## Détection de changements
 
 Certaines tâches comparent leurs fichiers d'entrée et de sortie et ne s'exécutent que si nécessaire : le build du frontend, le build Storybook, les `install` (relancés quand `uv.lock` ou `pnpm-lock.yaml` change) et la conversion jupytext. Les tâches `dev` et `test` dépendent de `install` : après un pull qui change un lockfile, les dépendances se mettent à jour toutes seules au prochain lancement.

--- a/docs/mise.md
+++ b/docs/mise.md
@@ -54,6 +54,14 @@ Le `mise.toml` de chaque sous-projet charge son fichier `env.d/*` et active son 
 
 En dev, les pages ATS chargent leurs assets depuis le serveur Vite, pas depuis le build : `mise run dev` lance les deux (Django + Vite HMR) ; `web:dev` et `front:dev` restent disponibles séparément. Le build n'est utilisé que quand `debug` est désactivé, notamment par les tests e2e, qui le régénèrent en dépendance.
 
+## Secrets
+
+Chaque service lit ses secrets dans Scaleway Secret Manager, sous `/{service}/{SCALEWAY_ENV}` (`/web/dev`, `/ingestion/dev`, `/ocr/dev`). La directive `_.source` de la section `[env]` les charge quand mise calcule l'environnement du service : toutes ses tâches et le shell activé en disposent. Le calcul a lieu à l'entrée dans le dossier et à chaque changement de configuration.
+
+Prérequis, une fois par machine : `scw init` avec le projet et la région CSPLab. Les identifiants sont stockés dans `~/.config/scw/config.yaml`. Les variables `SCW_*`, si elles sont définies, ont priorité : c'est le mode utilisé sur Scalingo. Sans `SCALEWAY_ENV`, le chargement est ignoré et la CI fournit ses valeurs dans `mise.ci.toml`.
+
+`mise run secrets:check` vérifie l'accès et liste les noms des secrets de chaque service.
+
 ## Détection de changements
 
 Certaines tâches comparent leurs fichiers d'entrée et de sortie et ne s'exécutent que si nécessaire : le build du frontend, le build Storybook, les `install` (relancés quand `uv.lock` ou `pnpm-lock.yaml` change) et la conversion jupytext. Les tâches `dev` et `test` dépendent de `install` : après un pull qui change un lockfile, les dépendances se mettent à jour toutes seules au prochain lancement.

--- a/env.d/ingestion-example
+++ b/env.d/ingestion-example
@@ -1,7 +1,6 @@
 # In dev, secrets are fetched from Scaleway Secret Manager instead of being
-# set here, one secret per env value, named after the field (e.g.
-# "database_url") under the "/ingestion/{SCALEWAY_ENV}" directory (e.g.
-# "/ingestion/dev"). Authenticate with `scw init` (or export SCW_ACCESS_KEY /
-# SCW_SECRET_KEY / SCW_DEFAULT_PROJECT_ID / SCW_DEFAULT_REGION yourself), then
-# set SCALEWAY_ENV to your environment, e.g. dev.
+# set here, one secret per env value, named after the field (e.g. "database_url")
+# under the "/ingestion/{SCALEWAY_ENV}" directory (e.g. "/ingestion/dev").
+# Run `scw init` once per machine, then set SCALEWAY_ENV to your environment.
+# Check with `mise run secrets:check`.
 SCALEWAY_ENV=dev

--- a/env.d/ocr-example
+++ b/env.d/ocr-example
@@ -1,7 +1,6 @@
 # In dev, secrets are fetched from Scaleway Secret Manager instead of being
 # set here, one secret per env value, named after the field (e.g. "api_key")
-# under the "/ocr/{SCALEWAY_ENV}" directory (e.g. "/ocr/dev"). Authenticate
-# with `scw init` (or export SCW_ACCESS_KEY / SCW_SECRET_KEY /
-# SCW_DEFAULT_PROJECT_ID / SCW_DEFAULT_REGION yourself), then set
-# SCALEWAY_ENV to your environment, e.g. dev.
+# under the "/ocr/{SCALEWAY_ENV}" directory (e.g. "/ocr/dev").
+# Run `scw init` once per machine, then set SCALEWAY_ENV to your environment.
+# Check with `mise run secrets:check`.
 SCALEWAY_ENV=dev

--- a/env.d/web-example
+++ b/env.d/web-example
@@ -1,9 +1,8 @@
 # In dev, secrets are fetched from Scaleway Secret Manager instead of being
-# set here, one secret per env value, named after the field (e.g.
-# "WEB_SECRET_KEY") under the "/web/{SCALEWAY_ENV}" directory (e.g.
-# "/web/dev"). Authenticate with `scw init` (or export SCW_ACCESS_KEY /
-# SCW_SECRET_KEY / SCW_DEFAULT_PROJECT_ID / SCW_DEFAULT_REGION yourself), then
-# set SCALEWAY_ENV to your environment, e.g. dev.
+# set here, one secret per env value, named after the field (e.g. "WEB_SECRET_KEY")
+# under the "/web/{SCALEWAY_ENV}" directory (e.g. "/web/dev").
+# Run `scw init` once per machine, then set SCALEWAY_ENV to your environment.
+# Check with `mise run secrets:check`.
 SCALEWAY_ENV=dev
 
 PORT=8000

--- a/libs/scaleway_secrets/README.md
+++ b/libs/scaleway_secrets/README.md
@@ -9,3 +9,5 @@ Invoked as `python -m scaleway_secrets.fetch <service>` from each service's
 
 Credentials come from the `scw` config file (`scw init`, or `SCW_CONFIG_PATH`)
 when it exists, and from the `SCW_*` env vars, which take precedence.
+
+`--names` prints the secret names only, for diagnostics (`mise run secrets:check`).

--- a/libs/scaleway_secrets/README.md
+++ b/libs/scaleway_secrets/README.md
@@ -6,3 +6,6 @@ script before a service's process starts.
 
 Invoked as `python -m scaleway_secrets.fetch <service>` from each service's
 `bin/inject_scaleway_env.sh`.
+
+Credentials come from the `scw` config file (`scw init`, or `SCW_CONFIG_PATH`)
+when it exists, and from the `SCW_*` env vars, which take precedence.

--- a/libs/scaleway_secrets/fetch.py
+++ b/libs/scaleway_secrets/fetch.py
@@ -3,9 +3,9 @@
 Meant to be eval'd by a shell script before a service's process starts (see
 each service's bin/inject_scaleway_env.sh), so config lives in Scaleway
 Secret Manager instead of being set by hand (dev, and prod's Scalingo
-dashboard alike). Scaleway API credentials (SCW_ACCESS_KEY, SCW_SECRET_KEY,
-SCW_DEFAULT_PROJECT_ID, SCW_DEFAULT_REGION) are still real env vars, read the
-same way the `scw` CLI reads them.
+dashboard alike). Scaleway API credentials come from the `scw` CLI config
+file (`scw init`) or from the SCW_ACCESS_KEY, SCW_SECRET_KEY,
+SCW_DEFAULT_PROJECT_ID and SCW_DEFAULT_REGION env vars, which take precedence.
 """
 
 from __future__ import annotations
@@ -14,9 +14,11 @@ import base64
 import os
 import shlex
 import sys
+from pathlib import Path
 
 from scaleway import Client
 from scaleway.secret.v1beta1 import SecretV1Beta1API
+from scaleway_core.profile import Profile
 
 
 def main(service: str) -> None:
@@ -25,7 +27,10 @@ def main(service: str) -> None:
         return
     secret_path = f"/{service}/{env}"
 
-    client = Client.from_env()
+    config_file = Path(Profile.get_default_config_file_path())
+    client = (
+        Client.from_config_file_and_env() if config_file.exists() else Client.from_env()
+    )
     api = SecretV1Beta1API(client)
 
     for secret in api.list_secrets_all(path=secret_path, scheduled_for_deletion=False):

--- a/libs/scaleway_secrets/fetch.py
+++ b/libs/scaleway_secrets/fetch.py
@@ -21,7 +21,7 @@ from scaleway.secret.v1beta1 import SecretV1Beta1API
 from scaleway_core.profile import Profile
 
 
-def main(service: str) -> None:
+def main(service: str, names_only: bool = False) -> None:
     env = os.environ.get("SCALEWAY_ENV")
     if not env:
         return
@@ -35,6 +35,9 @@ def main(service: str) -> None:
 
     for secret in api.list_secrets_all(path=secret_path, scheduled_for_deletion=False):
         name = secret.name.upper()
+        if names_only:
+            print(name)
+            continue
         if os.environ.get(name):
             continue  # a real Scalingo env var was set by hand: it wins
         response = api.access_secret_version(
@@ -45,10 +48,12 @@ def main(service: str) -> None:
 
 
 def cli() -> None:
-    if len(sys.argv) != 2:
-        print("usage: python -m scaleway_secrets.fetch <service>", file=sys.stderr)
+    args = [arg for arg in sys.argv[1:] if arg != "--names"]
+    if len(args) != 1:
+        usage = "usage: python -m scaleway_secrets.fetch <service> [--names]"
+        print(usage, file=sys.stderr)
         raise SystemExit(1)
-    main(sys.argv[1])
+    main(args[0], names_only="--names" in sys.argv)
 
 
 if __name__ == "__main__":

--- a/libs/scaleway_secrets/pyproject.toml
+++ b/libs/scaleway_secrets/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scaleway_secrets"
-version = "0.1.0"
+version = "0.1.1"
 description = "Fetch a service's secrets from Scaleway Secret Manager as shell exports"
 readme = "README.md"
 requires-python = "~=3.12.0"

--- a/libs/scaleway_secrets/uv.lock
+++ b/libs/scaleway_secrets/uv.lock
@@ -266,7 +266,7 @@ wheels = [
 
 [[package]]
 name = "scaleway-secrets"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "scaleway" },

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 
 min_version = "2026.8.14"
 monorepo_root = true
+redactions = ["*SECRET*", "*_KEY", "*PASSWORD*", "*TOKEN*", "*CREDENTIALS*", "DATABASE_URL", "*_DATABASE_URL"]
 
 [monorepo]
 config_roots = [

--- a/mise.toml
+++ b/mise.toml
@@ -25,6 +25,10 @@ uv = "0.9"
 # corepack shims let pnpm resolve its version from packageManager (single source of truth)
 node.corepack = true
 
+[tasks."secrets:check"]
+description = "Check the Scaleway access and list the secret names of every service"
+depends = ["//src/web:secrets:check", "//src/ingestion:secrets:check", "//src/ocr:secrets:check"]
+
 [tasks.default]
 description = "Show the everyday commands"
 hide = true

--- a/src/ingestion/bin/inject_scaleway_env.sh
+++ b/src/ingestion/bin/inject_scaleway_env.sh
@@ -9,8 +9,18 @@
 if [ -n "${SCALEWAY_ENV:-}" ]; then
     if [ "$SCALEWAY_ENV" = "prod" ] && [ -z "${SCALINGO_APPLICATION_ID:-}" ]; then
         echo "SCALEWAY_ENV=prod is only allowed on Scalingo (SCALINGO_APPLICATION_ID not set)" >&2
-        exit 1
+        return 1
     fi
-    scaleway_env="$(python -m scaleway_secrets.fetch ingestion)"
+    lib_dir="$(dirname "${BASH_SOURCE[0]}")/../../../libs/scaleway_secrets"
+    if command -v uv >/dev/null 2>&1; then
+        fetch=(uv run -q --project "$lib_dir" python -m scaleway_secrets.fetch ingestion)
+    else
+        fetch=(python -m scaleway_secrets.fetch ingestion)
+    fi
+    if [ "$SCALEWAY_ENV" = "prod" ]; then
+        scaleway_env="$("${fetch[@]}")" || return 1
+    else
+        scaleway_env="$("${fetch[@]}" 2>/dev/null)" || return 1
+    fi
     eval "$scaleway_env"
 fi

--- a/src/ingestion/mise.toml
+++ b/src/ingestion/mise.toml
@@ -1,6 +1,7 @@
 [env]
 _.file = "../../env.d/ingestion"
 _.python.venv = { path = ".venv" }
+_.source = { path = "bin/inject_scaleway_env.sh", tools = true }
 
 [tasks.install]
 alias = "ingestion:install"
@@ -15,7 +16,6 @@ description = "Ingestion API + celery worker + flower (uvicorn :8002)"
 depends = ["install", "//:services:postgres", "//:services:redis"]
 shell = "bash -c"
 run = """
-source bin/inject_scaleway_env.sh
 trap 'kill 0' EXIT
 uvicorn api.main:app --reload --port=8002 &
 bin/start_worker.sh &
@@ -40,13 +40,13 @@ alias = "ingestion:migrate"
 description = "Apply alembic migrations"
 depends = ["db:create"]
 shell = "bash -c"
-run = "source bin/inject_scaleway_env.sh && uv run alembic upgrade head"
+run = "uv run alembic upgrade head"
 
 [tasks.migration]
 alias = "ingestion:migration"
 description = "Generate an alembic migration (mise run :migration -- -m 'description')"
 shell = "bash -c"
-run = "source bin/inject_scaleway_env.sh && uv run alembic revision --autogenerate"
+run = "uv run alembic revision --autogenerate"
 
 [tasks.test]
 alias = "ingestion:test"
@@ -85,7 +85,7 @@ alias = "ingestion:lint:migrations"
 description = "Check alembic migrations are up to date"
 depends = ["db:create"]
 shell = "bash -c"
-run = "source bin/inject_scaleway_env.sh && uv run alembic upgrade head && uv run alembic check"
+run = "uv run alembic upgrade head && uv run alembic check"
 
 [tasks."lint:fix"]
 alias = "ingestion:lint:fix"

--- a/src/ingestion/mise.toml
+++ b/src/ingestion/mise.toml
@@ -10,6 +10,11 @@ sources = ["pyproject.toml", "uv.lock"]
 outputs = { auto = true }
 run = "uv sync --locked"
 
+[tasks."secrets:check"]
+alias = "ingestion:secrets:check"
+description = "Check the Scaleway access and list the secret names of this service"
+run = "uv run -q --project ../../libs/scaleway_secrets python -m scaleway_secrets.fetch ingestion --names"
+
 [tasks.dev]
 alias = "ingestion:dev"
 description = "Ingestion API + celery worker + flower (uvicorn :8002)"

--- a/src/ingestion/uv.lock
+++ b/src/ingestion/uv.lock
@@ -1563,7 +1563,7 @@ wheels = [
 
 [[package]]
 name = "scaleway-secrets"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "../../libs/scaleway_secrets" }
 dependencies = [
     { name = "scaleway" },

--- a/src/ocr/bin/inject_scaleway_env.sh
+++ b/src/ocr/bin/inject_scaleway_env.sh
@@ -9,8 +9,18 @@
 if [ -n "${SCALEWAY_ENV:-}" ]; then
     if [ "$SCALEWAY_ENV" = "prod" ] && [ -z "${SCALINGO_APPLICATION_ID:-}" ]; then
         echo "SCALEWAY_ENV=prod is only allowed on Scalingo (SCALINGO_APPLICATION_ID not set)" >&2
-        exit 1
+        return 1
     fi
-    scaleway_env="$(python -m scaleway_secrets.fetch ocr)"
+    lib_dir="$(dirname "${BASH_SOURCE[0]}")/../../../libs/scaleway_secrets"
+    if command -v uv >/dev/null 2>&1; then
+        fetch=(uv run -q --project "$lib_dir" python -m scaleway_secrets.fetch ocr)
+    else
+        fetch=(python -m scaleway_secrets.fetch ocr)
+    fi
+    if [ "$SCALEWAY_ENV" = "prod" ]; then
+        scaleway_env="$("${fetch[@]}")" || return 1
+    else
+        scaleway_env="$("${fetch[@]}" 2>/dev/null)" || return 1
+    fi
     eval "$scaleway_env"
 fi

--- a/src/ocr/env.test
+++ b/src/ocr/env.test
@@ -1,0 +1,1 @@
+API_KEY=test-api-key-for-development

--- a/src/ocr/mise.ci.toml
+++ b/src/ocr/mise.ci.toml
@@ -1,5 +1,5 @@
 # Loaded over mise.toml when MISE_ENV=ci: env.d/ocr isn't checked out in CI,
-# so provide the API key the settings module needs at import time.
+# so provide the test values the settings module needs at import time.
 
 [env]
-API_KEY = "test-api-key-for-development"
+_.file = "env.test"

--- a/src/ocr/mise.toml
+++ b/src/ocr/mise.toml
@@ -1,6 +1,7 @@
 [env]
 _.file = "../../env.d/ocr"
 _.python.venv = { path = ".venv" }
+_.source = { path = "bin/inject_scaleway_env.sh", tools = true }
 
 [tasks.install]
 alias = "ocr:install"
@@ -15,7 +16,6 @@ description = "OCR API (uvicorn :8001)"
 depends = ["install"]
 shell = "bash -c"
 run = """
-source bin/inject_scaleway_env.sh
 uvicorn api.main:app --reload --port=8001
 """
 

--- a/src/ocr/mise.toml
+++ b/src/ocr/mise.toml
@@ -28,12 +28,14 @@ uvicorn api.main:app --reload --port=8001
 alias = "ocr:test"
 description = "OCR tests"
 depends = ["install"]
+env = { _.file = "env.test" }
 run = "pytest --no-cov"
 
 [tasks."test:cov"]
 alias = "ocr:test:cov"
 description = "OCR tests with an HTML coverage report"
 depends = ["install"]
+env = { _.file = "env.test" }
 run = [
   "pytest --cov=. --cov-report=html:tests/cov_html --cov-report=term-missing",
   "open tests/cov_html/index.html",

--- a/src/ocr/mise.toml
+++ b/src/ocr/mise.toml
@@ -10,6 +10,11 @@ sources = ["pyproject.toml", "uv.lock"]
 outputs = { auto = true }
 run = "uv sync --group dev --locked"
 
+[tasks."secrets:check"]
+alias = "ocr:secrets:check"
+description = "Check the Scaleway access and list the secret names of this service"
+run = "uv run -q --project ../../libs/scaleway_secrets python -m scaleway_secrets.fetch ocr --names"
+
 [tasks.dev]
 alias = "ocr:dev"
 description = "OCR API (uvicorn :8001)"

--- a/src/ocr/uv.lock
+++ b/src/ocr/uv.lock
@@ -1162,7 +1162,7 @@ wheels = [
 
 [[package]]
 name = "scaleway-secrets"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "../../libs/scaleway_secrets" }
 dependencies = [
     { name = "scaleway" },

--- a/src/web/bin/inject_scaleway_env.sh
+++ b/src/web/bin/inject_scaleway_env.sh
@@ -9,8 +9,18 @@
 if [ -n "${SCALEWAY_ENV:-}" ]; then
     if [ "$SCALEWAY_ENV" = "prod" ] && [ -z "${SCALINGO_APPLICATION_ID:-}" ]; then
         echo "SCALEWAY_ENV=prod is only allowed on Scalingo (SCALINGO_APPLICATION_ID not set)" >&2
-        exit 1
+        return 1
     fi
-    scaleway_env="$(python -m scaleway_secrets.fetch web)"
+    lib_dir="$(dirname "${BASH_SOURCE[0]}")/../../../libs/scaleway_secrets"
+    if command -v uv >/dev/null 2>&1; then
+        fetch=(uv run -q --project "$lib_dir" python -m scaleway_secrets.fetch web)
+    else
+        fetch=(python -m scaleway_secrets.fetch web)
+    fi
+    if [ "$SCALEWAY_ENV" = "prod" ]; then
+        scaleway_env="$("${fetch[@]}")" || return 1
+    else
+        scaleway_env="$("${fetch[@]}" 2>/dev/null)" || return 1
+    fi
     eval "$scaleway_env"
 fi

--- a/src/web/env.test
+++ b/src/web/env.test
@@ -1,0 +1,4 @@
+WEB_SECRET_KEY=the_secret_key
+WEB_QDRANT_URL=http://localhost:6333
+WEB_VECTOR_DB_TYPE=QDRANT
+DJANGO_SETTINGS_MODULE=config.settings.test

--- a/src/web/mise.ci.toml
+++ b/src/web/mise.ci.toml
@@ -1,9 +1,6 @@
 # Loaded over mise.toml when MISE_ENV=ci: env.d/web isn't checked out in CI,
-# so provide what the settings module and the test database need.
+# so provide the test values and the database the workflow's service exposes.
 
 [env]
-WEB_SECRET_KEY = "the_secret_key"
+_.file = "env.test"
 WEB_DATABASE_URL = "psql://postgres:pass@localhost:5432/web"
-WEB_QDRANT_URL = "http://localhost:6333"
-WEB_VECTOR_DB_TYPE = "QDRANT"
-DJANGO_SETTINGS_MODULE = "config.settings.test"

--- a/src/web/mise.toml
+++ b/src/web/mise.toml
@@ -115,18 +115,21 @@ run = [
 alias = "web:test"
 description = "Backend tests (e2e and accessibility excluded)"
 depends = ["install:py", "//:services:postgres"]
+env = { _.file = "env.test" }
 run = "pytest --numprocesses=logical --create-db -m 'not accessibility and not e2e' --no-cov"
 
 [tasks."test:e2e"]
 alias = "web:test:e2e"
 description = "Playwright e2e tests (live_server + browser, rebuilds the frontend when needed)"
 depends = ["install:py", "//src/web/presentation/frontend:build", "//:services:postgres"]
+env = { _.file = "env.test" }
 run = "pytest -m e2e --no-cov"
 
 [tasks."test:a11y"]
 alias = "web:test:a11y"
 description = "Accessibility tests (Playwright + axe)"
 depends = ["install:py", "//:services:postgres"]
+env = { _.file = "env.test" }
 run = "pytest -m accessibility --create-db --no-cov"
 
 [tasks.lint]
@@ -223,6 +226,7 @@ run = [
 alias = "web:test:cov"
 description = "Web tests with an HTML coverage report"
 depends = ["install:py", "//:services:postgres"]
+env = { _.file = "env.test" }
 run = [
   "mkdir -p tests/cov_html",
   "pytest --cov=application --cov=domain --cov=infrastructure --cov=presentation --numprocesses=logical --create-db -m 'not accessibility and not e2e' --cov-append --exitfirst",

--- a/src/web/mise.toml
+++ b/src/web/mise.toml
@@ -22,6 +22,11 @@ sources = ["package.json", "pnpm-lock.yaml", "presentation/frontend/package.json
 outputs = { auto = true }
 run = "pnpm install"
 
+[tasks."secrets:check"]
+alias = "web:secrets:check"
+description = "Check the Scaleway access and list the secret names of this service"
+run = "uv run -q --project ../../libs/scaleway_secrets python -m scaleway_secrets.fetch web --names"
+
 [tasks.dev]
 alias = "web:dev"
 description = "Django dev server"

--- a/src/web/mise.toml
+++ b/src/web/mise.toml
@@ -1,6 +1,7 @@
 [env]
 _.file = "../../env.d/web"
 _.python.venv = { path = ".venv" }
+_.source = { path = "bin/inject_scaleway_env.sh", tools = true }
 
 [tasks.install]
 alias = "web:install"
@@ -27,7 +28,6 @@ description = "Django dev server"
 depends = ["install:py", "//:services:postgres"]
 shell = "bash -c"
 run = """
-source bin/inject_scaleway_env.sh
 python manage.py runserver
 """
 
@@ -54,14 +54,14 @@ alias = "web:migrate"
 description = "Apply Django migrations"
 depends = ["install:py", "//:services:postgres"]
 shell = "bash -c"
-run = "source bin/inject_scaleway_env.sh && python manage.py migrate"
+run = "python manage.py migrate"
 
 [tasks.migration]
 alias = "web:migration"
 description = "Generate Django migrations (makemigrations)"
 depends = ["install:py", "//:services:postgres"]
 shell = "bash -c"
-run = "source bin/inject_scaleway_env.sh && python manage.py makemigrations"
+run = "python manage.py makemigrations"
 
 [tasks.manage]
 alias = "web:manage"
@@ -161,7 +161,7 @@ alias = "web:lint:migrations"
 description = "Check no Django migration is missing"
 depends = ["install:py"]
 shell = "bash -c"
-run = "source bin/inject_scaleway_env.sh && python manage.py makemigrations --check"
+run = "python manage.py makemigrations --check"
 
 [tasks."lint:candidate-js"]
 alias = "web:lint:candidate-js"

--- a/src/web/uv.lock
+++ b/src/web/uv.lock
@@ -1522,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "scaleway-secrets"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "../../libs/scaleway_secrets" }
 dependencies = [
     { name = "scaleway" },


### PR DESCRIPTION
## 📝 Description
🎸 Suite de #1270 et #1302 :

1. Seules certaines tâches sourçaient les secrets, directement dans leur script de lancement : cette PR propose d'utiliser [l'injection idiomatique de mise](https://mise.jdx.dev/environments/#env-source) propagée à toutes les tâches au chargement du shell (1 ou 2s au chargement puis >0.1s par commande lancée ensuite)

2. Le mécanisme recommandé "scw init" ne fonctionnait pas en l'état et est préférable à la déclaration des variables SCW_* faites dans plusieurs fichiersaujourd'hui => cette PR permet d'utiliser [le cli scaleway](https://github.com/scaleway/scaleway-cli#basic-commands) pour configurer une seule fois les variables (les variables gardent la priorité si déclarées).

3. La suite de tests dépendait d'un accès scaleway => cette PR permet de lancer les tests offline

4. ajoute une `redaction` dans mise pour les variables sensibles

5. Ajoute une tâche `mise run secrets:check` pour le diagnostic des secrets

## 🏝️ Comment tester (si applicable)

- Dans un terminal neuf sur main, avant cette PR, `mise run web:manage -- check` échoue, sur la branche il passe
- Télécharger le cli scw, lancer `scw init`, suivre les étapes de config, puis `mise run secrets:check`
- mise run bootstrap:reset doit passer entièrement
- `mise run web:manage -- shell -c "import os; print(os.environ['WEB_SECRET_KEY'])"` doit afficher [redacted].
- `mise run web:test`doit passer offline