### PR TITLE
✨(recruteur) endpoint de creation d'un agent

### DIFF
--- a/src/web/application/identite/usecases/create_agent.py
+++ b/src/web/application/identite/usecases/create_agent.py
@@ -40,7 +40,7 @@ class CreateAgentUsecase:
 
     def can_execute(self, input_data: CreateAgentInput) -> None:
         self.permission_service.est_autorise(
-            action=OrganismeAction.CREER_AGENT,
+            action=OrganismeAction.CREATE_AGENT,
             utilisateur=input_data.utilisateur,
             organisme_id=input_data.organisme_id,
         )

--- a/src/web/application/identite/usecases/create_agent.py
+++ b/src/web/application/identite/usecases/create_agent.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from uuid import UUID
 
 from pydantic import EmailStr
 
@@ -10,6 +11,10 @@ from domain.identite.repositories.agent_repository_interface import IAgentReposi
 from domain.identite.repositories.utilisateur_repository_interface import (
     IUtilisateurRepository,
 )
+from domain.identite.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.identite.value_objects.organisme_action import OrganismeAction
 
 
 @dataclass
@@ -18,6 +23,8 @@ class CreateAgentInput:
     prenom: str
     nom: str
     intitule_poste: str
+    organisme_id: UUID
+    utilisateur: Utilisateur
 
 
 class CreateAgentUsecase:
@@ -25,19 +32,32 @@ class CreateAgentUsecase:
         self,
         agent_repository: IAgentRepository,
         utilisateur_repository: IUtilisateurRepository,
+        permission_service: OrganismePermissionService,
     ):
         self.agent_repository = agent_repository
         self.utilisateur_repository = utilisateur_repository
+        self.permission_service = permission_service
+
+    def can_execute(self, input_data: CreateAgentInput) -> None:
+        self.permission_service.est_autorise(
+            action=OrganismeAction.CREER_AGENT,
+            utilisateur=input_data.utilisateur,
+            organisme_id=input_data.organisme_id,
+        )
 
     def execute(self, input_data: CreateAgentInput) -> Agent:
+        self.can_execute(input_data)
+
         existing = self.agent_repository.get_by_email(input_data.email)
         if existing is not None:
             raise ProfilAgentExisteDeja(input_data.email)
 
         try:
-            utilisateur = self.utilisateur_repository.get_by_email(input_data.email)
+            agent_utilisateur = self.utilisateur_repository.get_by_email(
+                input_data.email
+            )
         except UtilisateurNexistePas:
-            utilisateur = self.utilisateur_repository.create(
+            agent_utilisateur = self.utilisateur_repository.create(
                 Utilisateur(
                     email=input_data.email,
                     prenom=input_data.prenom,
@@ -50,7 +70,7 @@ class CreateAgentUsecase:
             prenom=input_data.prenom,
             nom=input_data.nom,
             intitule_poste=input_data.intitule_poste,
-            user_id=utilisateur.entity_id,
+            user_id=agent_utilisateur.entity_id,
         )
 
-        return self.agent_repository.create(utilisateur, agent)
+        return self.agent_repository.create(agent_utilisateur, agent)

--- a/src/web/domain/identite/services/organisme_permission_service.py
+++ b/src/web/domain/identite/services/organisme_permission_service.py
@@ -44,6 +44,7 @@ _AUTORISE_POUR_STAFF: frozenset[OrganismeAction] = frozenset(
         OrganismeAction.ATTACH_ORGANISME_AGENT,
         OrganismeAction.UPDATE_ORGANISME_AGENT,
         OrganismeAction.REVOKE_ORGANISME_AGENT,
+        OrganismeAction.CREER_AGENT,
     }
 )
 
@@ -78,6 +79,7 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.ATTACH_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.UPDATE_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.REVOKE_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
+    OrganismeAction.CREER_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
 }
 
 # -------------------------------------

--- a/src/web/domain/identite/services/organisme_permission_service.py
+++ b/src/web/domain/identite/services/organisme_permission_service.py
@@ -44,7 +44,7 @@ _AUTORISE_POUR_STAFF: frozenset[OrganismeAction] = frozenset(
         OrganismeAction.ATTACH_ORGANISME_AGENT,
         OrganismeAction.UPDATE_ORGANISME_AGENT,
         OrganismeAction.REVOKE_ORGANISME_AGENT,
-        OrganismeAction.CREER_AGENT,
+        OrganismeAction.CREATE_AGENT,
     }
 )
 
