### PR TITLE
💎(ats-presentation) tab icons, toolbar and segmented control on the candidatures views

### DIFF
--- a/src/web/presentation/frontend/src/app/icons.generated.ts
+++ b/src/web/presentation/frontend/src/app/icons.generated.ts
@@ -3,6 +3,7 @@
 import riAddLine from '@iconify-icons/ri/add-line'
 import riAlertFill from '@iconify-icons/ri/alert-fill'
 import riAlertLine from '@iconify-icons/ri/alert-line'
+import riArchiveLine from '@iconify-icons/ri/archive-line'
 import riArrowDownLine from '@iconify-icons/ri/arrow-down-line'
 import riArrowDownSLine from '@iconify-icons/ri/arrow-down-s-line'
 import riArrowLeftDoubleLine from '@iconify-icons/ri/arrow-left-double-line'
@@ -43,7 +44,9 @@ import riInbox2Line from '@iconify-icons/ri/inbox-2-line'
 import riInformationFill from '@iconify-icons/ri/information-fill'
 import riInformationLine from '@iconify-icons/ri/information-line'
 import riLayoutColumnLine from '@iconify-icons/ri/layout-column-line'
+import riLayoutGridLine from '@iconify-icons/ri/layout-grid-line'
 import riLightbulbLine from '@iconify-icons/ri/lightbulb-line'
+import riListCheck from '@iconify-icons/ri/list-check'
 import riListUnordered from '@iconify-icons/ri/list-unordered'
 import riLogoutBoxRLine from '@iconify-icons/ri/logout-box-r-line'
 import riMailLine from '@iconify-icons/ri/mail-line'
@@ -72,6 +75,7 @@ import { addIcon } from '@iconify/vue'
 addIcon('ri:add-line', riAddLine)
 addIcon('ri:alert-fill', riAlertFill)
 addIcon('ri:alert-line', riAlertLine)
+addIcon('ri:archive-line', riArchiveLine)
 addIcon('ri:arrow-down-line', riArrowDownLine)
 addIcon('ri:arrow-down-s-line', riArrowDownSLine)
 addIcon('ri:arrow-left-double-line', riArrowLeftDoubleLine)
@@ -112,7 +116,9 @@ addIcon('ri:inbox-2-line', riInbox2Line)
 addIcon('ri:information-fill', riInformationFill)
 addIcon('ri:information-line', riInformationLine)
 addIcon('ri:layout-column-line', riLayoutColumnLine)
+addIcon('ri:layout-grid-line', riLayoutGridLine)
 addIcon('ri:lightbulb-line', riLightbulbLine)
+addIcon('ri:list-check', riListCheck)
 addIcon('ri:list-unordered', riListUnordered)
 addIcon('ri:logout-box-r-line', riLogoutBoxRLine)
 addIcon('ri:mail-line', riMailLine)

--- a/src/web/presentation/frontend/src/components/base/CspMeta/CspMeta.vue
+++ b/src/web/presentation/frontend/src/components/base/CspMeta/CspMeta.vue
@@ -12,6 +12,7 @@ withDefaults(defineProps<CspMetaItem & {
 
 <template>
   <span
+    v-if="label"
     class="csp-meta"
     :class="[
       `csp-meta--${size}`,

--- a/src/web/presentation/frontend/src/components/base/CspMeta/CspMetaList.vue
+++ b/src/web/presentation/frontend/src/components/base/CspMeta/CspMetaList.vue
@@ -12,6 +12,8 @@ const props = withDefaults(defineProps<{
   size: 'md',
 })
 
+const visibleItems = computed(() => props.items.filter(item => item.label))
+
 const classes = computed(() => [
   'csp-meta-list',
   `csp-meta-list--${props.layout}`,
@@ -21,11 +23,11 @@ const classes = computed(() => [
 
 <template>
   <ul
-    v-if="items.length"
+    v-if="visibleItems.length"
     :class="classes"
   >
     <li
-      v-for="(item, index) in items"
+      v-for="(item, index) in visibleItems"
       :key="`${item.label}-${index}`"
       class="csp-meta-list__item"
     >

--- a/src/web/presentation/frontend/src/components/base/CspSegmentedControl/CspSegmentedControl.stories.ts
+++ b/src/web/presentation/frontend/src/components/base/CspSegmentedControl/CspSegmentedControl.stories.ts
@@ -1,0 +1,137 @@
+import type { ComponentPropsAndSlots, StoryObj } from '@storybook/vue3-vite'
+import { ref, watch } from 'vue'
+import CspSegmentedControl from '@/components/base/CspSegmentedControl/CspSegmentedControl.vue'
+
+type CspSegmentedControlProps = ComponentPropsAndSlots<typeof CspSegmentedControl>
+
+const DEFAULT_OPTIONS = [
+  { value: 'option-1', label: 'Option 1' },
+  { value: 'option-2', label: 'Option 2' },
+  { value: 'option-3', label: 'Option 3' },
+]
+
+const ICON_OPTIONS = [
+  { value: 'grille', label: 'Grille', icon: 'ri:layout-grid-line' },
+  { value: 'liste', label: 'Liste', icon: 'ri:list-unordered' },
+]
+
+const meta = {
+  title: 'Éléments/Génériques/CspSegmentedControl',
+  component: CspSegmentedControl,
+  tags: ['autodocs'],
+  parameters: {
+    controls: {
+      include: ['modelValue', 'options', 'legend', 'hideLegend', 'inlineLegend', 'size', 'disabled'],
+    },
+    docs: {
+      description: {
+        component: 'Contrôle segmenté du DSFR : une option unique parmi deux à cinq, liée via `v-model`. La légende est obligatoire ; `hideLegend` la réserve aux lecteurs d\'écran.',
+      },
+    },
+  },
+  argTypes: {
+    modelValue: {
+      control: { type: 'text' },
+      description: 'Valeur sélectionnée.',
+      table: { type: { summary: 'string' } },
+    },
+    options: {
+      control: { type: 'object' },
+      description: 'Options du contrôle.',
+      table: { type: { summary: '{ value: string; label: string; icon?: string; disabled?: boolean }[]' } },
+    },
+    legend: {
+      control: { type: 'text' },
+      description: 'Légende du groupe, toujours présente pour les technologies d\'assistance.',
+    },
+    hideLegend: {
+      control: { type: 'boolean' },
+      description: 'Masque visuellement la légende.',
+    },
+    inlineLegend: {
+      control: { type: 'boolean' },
+      description: 'Affiche la légende sur la même ligne que le contrôle.',
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md'],
+      table: { defaultValue: { summary: 'md' } },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Désactive tout le groupe.',
+    },
+  },
+  args: {
+    modelValue: 'option-1',
+    options: DEFAULT_OPTIONS,
+    legend: 'Choix',
+    hideLegend: false,
+    inlineLegend: false,
+    size: 'md',
+    disabled: false,
+  },
+  render: (args: CspSegmentedControlProps) => ({
+    components: { CspSegmentedControl },
+    setup() {
+      const model = ref(args.modelValue)
+      watch(() => args.modelValue, (value) => {
+        model.value = value
+      })
+      return { args, model }
+    },
+    template: '<CspSegmentedControl v-bind="args" v-model="model" />',
+  }),
+}
+
+export default meta
+type Story = StoryObj<CspSegmentedControlProps>
+
+export const Default: Story = {}
+
+export const InlineLegend: Story = {
+  args: { inlineLegend: true },
+}
+
+export const NoLegend: Story = {
+  args: { hideLegend: true },
+}
+
+export const WithIcons: Story = {
+  args: { options: ICON_OPTIONS, modelValue: 'grille', legend: 'Affichage', hideLegend: true },
+}
+
+export const Sizes: Story = {
+  render: () => ({
+    components: { CspSegmentedControl },
+    setup() {
+      const md = ref('grille')
+      const sm = ref('grille')
+      return { md, sm, options: ICON_OPTIONS }
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+        <CspSegmentedControl v-model="md" :options="options" legend="Taille md" inline-legend />
+        <CspSegmentedControl v-model="sm" :options="options" legend="Taille sm" inline-legend size="sm" />
+      </div>
+    `,
+  }),
+}
+
+export const States: Story = {
+  render: () => ({
+    components: { CspSegmentedControl },
+    setup() {
+      const partial = ref('option-1')
+      const disabled = ref('option-1')
+      const options = [...DEFAULT_OPTIONS.slice(0, 2), { value: 'option-3', label: 'Option 3', disabled: true }]
+      return { partial, disabled, options, DEFAULT_OPTIONS }
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+        <CspSegmentedControl v-model="partial" :options="options" legend="Une option désactivée" inline-legend />
+        <CspSegmentedControl v-model="disabled" :options="DEFAULT_OPTIONS" legend="Groupe désactivé" inline-legend disabled />
+      </div>
+    `,
+  }),
+}

--- a/src/web/presentation/frontend/src/components/base/CspSegmentedControl/CspSegmentedControl.vue
+++ b/src/web/presentation/frontend/src/components/base/CspSegmentedControl/CspSegmentedControl.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts" generic="V extends string = string">
+import { useId } from 'vue'
+import CspIcon from '@/components/base/CspIcon/CspIcon.vue'
+
+export interface CspSegmentedControlOption<V extends string = string> {
+  value: V
+  label: string
+  icon?: string
+  disabled?: boolean
+}
+
+export interface CspSegmentedControlProps<V extends string = string> {
+  options: CspSegmentedControlOption<V>[]
+  legend: string
+  hideLegend?: boolean
+  inlineLegend?: boolean
+  size?: 'sm' | 'md'
+  name?: string
+  disabled?: boolean
+}
+
+const props = withDefaults(defineProps<CspSegmentedControlProps<V>>(), {
+  hideLegend: false,
+  inlineLegend: false,
+  size: 'md',
+  name: undefined,
+  disabled: false,
+})
+
+const model = defineModel<V>({ required: true })
+
+const groupName = props.name ?? useId()
+</script>
+
+<template>
+  <fieldset
+    class="csp-segmented"
+    :class="[`csp-segmented--${size}`, { 'csp-segmented--no-legend': hideLegend }]"
+    :disabled="disabled"
+  >
+    <legend
+      class="csp-segmented__legend"
+      :class="{ 'csp-segmented__legend--inline': inlineLegend }"
+    >
+      {{ legend }}
+    </legend>
+    <div class="csp-segmented__elements">
+      <div
+        v-for="option in options"
+        :key="option.value"
+        class="csp-segmented__element"
+      >
+        <input
+          :id="`${groupName}-${option.value}`"
+          v-model="model"
+          type="radio"
+          :name="groupName"
+          :value="option.value"
+          :disabled="option.disabled"
+        >
+        <label :for="`${groupName}-${option.value}`">
+          <CspIcon
+            v-if="option.icon"
+            :name="option.icon"
+            class="csp-segmented__icon"
+          />
+          {{ option.label }}
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</template>
+
+<style scoped lang="scss">
+.csp-segmented {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  --csp-segmented-font-size: 1rem;
+  --csp-segmented-padding: 0.5rem 1rem;
+  --csp-segmented-icon-size: 1.5rem;
+}
+
+.csp-segmented--sm {
+  --csp-segmented-font-size: 0.875rem;
+  --csp-segmented-padding: 0.25rem 0.75rem;
+  --csp-segmented-icon-size: 1.25rem;
+}
+
+.csp-segmented__legend {
+  margin-bottom: var(--csp-space-3);
+  padding: 0;
+  font-size: var(--csp-segmented-font-size);
+  color: var(--text-default-grey);
+}
+
+.csp-segmented__legend--inline {
+  float: left;
+  display: contents;
+
+  ~ .csp-segmented__elements {
+    margin-left: var(--csp-space-4);
+  }
+}
+
+.csp-segmented--no-legend .csp-segmented__legend {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.csp-segmented__elements {
+  display: flex;
+  border-radius: 0.25rem;
+  box-shadow: inset 0 0 0 1px var(--border-default-grey);
+}
+
+.csp-segmented__element {
+  position: relative;
+  isolation: isolate;
+}
+
+.csp-segmented__element input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  z-index: -1;
+}
+
+.csp-segmented__element label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: var(--csp-segmented-padding);
+  border-radius: 0.25rem;
+  font-size: var(--csp-segmented-font-size);
+  font-weight: 500;
+  line-height: 1.5rem;
+  color: var(--text-action-high-grey);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.csp-segmented__element label::before {
+  content: '';
+  position: absolute;
+  inset: 0.25rem;
+  border-radius: 0.25rem;
+  z-index: -1;
+}
+
+.csp-segmented__icon {
+  width: var(--csp-segmented-icon-size);
+  height: var(--csp-segmented-icon-size);
+  flex-shrink: 0;
+}
+
+.csp-segmented__element input:not(:disabled):not(:checked) ~ label:hover::before {
+  background-color: var(--background-default-grey-hover);
+}
+
+.csp-segmented__element input:not(:disabled):not(:checked) ~ label:active::before {
+  background-color: var(--background-default-grey-active);
+}
+
+.csp-segmented__element input:checked ~ label {
+  box-shadow: inset 0 0 0 1px var(--border-active-blue-france);
+  color: var(--text-active-blue-france);
+}
+
+.csp-segmented__element input:disabled ~ label,
+.csp-segmented:disabled label {
+  color: var(--text-disabled-grey);
+  cursor: not-allowed;
+}
+
+.csp-segmented__element input:checked:disabled ~ label,
+.csp-segmented:disabled input:checked ~ label {
+  box-shadow: inset 0 0 0 1px var(--border-disabled-grey);
+}
+
+.csp-segmented__element input:focus-visible ~ label {
+  outline: var(--focus-ring);
+  outline-offset: var(--csp-focus-ring-offset);
+}
+</style>

--- a/src/web/presentation/frontend/src/composables/navigation/tabs.ts
+++ b/src/web/presentation/frontend/src/composables/navigation/tabs.ts
@@ -4,6 +4,9 @@ export function tabMetaFor<T extends string>(_labels: Record<T, string>) {
   return (tab: T): { tab: T } => ({ tab })
 }
 
-export function tabItems<T extends string>(labels: Record<T, string>): CspTabItem<T>[] {
-  return (Object.keys(labels) as T[]).map(value => ({ value, label: labels[value] }))
+export function tabItems<T extends string>(
+  labels: Record<T, string>,
+  icons?: Record<T, string>,
+): CspTabItem<T>[] {
+  return (Object.keys(labels) as T[]).map(value => ({ value, label: labels[value], icon: icons?.[value] }))
 }

--- a/src/web/presentation/frontend/src/features/candidatures/components/CandidaturesViewSwitch.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/components/CandidaturesViewSwitch.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import type { CspSegmentedControlOption } from '@/components/base/CspSegmentedControl/CspSegmentedControl.vue'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
-import CspButton from '@/components/base/CspButton/CspButton.vue'
+import CspSegmentedControl from '@/components/base/CspSegmentedControl/CspSegmentedControl.vue'
 
 export type CandidaturesViewName = 'liste' | 'kanban'
 
@@ -16,46 +18,30 @@ const ROUTE_BY_VIEW: Record<CandidaturesViewName, string> = {
   liste: 'recrutement-candidatures',
 }
 
-function switchTo(view: CandidaturesViewName) {
-  if (view === props.current)
-    return
-  void router.push({
-    name: ROUTE_BY_VIEW[view],
-    params: { recrutementUuid: props.recrutementUuid },
-  })
-}
+const OPTIONS: CspSegmentedControlOption<CandidaturesViewName>[] = [
+  { value: 'kanban', label: 'Kanban', icon: 'ri:table-line' },
+  { value: 'liste', label: 'Liste', icon: 'ri:list-unordered' },
+]
+
+const view = computed({
+  get: () => props.current,
+  set: (value) => {
+    if (value === props.current)
+      return
+    void router.push({
+      name: ROUTE_BY_VIEW[value],
+      params: { recrutementUuid: props.recrutementUuid },
+    })
+  },
+})
 </script>
 
 <template>
-  <div
-    class="candidatures-view-switch"
-    role="group"
-    aria-label="Affichage des candidatures"
-  >
-    <CspButton
-      icon="ri:table-line"
-      label="Kanban"
-      is-icon-left
-      size="sm"
-      :variant="current === 'kanban' ? 'secondary' : 'tertiary'"
-      :aria-pressed="current === 'kanban'"
-      @click="switchTo('kanban')"
-    />
-    <CspButton
-      icon="ri:list-unordered"
-      label="Liste"
-      is-icon-left
-      size="sm"
-      :variant="current === 'liste' ? 'secondary' : 'tertiary'"
-      :aria-pressed="current === 'liste'"
-      @click="switchTo('liste')"
-    />
-  </div>
+  <CspSegmentedControl
+    v-model="view"
+    :options="OPTIONS"
+    legend="Affichage des candidatures"
+    hide-legend
+    size="sm"
+  />
 </template>
-
-<style scoped lang="scss">
-.candidatures-view-switch {
-  display: inline-flex;
-  gap: 0.375rem;
-}
-</style>

--- a/src/web/presentation/frontend/src/features/candidatures/constants/candidature.ts
+++ b/src/web/presentation/frontend/src/features/candidatures/constants/candidature.ts
@@ -4,3 +4,8 @@ export const CANDIDATURE_TAB_LABELS = {
 } as const
 
 export type CandidatureTabKey = keyof typeof CANDIDATURE_TAB_LABELS
+
+export const CANDIDATURE_TAB_ICONS = {
+  'candidatures': 'ri:group-line',
+  'activites-et-taches': 'ri:list-check',
+} as const satisfies Record<CandidatureTabKey, string>

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -18,7 +18,7 @@ import { recrutementsListLocation } from '@/features/recrutements/routes'
 import CandidaturesFiltersDrawer from '../components/CandidaturesFiltersDrawer.vue'
 import CandidaturesViewSwitch from '../components/CandidaturesViewSwitch.vue'
 import { useCandidatures } from '../composables/useCandidatures'
-import { CANDIDATURE_TAB_LABELS } from '../constants/candidature'
+import { CANDIDATURE_TAB_ICONS, CANDIDATURE_TAB_LABELS } from '../constants/candidature'
 import { formatRecrutementMeta } from '../format'
 import { CANDIDATURES_TAB_ROUTE_NAMES } from '../routes'
 
@@ -100,7 +100,7 @@ const headerMenuSections = [{
   }],
 }]
 
-const TABS = tabItems(CANDIDATURE_TAB_LABELS)
+const TABS = tabItems(CANDIDATURE_TAB_LABELS, CANDIDATURE_TAB_ICONS)
 const activeTab = useRouteTab(CANDIDATURES_TAB_ROUTE_NAMES, 'candidatures')
 </script>
 

--- a/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
+++ b/src/web/presentation/frontend/src/features/candidatures/views/CandidaturesView.vue
@@ -8,6 +8,7 @@ import CspEmptyState from '@/components/base/CspEmptyState/CspEmptyState.vue'
 import CspErrorState from '@/components/base/CspErrorState/CspErrorState.vue'
 import CspInput from '@/components/base/CspInput/CspInput.vue'
 import CspMetaList from '@/components/base/CspMeta/CspMetaList.vue'
+import CspTableToolbar from '@/components/base/CspTableToolbar/CspTableToolbar.vue'
 import CspPageContainer from '@/components/layout/CspPageContainer/CspPageContainer.vue'
 import CspPageHeader from '@/components/layout/CspPageHeader/CspPageHeader.vue'
 import { useMinimumPending } from '@/composables/async/useMinimumPending'
@@ -153,29 +154,29 @@ const activeTab = useRouteTab(CANDIDATURES_TAB_ROUTE_NAMES, 'candidatures')
       />
 
       <template v-else>
-        <div class="candidatures-view__toolbar">
-          <CandidaturesViewSwitch
-            :recrutement-uuid="recrutementUuid"
-            :current="currentView"
+        <CspTableToolbar :bordered="false">
+          <template #status>
+            <CandidaturesViewSwitch
+              :recrutement-uuid="recrutementUuid"
+              :current="currentView"
+            />
+          </template>
+          <CspInput
+            v-model="search"
+            type="search"
+            aria-label="Rechercher un candidat"
+            placeholder="Rechercher un candidat…"
+            class="candidatures-view__search"
+            @keydown.enter="filters.flushSearch()"
           />
-          <div class="candidatures-view__actions">
-            <CspInput
-              v-model="search"
-              type="search"
-              aria-label="Rechercher un candidat"
-              placeholder="Rechercher un candidat…"
-              class="candidatures-view__search"
-              @keydown.enter="filters.flushSearch()"
-            />
-            <CspButton
-              :label="activeFiltersCount ? `Filtres (${activeFiltersCount})` : 'Filtres'"
-              variant="tertiary"
-              icon="ri:filter-line"
-              is-icon-left
-              @click="openFilters"
-            />
-          </div>
-        </div>
+          <CspButton
+            :label="activeFiltersCount ? `Filtres (${activeFiltersCount})` : 'Filtres'"
+            variant="tertiary"
+            icon="ri:filter-line"
+            is-icon-left
+            @click="openFilters"
+          />
+        </CspTableToolbar>
         <router-view />
         <CandidaturesFiltersDrawer
           v-model:open="isFiltersDrawerOpen"
@@ -196,22 +197,6 @@ const activeTab = useRouteTab(CANDIDATURES_TAB_ROUTE_NAMES, 'candidatures')
 </template>
 
 <style scoped lang="scss">
-.candidatures-view__toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: var(--csp-space-4);
-}
-
-.candidatures-view__actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 0.75rem;
-}
-
 .candidatures-view__search {
   min-width: 20rem;
 }

--- a/src/web/presentation/frontend/src/features/recrutements/constants/recrutement.ts
+++ b/src/web/presentation/frontend/src/features/recrutements/constants/recrutement.ts
@@ -4,3 +4,8 @@ export const RECRUTEMENT_TAB_LABELS = {
   actifs: 'Recrutements en cours',
   archives: 'Offres archivées',
 } as const satisfies Record<RecrutementKey, string>
+
+export const RECRUTEMENT_TAB_ICONS = {
+  actifs: 'ri:briefcase-line',
+  archives: 'ri:archive-line',
+} as const satisfies Record<RecrutementKey, string>

--- a/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
+++ b/src/web/presentation/frontend/src/features/recrutements/views/MesRecrutementsView.vue
@@ -23,7 +23,7 @@ import RecrutementsArchivesFiltersDrawer from '../components/RecrutementsArchive
 
 import { useRecrutements } from '../composables/useRecrutements'
 import { useRecrutementsFilters } from '../composables/useRecrutementsFilters'
-import { RECRUTEMENT_TAB_LABELS } from '../constants/recrutement'
+import { RECRUTEMENT_TAB_ICONS, RECRUTEMENT_TAB_LABELS } from '../constants/recrutement'
 import { DEFAULT_RECRUTEMENT_TAB, RECRUTEMENTS_TAB_ROUTE_NAMES } from '../routes'
 
 const BREADCRUMB: CspBreadcrumbItem[] = [
@@ -35,7 +35,7 @@ const router = useRouter()
 
 const activeTab = useRouteTab(RECRUTEMENTS_TAB_ROUTE_NAMES, DEFAULT_RECRUTEMENT_TAB)
 
-const TABS = tabItems(RECRUTEMENT_TAB_LABELS)
+const TABS = tabItems(RECRUTEMENT_TAB_LABELS, RECRUTEMENT_TAB_ICONS)
 
 const { organismeUuid } = useCurrentOrganisme()
 


### PR DESCRIPTION
## 📝 Description

Quatre améliorations ciblées des vues « Mes recrutements » et « Candidatures ».

## 🏷️ Type de changement

- [x] 🐛 Correction de bug
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications

- Des icônes sur les onglets des deux vues, par une table d'icônes à côté des libellés.
- Corrige un bug ou un élément de méta sans libellé rendait le picto seul
- Utilise `CspTableToolbar` pour la barre d'outils du kanban
- Ajoute un composant `CspSegmentedControl` sur la base [de la spec dsfr](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/controle-segmente) pour remplacer les deux boutons Kanban/Liste.

## 🏝️ Comment tester

Ouvrir « Mes recrutements » puis un recrutement

<img width="895" height="475" alt="Capture d’écran 2026-09-03 à 20 45 08" src="https://github.com/user-attachments/assets/9a2b5208-bf78-47c3-be4c-a109b37318e4" />