@@ -79,7 +79,7 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.ATTACH_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.UPDATE_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.REVOKE_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
-    OrganismeAction.CREER_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
+    OrganismeAction.CREATE_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
 }
 
 # -------------------------------------

--- a/src/web/domain/identite/value_objects/organisme_action.py
+++ b/src/web/domain/identite/value_objects/organisme_action.py
@@ -18,3 +18,4 @@ class OrganismeAction(Enum):
     ATTACH_ORGANISME_AGENT = "attach_organisme_agent"
     UPDATE_ORGANISME_AGENT = "update_organisme_agent"
     REVOKE_ORGANISME_AGENT = "revoke_organisme_agent"
+    CREER_AGENT = "creer_agent"

--- a/src/web/domain/identite/value_objects/organisme_action.py
+++ b/src/web/domain/identite/value_objects/organisme_action.py
@@ -18,4 +18,4 @@ class OrganismeAction(Enum):
     ATTACH_ORGANISME_AGENT = "attach_organisme_agent"
     UPDATE_ORGANISME_AGENT = "update_organisme_agent"
     REVOKE_ORGANISME_AGENT = "revoke_organisme_agent"
-    CREER_AGENT = "creer_agent"
+    CREATE_AGENT = "create_agent"

--- a/src/web/infrastructure/di/identite/identite_container.py
+++ b/src/web/infrastructure/di/identite/identite_container.py
@@ -65,12 +65,6 @@ class IdentiteContainer(containers.DeclarativeContainer):
         utilisateur_repository=postgres_utilisateur_repository,
     )
 
-    create_agent_usecase = providers.Factory(
-        CreateAgentUsecase,
-        agent_repository=postgres_agent_repository,
-        utilisateur_repository=postgres_utilisateur_repository,
-    )
-
     create_candidat_usecase = providers.Factory(
         CreateCandidatUsecase,
         candidat_repository=postgres_candidat_repository,
@@ -100,6 +94,13 @@ class IdentiteContainer(containers.DeclarativeContainer):
         organisme_recruteur_repository=postgres_organisme_recruteur_repository,
         organisme_agent_repository=postgres_organisme_agent_repository,
         recrutement_agent_repository=postgres_recrutement_agent_repository,
+    )
+
+    create_agent_usecase = providers.Factory(
+        CreateAgentUsecase,
+        agent_repository=postgres_agent_repository,
+        utilisateur_repository=postgres_utilisateur_repository,
+        permission_service=organisme_permission_service,
     )
 
     create_organisme_usecase = providers.Factory(

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -4,6 +4,23 @@
  */
 
 export interface paths {
+    "/recruteur/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Créer un profil agent */
+        post: operations["recruteur_agents_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/recruteur/candidatures/{candidature_uuid}/notes": {
         parameters: {
             query?: never;
@@ -294,6 +311,15 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        Agent: {
+            /** Format: uuid */
+            agent_id: string;
+            /** Format: email */
+            email: string;
+            prenom: string;
+            nom: string;
+            intitule_poste: string;
+        };
         AgentOrganisme: {
             /** Format: uuid */
             agent_id: string;
@@ -373,6 +399,15 @@ export interface components {
         ChangerEtapeResultat: {
             reussites: string[];
             echecs: components["schemas"]["CandidatureEchec"][];
+        };
+        CreateAgent: {
+            /** Format: email */
+            email: string;
+            prenom: string;
+            nom: string;
+            intitule_poste: string;
+            /** Format: uuid */
+            organisme_id: string;
         };
         CreateOrganisme: {
             nom: string;
@@ -788,6 +823,71 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    recruteur_agents_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAgent"];
+                "application/x-www-form-urlencoded": components["schemas"]["CreateAgent"];
+                "multipart/form-data": components["schemas"]["CreateAgent"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Agent"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+        };
+    };
     recruteur_candidatures_notes_list: {
         parameters: {
             query?: never;

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -144,6 +144,7 @@ class CreateAgentSerializer(serializers.Serializer):
     prenom = serializers.CharField()
     nom = serializers.CharField()
     intitule_poste = serializers.CharField()
+    organisme_id = serializers.UUIDField()
 
 
 class AgentSerializer(serializers.Serializer):

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -135,6 +135,26 @@ class CandidatureListeSerializer(serializers.Serializer):
 
 
 # ---------------------------------------------------------------------------
+# Serializers pour la création d'un profil agent
+# ---------------------------------------------------------------------------
+
+
+class CreateAgentSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    prenom = serializers.CharField()
+    nom = serializers.CharField()
+    intitule_poste = serializers.CharField()
+
+
+class AgentSerializer(serializers.Serializer):
+    agent_id = serializers.UUIDField(source="entity_id")
+    email = serializers.EmailField()
+    prenom = serializers.CharField()
+    nom = serializers.CharField()
+    intitule_poste = serializers.CharField()
+
+
+# ---------------------------------------------------------------------------
 # Serializers pour les agents rattachés à un organisme
 # ---------------------------------------------------------------------------
 

--- a/src/web/presentation/recruteur/urls.py
+++ b/src/web/presentation/recruteur/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from presentation.recruteur.views.agents import AgentsView
 from presentation.recruteur.views.notes import (
     CandidatureNoteDetailView,
     CandidatureNotesView,
@@ -33,6 +34,11 @@ from presentation.recruteur.views.recrutement_params import (
 app_name = "recruteur"
 
 urlpatterns = [
+    path(
+        "agents",
+        AgentsView.as_view(),
+        name="agents",
+    ),
     path(
         "organismes",
         OrganismesView.as_view(),

--- a/src/web/presentation/recruteur/views/agents.py
+++ b/src/web/presentation/recruteur/views/agents.py
@@ -1,0 +1,52 @@
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from application.identite.usecases.create_agent import CreateAgentInput
+from domain.identite.errors.agent_errors import ProfilAgentExisteDeja
+from infrastructure.di.identite.identite_factory import create_identite_container
+from presentation.api.serializers import GenericErrorSerializer, generic_response_format
+from presentation.recruteur.serializers import AgentSerializer, CreateAgentSerializer
+
+
+@extend_schema_view(
+    post=extend_schema(
+        summary="Créer un profil agent",
+        tags=["recruteur"],
+        request=CreateAgentSerializer,
+        responses={
+            **generic_response_format,
+            201: AgentSerializer,
+            400: GenericErrorSerializer,
+        },
+    ),
+)
+class AgentsView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.container = create_identite_container()
+
+    def post(self, request: Request) -> Response:
+        serializer = CreateAgentSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            usecase = self.container.create_agent_usecase()
+            agent = usecase.execute(CreateAgentInput(**serializer.validated_data))
+            return Response(AgentSerializer(agent).data, status=status.HTTP_201_CREATED)
+        except ProfilAgentExisteDeja as e:
+            return Response(
+                GenericErrorSerializer({"error": str(e)}).data,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Exception:
+            return Response(
+                GenericErrorSerializer({"error": "Unexpected error"}).data,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/src/web/presentation/recruteur/views/agents.py
+++ b/src/web/presentation/recruteur/views/agents.py
@@ -6,9 +6,15 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from application.identite.usecases.create_agent import CreateAgentInput
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.identite.errors.agent_errors import ProfilAgentExisteDeja
+from domain.identite.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    OperationOrganismeRefusee,
+)
 from infrastructure.di.identite.identite_factory import create_identite_container
 from presentation.api.serializers import GenericErrorSerializer, generic_response_format
+from presentation.recruteur.mappers import UtilisateurMapper
 from presentation.recruteur.serializers import AgentSerializer, CreateAgentSerializer
 
 
@@ -21,6 +27,8 @@ from presentation.recruteur.serializers import AgentSerializer, CreateAgentSeria
             **generic_response_format,
             201: AgentSerializer,
             400: GenericErrorSerializer,
+            403: GenericErrorSerializer,
+            404: GenericErrorSerializer,
         },
     ),
 )
@@ -30,6 +38,7 @@ class AgentsView(APIView):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.container = create_identite_container()
+        self.user_mapper = UtilisateurMapper()
 
     def post(self, request: Request) -> Response:
         serializer = CreateAgentSerializer(data=request.data)
@@ -38,12 +47,26 @@ class AgentsView(APIView):
 
         try:
             usecase = self.container.create_agent_usecase()
-            agent = usecase.execute(CreateAgentInput(**serializer.validated_data))
+            agent = usecase.execute(
+                CreateAgentInput(
+                    **serializer.validated_data,
+                    utilisateur=self.user_mapper.to_domain(request),
+                )
+            )
             return Response(AgentSerializer(agent).data, status=status.HTTP_201_CREATED)
         except ProfilAgentExisteDeja as e:
             return Response(
                 GenericErrorSerializer({"error": str(e)}).data,
                 status=status.HTTP_400_BAD_REQUEST,
+            )
+        except (AccesOrganismeRefuse, OperationOrganismeRefusee) as e:
+            return Response(
+                GenericErrorSerializer({"error": str(e)}).data,
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        except OrganismeNexistePas:
+            return Response(
+                {"organisme_id": "Not found."}, status=status.HTTP_404_NOT_FOUND
             )
         except Exception:
             return Response(

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -1636,10 +1636,14 @@ components:
           type: string
         intitule_poste:
           type: string
+        organisme_id:
+          type: string
+          format: uuid
       required:
       - email
       - intitule_poste
       - nom
+      - organisme_id
       - prenom
     CreateOrganisme:
       type: object

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -3,6 +3,64 @@ info:
   title: CSPLab Internal API
   version: 0.0.1
 paths:
+  /recruteur/agents:
+    post:
+      operationId: recruteur_agents_create
+      summary: Créer un profil agent
+      tags:
+      - recruteur
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAgent'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CreateAgent'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CreateAgent'
+        required: true
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
   /recruteur/candidatures/{candidature_uuid}/notes:
     get:
       operationId: recruteur_candidatures_notes_list
@@ -1370,6 +1428,27 @@ paths:
           description: ''
 components:
   schemas:
+    Agent:
+      type: object
+      properties:
+        agent_id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        prenom:
+          type: string
+        nom:
+          type: string
+        intitule_poste:
+          type: string
+      required:
+      - agent_id
+      - email
+      - intitule_poste
+      - nom
+      - prenom
     AgentOrganisme:
       type: object
       properties:
@@ -1545,6 +1624,23 @@ components:
       required:
       - echecs
       - reussites
+    CreateAgent:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        prenom:
+          type: string
+        nom:
+          type: string
+        intitule_poste:
+          type: string
+      required:
+      - email
+      - intitule_poste
+      - nom
+      - prenom
     CreateOrganisme:
       type: object
       properties:

--- a/src/web/tests/application/identite/test_create_agent.py
+++ b/src/web/tests/application/identite/test_create_agent.py
@@ -71,7 +71,7 @@ def test_create_agent_checks_permission(permission_service, usecase):
     usecase.execute(input_data)
 
     permission_service.est_autorise.assert_called_once_with(
-        action=OrganismeAction.CREER_AGENT,
+        action=OrganismeAction.CREATE_AGENT,
         utilisateur=input_data.utilisateur,
         organisme_id=input_data.organisme_id,
     )

--- a/src/web/tests/application/identite/test_create_agent.py
+++ b/src/web/tests/application/identite/test_create_agent.py
@@ -1,0 +1,91 @@
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from faker import Faker
+
+from application.identite.usecases.create_agent import (
+    CreateAgentInput,
+    CreateAgentUsecase,
+)
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
+from domain.identite.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.identite.repositories.agent_repository_interface import IAgentRepository
+from domain.identite.repositories.utilisateur_repository_interface import (
+    IUtilisateurRepository,
+)
+from domain.identite.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.identite.value_objects.organisme_action import OrganismeAction
+from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from infrastructure.factories.identite.utilisateur_factory import UtilisateurFactory
+
+fake = Faker()
+
+
+@pytest.fixture(name="permission_service")
+def permission_service_fixture():
+    service = Mock(spec=OrganismePermissionService)
+    service.est_autorise.return_value = AgentOrganismeRole.RESPONSABLE
+    return service
+
+
+@pytest.fixture(name="agent_repository")
+def agent_repository_fixture():
+    repository = Mock(spec=IAgentRepository)
+    repository.get_by_email.return_value = None
+    return repository
+
+
+@pytest.fixture(name="utilisateur_repository")
+def utilisateur_repository_fixture():
+    repository = Mock(spec=IUtilisateurRepository)
+    repository.get_by_email.return_value = UtilisateurFactory.create_entity()
+    return repository
+
+
+@pytest.fixture(name="usecase")
+def usecase_fixture(permission_service, agent_repository, utilisateur_repository):
+    return CreateAgentUsecase(
+        agent_repository=agent_repository,
+        utilisateur_repository=utilisateur_repository,
+        permission_service=permission_service,
+    )
+
+
+def _input() -> CreateAgentInput:
+    return CreateAgentInput(
+        email=fake.email(),
+        prenom=fake.first_name(),
+        nom=fake.last_name(),
+        intitule_poste=fake.job(),
+        organisme_id=uuid4(),
+        utilisateur=UtilisateurFactory.create_entity(),
+    )
+
+
+def test_create_agent_checks_permission(permission_service, usecase):
+    input_data = _input()
+
+    usecase.execute(input_data)
+
+    permission_service.est_autorise.assert_called_once_with(
+        action=OrganismeAction.CREER_AGENT,
+        utilisateur=input_data.utilisateur,
+        organisme_id=input_data.organisme_id,
+    )
+
+
+@pytest.mark.parametrize(
+    "exception", [AccesOrganismeRefuse(uuid4()), OrganismeNexistePas(str(uuid4()))]
+)
+def test_create_agent_propagates_permission_errors(
+    permission_service, agent_repository, usecase, exception
+):
+    permission_service.est_autorise.side_effect = exception
+
+    with pytest.raises(type(exception)):
+        usecase.execute(_input())
+
+    agent_repository.get_by_email.assert_not_called()

--- a/src/web/tests/domain/identite/test_organisme_permission_service.py
+++ b/src/web/tests/domain/identite/test_organisme_permission_service.py
@@ -42,6 +42,7 @@ RESPONSABLE_ACTIONS = [
     OrganismeAction.ATTACH_ORGANISME_AGENT,
     OrganismeAction.UPDATE_ORGANISME_AGENT,
     OrganismeAction.REVOKE_ORGANISME_AGENT,
+    OrganismeAction.CREER_AGENT,
 ]
 STAFF_BYPASS_ACTIONS = [
     OrganismeAction.GET_ORGANISME,
@@ -51,6 +52,7 @@ STAFF_BYPASS_ACTIONS = [
     OrganismeAction.ATTACH_ORGANISME_AGENT,
     OrganismeAction.UPDATE_ORGANISME_AGENT,
     OrganismeAction.REVOKE_ORGANISME_AGENT,
+    OrganismeAction.CREER_AGENT,
 ]
 
 

--- a/src/web/tests/domain/identite/test_organisme_permission_service.py
+++ b/src/web/tests/domain/identite/test_organisme_permission_service.py
@@ -42,7 +42,7 @@ RESPONSABLE_ACTIONS = [
     OrganismeAction.ATTACH_ORGANISME_AGENT,
     OrganismeAction.UPDATE_ORGANISME_AGENT,
     OrganismeAction.REVOKE_ORGANISME_AGENT,
-    OrganismeAction.CREER_AGENT,
+    OrganismeAction.CREATE_AGENT,
 ]
 STAFF_BYPASS_ACTIONS = [
     OrganismeAction.GET_ORGANISME,
@@ -52,7 +52,7 @@ STAFF_BYPASS_ACTIONS = [
     OrganismeAction.ATTACH_ORGANISME_AGENT,
     OrganismeAction.UPDATE_ORGANISME_AGENT,
     OrganismeAction.REVOKE_ORGANISME_AGENT,
-    OrganismeAction.CREER_AGENT,
+    OrganismeAction.CREATE_AGENT,
 ]
 
 

--- a/src/web/tests/infrastructure/identite/test_create_agent.py
+++ b/src/web/tests/infrastructure/identite/test_create_agent.py
@@ -6,10 +6,13 @@ from config.app_config import AppConfig
 from domain.identite.errors.agent_errors import ProfilAgentExisteDeja
 from infrastructure.di.identite.identite_container import IdentiteContainer
 from infrastructure.factories.identite.agent_factory import AgentFactory
+from infrastructure.factories.identite.organisme_factory import OrganismeFactory
 from infrastructure.factories.identite.utilisateur_factory import UtilisateurFactory
 from infrastructure.gateways.shared.logger import LoggerService
 
 fake = Faker()
+
+STAFF_UTILISATEUR = UtilisateurFactory.create_entity(is_staff=True)
 
 
 @pytest.fixture(name="identite_integration_container")
@@ -22,12 +25,19 @@ def identite_integration_container_fixture(db):
     return container
 
 
-def test_create_agent(identite_integration_container):
+@pytest.fixture(name="organisme_id")
+def organisme_id_fixture(db):
+    return OrganismeFactory.create_model().id
+
+
+def test_create_agent(identite_integration_container, organisme_id):
     input_data = CreateAgentInput(
         email=fake.email(),
         prenom=fake.first_name(),
         nom=fake.last_name(),
         intitule_poste=fake.bothify("MAT-####"),
+        organisme_id=organisme_id,
+        utilisateur=STAFF_UTILISATEUR,
     )
 
     result = identite_integration_container.create_agent_usecase().execute(input_data)
@@ -38,13 +48,15 @@ def test_create_agent(identite_integration_container):
     assert result.intitule_poste == input_data.intitule_poste
 
 
-def test_create_agent_with_existing_user(identite_integration_container):
+def test_create_agent_with_existing_user(identite_integration_container, organisme_id):
     existing_user = UtilisateurFactory.create_model(email=fake.email())
     input_data = CreateAgentInput(
         email=existing_user.email,
         prenom=fake.first_name(),
         nom=fake.last_name(),
         intitule_poste=fake.bothify("MAT-####"),
+        organisme_id=organisme_id,
+        utilisateur=STAFF_UTILISATEUR,
     )
 
     result = identite_integration_container.create_agent_usecase().execute(input_data)
@@ -52,13 +64,15 @@ def test_create_agent_with_existing_user(identite_integration_container):
     assert result.entity_id == existing_user.username
 
 
-def test_cannot_create_agent_twice(identite_integration_container):
+def test_cannot_create_agent_twice(identite_integration_container, organisme_id):
     existing_agent = AgentFactory.create_model()
     input_data = CreateAgentInput(
         email=existing_agent.utilisateur.email,
         prenom=fake.first_name(),
         nom=fake.last_name(),
         intitule_poste=fake.bothify("MAT-####"),
+        organisme_id=organisme_id,
+        utilisateur=STAFF_UTILISATEUR,
     )
 
     with pytest.raises(ProfilAgentExisteDeja):

--- a/src/web/tests/presentation/recruteur/test_views_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_agents.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from django.urls import reverse
@@ -6,7 +7,12 @@ from faker import Faker
 from rest_framework import status
 
 from application.identite.usecases.create_agent import CreateAgentInput
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
 from domain.identite.errors.agent_errors import ProfilAgentExisteDeja
+from domain.identite.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    OperationOrganismeRefusee,
+)
 from infrastructure.factories.identite.agent_factory import AgentFactory
 
 fake = Faker("fr_FR")
@@ -32,11 +38,13 @@ class TestAgentsView:
         agent = AgentFactory.create_entity()
         mock_usecase.execute.return_value = agent
         container.create_agent_usecase.return_value = mock_usecase
+        organisme_id = uuid4()
         body = {
             "email": agent.email,
             "prenom": agent.prenom,
             "nom": agent.nom,
             "intitule_poste": agent.intitule_poste,
+            "organisme_id": str(organisme_id),
         }
 
         response = authenticated_client.post(AGENTS_URL, body)
@@ -44,6 +52,8 @@ class TestAgentsView:
         (called_input,), _ = mock_usecase.execute.call_args
         assert isinstance(called_input, CreateAgentInput)
         assert called_input.email == agent.email
+        assert called_input.organisme_id == organisme_id
+        assert called_input.utilisateur is not None
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == {
             "agent_id": str(agent.entity_id),
@@ -70,6 +80,21 @@ class TestAgentsView:
                 None,
             ),
             (
+                AccesOrganismeRefuse(uuid4()),
+                status.HTTP_403_FORBIDDEN,
+                None,
+            ),
+            (
+                OperationOrganismeRefusee(),
+                status.HTTP_403_FORBIDDEN,
+                None,
+            ),
+            (
+                OrganismeNexistePas(str(uuid4())),
+                status.HTTP_404_NOT_FOUND,
+                {"organisme_id": "Not found."},
+            ),
+            (
                 Exception("unexpected"),
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
                 {"error": "Unexpected error"},
@@ -92,6 +117,7 @@ class TestAgentsView:
             "prenom": fake.first_name(),
             "nom": fake.last_name(),
             "intitule_poste": fake.job(),
+            "organisme_id": str(uuid4()),
         }
 
         response = authenticated_client.post(AGENTS_URL, body)

--- a/src/web/tests/presentation/recruteur/test_views_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_agents.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.urls import reverse
+from faker import Faker
+from rest_framework import status
+
+from application.identite.usecases.create_agent import CreateAgentInput
+from domain.identite.errors.agent_errors import ProfilAgentExisteDeja
+from infrastructure.factories.identite.agent_factory import AgentFactory
+
+fake = Faker("fr_FR")
+
+AGENTS_URL = reverse("recruteur:agents")
+
+
+@pytest.fixture
+def container():
+    with patch("presentation.recruteur.views.agents.create_identite_container") as mock:
+        instance = MagicMock()
+        mock.return_value = instance
+        yield instance
+
+
+class TestAgentsView:
+    def test_anonymous_access_is_unauthorized(self, api_client):
+        response = api_client.post(AGENTS_URL)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_post_create_agent(self, container, authenticated_client):
+        mock_usecase = MagicMock()
+        agent = AgentFactory.create_entity()
+        mock_usecase.execute.return_value = agent
+        container.create_agent_usecase.return_value = mock_usecase
+        body = {
+            "email": agent.email,
+            "prenom": agent.prenom,
+            "nom": agent.nom,
+            "intitule_poste": agent.intitule_poste,
+        }
+
+        response = authenticated_client.post(AGENTS_URL, body)
+
+        (called_input,), _ = mock_usecase.execute.call_args
+        assert isinstance(called_input, CreateAgentInput)
+        assert called_input.email == agent.email
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json() == {
+            "agent_id": str(agent.entity_id),
+            "email": agent.email,
+            "prenom": agent.prenom,
+            "nom": agent.nom,
+            "intitule_poste": agent.intitule_poste,
+        }
+
+    def test_post_missing_field_returns_bad_request(
+        self, container, authenticated_client
+    ):
+        response = authenticated_client.post(AGENTS_URL, {"email": fake.email()})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        container.create_agent_usecase.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("exception", "expected_status", "expected_body"),
+        [
+            (
+                ProfilAgentExisteDeja(fake.email()),
+                status.HTTP_400_BAD_REQUEST,
+                None,
+            ),
+            (
+                Exception("unexpected"),
+                status.HTTP_500_INTERNAL_SERVER_ERROR,
+                {"error": "Unexpected error"},
+            ),
+        ],
+    )
+    def test_post_returns_error_from_usecase(
+        self,
+        container,
+        authenticated_client,
+        exception,
+        expected_status,
+        expected_body,
+    ):
+        mock_usecase = MagicMock()
+        mock_usecase.execute.side_effect = exception
+        container.create_agent_usecase.return_value = mock_usecase
+        body = {
+            "email": fake.email(),
+            "prenom": fake.first_name(),
+            "nom": fake.last_name(),
+            "intitule_poste": fake.job(),
+        }
+
+        response = authenticated_client.post(AGENTS_URL, body)
+
+        assert response.status_code == expected_status
+        if expected_body is not None:
+            assert response.json() == expected_body
+        else:
+            assert response.json() == {"error": str(exception)}

--- a/src/web/tests/utils/shared_fixtures.py
+++ b/src/web/tests/utils/shared_fixtures.py
@@ -486,9 +486,15 @@ def create_agent_usecase():
     utilisateur_repository = cast(
         IUtilisateurRepository, create_interface_aware_mock(IUtilisateurRepository)
     )
+    permission_service = OrganismePermissionService(
+        organisme_recruteur_repository=Mock(spec=IOrganismeRecruteurRepository),
+        organisme_agent_repository=Mock(spec=IOrganismeAgentRepository),
+        recrutement_agent_repository=Mock(spec=IRecrutementAgentRepository),
+    )
     return CreateAgentUsecase(
         agent_repository=agent_repository,
         utilisateur_repository=utilisateur_repository,
+        permission_service=permission_service,
     )
 
 


### PR DESCRIPTION
## 📝 Description
🎸 Ajout d'un endpoint permettant de créer un profil agent (`POST recruteur/agents`), avec un contrôle d'accès réservé au staff et aux agents `RESPONSABLE` de l'organisme concerné

🌕 DDD style


## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications

- Domain : nouvelle action `CREER_AGENT` dans `OrganismePermissionService`, autorisée pour le staff et les agents `RESPONSABLE` de l'organisme
- Application : `CreateAgentUsecase` prend désormais `organisme_id`/`utilisateur` en entrée et vérifie les droits avant création
- Presentation : nouvel endpoint `POST recruteur/agents` (`AgentsView`)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
