### PR TITLE
📝(api) documenter rate limiting dans le schéma OpenAPI

### DIFF
--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -378,6 +378,7 @@ SPECTACULAR_SETTINGS = {
     "POSTPROCESSING_HOOKS": [
         "drf_spectacular.hooks.postprocess_schema_enums",
         "presentation.api.openapi_hooks.postprocess_add_rate_limit_headers",
+        "presentation.api.openapi_hooks.postprocess_add_too_many_requests_response",
     ],
     "TAGS": [
         {"name": "token", "description": "Gestion de l'authentification"},

--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -375,6 +375,10 @@ SPECTACULAR_SETTINGS = {
         "drf_spectacular.hooks.preprocess_exclude_path_format",
         "presentation.api.openapi_hooks.preprocess_public_only",
     ],
+    "POSTPROCESSING_HOOKS": [
+        "drf_spectacular.hooks.postprocess_schema_enums",
+        "presentation.api.openapi_hooks.postprocess_add_rate_limit_headers",
+    ],
     "TAGS": [
         {"name": "token", "description": "Gestion de l'authentification"},
         {

--- a/src/web/presentation/api/openapi_hooks.py
+++ b/src/web/presentation/api/openapi_hooks.py
@@ -33,6 +33,49 @@ def postprocess_add_rate_limit_headers(result, **kwargs):
     return result
 
 
+_TOO_MANY_REQUESTS_RESPONSE = {
+    "description": "Nombre maximal d'appels autorisés dépassé.",
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "example": (
+                            "Request was throttled. Expected available in 42 seconds."
+                        ),
+                    },
+                },
+            },
+        },
+    },
+    "headers": {
+        "Retry-After": {
+            "schema": {"type": "integer"},
+            "description": "Nombre de secondes à attendre avant de pouvoir réessayer.",
+        },
+        **{name: dict(spec) for name, spec in _RATE_LIMIT_HEADERS.items()},
+    },
+}
+
+
+def postprocess_add_too_many_requests_response(result, **kwargs):
+    """Document the `429` response returned once an endpoint's rate limit is hit.
+
+    Every endpoint goes through DRF's DEFAULT_THROTTLE_CLASSES (see
+    REST_FRAMEWORK settings), which can raise a 429 regardless of what the
+    view itself declares, so drf-spectacular cannot pick it up automatically.
+    """
+    for path in result.get("paths", {}).values():
+        for operation in path.values():
+            responses = operation.get("responses")
+            if responses is None:
+                continue
+            responses.setdefault("429", dict(_TOO_MANY_REQUESTS_RESPONSE))
+    return result
+
+
 def preprocess_public_only(endpoints, **kwargs):
     selected_endpoints = []
     for path, path_regex, method, callback in endpoints:

--- a/src/web/presentation/api/openapi_hooks.py
+++ b/src/web/presentation/api/openapi_hooks.py
@@ -1,5 +1,37 @@
 PUBLIC_PATH = "/api"
 
+_RATE_LIMIT_HEADERS = {
+    "X-RateLimit-Limit": {
+        "schema": {"type": "integer"},
+        "description": "Nombre maximal d'appels autorisés sur la fenêtre courante.",
+    },
+    "X-RateLimit-Remaining": {
+        "schema": {"type": "integer"},
+        "description": "Nombre d'appels restants sur la fenêtre courante.",
+    },
+    "X-RateLimit-Reset": {
+        "schema": {"type": "integer"},
+        "description": (
+            "Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise."
+        ),
+    },
+}
+
+
+def postprocess_add_rate_limit_headers(result, **kwargs):
+    """Document the `X-RateLimit-*` headers set by RateLimitHeadersMiddleware.
+
+    These headers are added dynamically by a middleware rather than by the
+    views themselves, so drf-spectacular cannot pick them up automatically.
+    """
+    for path in result.get("paths", {}).values():
+        for operation in path.values():
+            for response in operation.get("responses", {}).values():
+                headers = response.setdefault("headers", {})
+                for name, spec in _RATE_LIMIT_HEADERS.items():
+                    headers.setdefault(name, dict(spec))
+    return result
+
 
 def preprocess_public_only(endpoints, **kwargs):
     selected_endpoints = []

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -935,6 +935,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -988,6 +1008,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -1079,6 +1119,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -1146,6 +1206,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -1222,6 +1302,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -1303,6 +1403,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -1406,6 +1526,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -1487,6 +1627,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -1592,6 +1752,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -1673,6 +1853,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -1776,6 +1976,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -1895,6 +2115,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -1994,6 +2234,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -2075,6 +2335,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -2180,6 +2460,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -2261,6 +2561,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -2365,6 +2685,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -2467,6 +2807,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -2549,6 +2909,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -2641,6 +3021,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -2723,6 +3123,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -2829,6 +3249,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -2913,6 +3353,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -2995,6 +3455,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {
@@ -3100,6 +3580,26 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
             500: {
                 headers: {
                     /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
@@ -3165,6 +3665,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
                 };
             };
             500: {

--- a/src/web/presentation/frontend/src/types/api.d.ts
+++ b/src/web/presentation/frontend/src/types/api.d.ts
@@ -867,6 +867,12 @@ export interface operations {
         responses: {
             201: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -875,6 +881,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -883,6 +895,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -891,6 +909,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -899,6 +923,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -907,6 +937,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -928,6 +964,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -936,6 +978,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -944,6 +992,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -971,6 +1025,12 @@ export interface operations {
         responses: {
             201: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -979,6 +1039,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -987,6 +1053,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -995,6 +1067,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1003,6 +1081,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1026,12 +1110,24 @@ export interface operations {
             /** @description No response body */
             204: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content?: never;
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1040,6 +1136,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1048,6 +1150,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1076,6 +1184,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1084,6 +1198,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1092,6 +1212,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1100,6 +1226,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1119,6 +1251,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1127,6 +1265,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1135,6 +1279,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1143,6 +1293,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1151,6 +1307,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1176,6 +1338,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1184,6 +1352,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1192,6 +1366,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1200,6 +1380,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1208,6 +1394,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1216,6 +1408,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1237,6 +1435,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1245,6 +1449,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1253,6 +1463,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1261,6 +1477,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1269,6 +1491,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1296,6 +1524,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1304,6 +1538,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1312,6 +1552,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1320,6 +1566,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1328,6 +1580,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1336,6 +1594,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1357,6 +1621,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1365,6 +1635,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1373,6 +1649,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1381,6 +1663,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1389,6 +1677,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1416,6 +1710,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1424,6 +1724,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1432,6 +1738,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1440,6 +1752,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1448,6 +1766,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1456,6 +1780,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1483,6 +1813,12 @@ export interface operations {
         responses: {
             201: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1491,6 +1827,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1499,6 +1841,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1507,6 +1855,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1515,6 +1869,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1523,6 +1883,12 @@ export interface operations {
             };
             409: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1531,6 +1897,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1554,6 +1926,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1562,6 +1940,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1570,6 +1954,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1578,6 +1968,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1586,6 +1982,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1594,6 +1996,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1615,6 +2023,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1623,6 +2037,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1631,6 +2051,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1639,6 +2065,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1647,6 +2079,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1674,6 +2112,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1682,6 +2126,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1690,6 +2140,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1698,6 +2154,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1706,6 +2168,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1714,6 +2182,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1735,6 +2209,12 @@ export interface operations {
         responses: {
             201: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1743,6 +2223,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1751,6 +2237,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1759,6 +2251,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1767,6 +2265,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1793,6 +2297,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1801,6 +2311,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1809,6 +2325,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1817,6 +2339,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1825,6 +2353,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1833,6 +2367,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1859,6 +2399,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1867,6 +2413,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1875,6 +2427,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1883,6 +2441,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1891,6 +2455,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1899,6 +2469,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1921,6 +2497,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1929,6 +2511,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1937,6 +2525,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1945,6 +2539,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1953,6 +2553,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1981,6 +2587,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1989,6 +2601,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -1997,6 +2615,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2005,6 +2629,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2013,6 +2643,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2035,6 +2671,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2043,6 +2685,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2051,6 +2699,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2059,6 +2713,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2067,6 +2727,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2095,6 +2761,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2103,6 +2775,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2111,6 +2789,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2119,6 +2803,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2127,6 +2817,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2135,6 +2831,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2157,6 +2859,12 @@ export interface operations {
         responses: {
             201: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2165,6 +2873,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2173,6 +2887,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2181,6 +2901,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2189,6 +2915,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2211,6 +2943,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2219,6 +2957,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2227,6 +2971,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2235,6 +2985,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2243,6 +2999,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2270,6 +3032,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2278,6 +3046,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2286,6 +3060,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2294,6 +3074,12 @@ export interface operations {
             };
             403: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2302,6 +3088,12 @@ export interface operations {
             };
             404: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2310,6 +3102,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2329,6 +3127,12 @@ export interface operations {
         responses: {
             200: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2337,6 +3141,12 @@ export interface operations {
             };
             400: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2345,6 +3155,12 @@ export interface operations {
             };
             401: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {
@@ -2353,6 +3169,12 @@ export interface operations {
             };
             500: {
                 headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
                     [name: string]: unknown;
                 };
                 content: {

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -145,6 +145,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/candidatures/{candidature_uuid}/notes:
     get:
       operationId: recruteur_candidatures_notes_list
@@ -211,6 +239,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -352,6 +408,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/candidatures/{candidature_uuid}/notes/{note_uuid}:
     patch:
       operationId: recruteur_candidatures_notes_partial_update
@@ -466,6 +550,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     delete:
       operationId: recruteur_candidatures_notes_destroy
       summary: Supprimer une note d'une candidature
@@ -551,6 +663,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -663,6 +803,34 @@ paths:
                   $ref: '#/components/schemas/OrganismesList'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -817,6 +985,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}:
     get:
       operationId: recruteur_organismes_retrieve
@@ -921,6 +1117,34 @@ paths:
                 $ref: '#/components/schemas/OrganismeDetail'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -1082,6 +1306,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/parametres/agents:
     get:
       operationId: recruteur_organismes_parametres_agents_list
@@ -1188,6 +1440,34 @@ paths:
                   $ref: '#/components/schemas/AgentOrganisme'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -1369,6 +1649,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     put:
       operationId: recruteur_organismes_parametres_agents_update
       summary: Modifier ou revoquer un agent d'un organisme
@@ -1504,6 +1812,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -1661,6 +1997,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organismes_parametres_etapes_list
@@ -1767,6 +2131,34 @@ paths:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -1936,6 +2328,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/parametres/etapes/init:
     post:
       operationId: recruteur_organismes_parametres_etapes_init_create
@@ -2042,6 +2462,34 @@ paths:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -2209,6 +2657,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements-archives:
     get:
       operationId: recruteur_organismes_recrutements_archives_list
@@ -2363,6 +2839,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}:
     get:
       operationId: recruteur_organismes_recrutements_retrieve
@@ -2473,6 +2977,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -2620,6 +3152,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes:
     get:
       operationId: recruteur_organismes_recrutements_etapes_list
@@ -2732,6 +3292,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -2907,6 +3495,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes/init:
     post:
       operationId: recruteur_organismes_recrutements_etapes_init_create
@@ -3032,6 +3648,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/kanban:
     get:
       operationId: recruteur_organismes_recrutements_kanban_retrieve
@@ -3142,6 +3786,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -3314,6 +3986,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /utilisateur/me:
     get:
       operationId: utilisateur_me_retrieve
@@ -3391,6 +4091,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -31,36 +31,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Agent'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/candidatures/{candidature_uuid}/notes:
     get:
       operationId: recruteur_candidatures_notes_list
@@ -86,18 +170,60 @@ paths:
                 items:
                   $ref: '#/components/schemas/Note'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     post:
       operationId: recruteur_candidatures_notes_create
       summary: Ajouter une note à une candidature
@@ -132,30 +258,100 @@ paths:
               schema:
                 $ref: '#/components/schemas/NoteDetail'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/candidatures/{candidature_uuid}/notes/{note_uuid}:
     patch:
       operationId: recruteur_candidatures_notes_partial_update
@@ -196,24 +392,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/NoteDetail'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     delete:
       operationId: recruteur_candidatures_notes_destroy
       summary: Supprimer une note d'une candidature
@@ -238,24 +490,80 @@ paths:
       responses:
         '204':
           description: No response body
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes:
     get:
       operationId: recruteur_organismes_list
@@ -272,24 +580,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
@@ -298,6 +662,20 @@ paths:
                 items:
                   $ref: '#/components/schemas/OrganismesList'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     post:
       operationId: recruteur_organismes_create
       summary: Créer un organisme
@@ -325,36 +703,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganismeDetail'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}:
     get:
       operationId: recruteur_organismes_retrieve
@@ -378,30 +840,100 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganismeDetail'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     put:
       operationId: recruteur_organismes_update
       summary: Modifier un organisme
@@ -436,36 +968,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganismeDetail'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/parametres/agents:
     get:
       operationId: recruteur_organismes_parametres_agents_list
@@ -489,24 +1105,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
@@ -515,6 +1187,20 @@ paths:
                 items:
                   $ref: '#/components/schemas/AgentOrganisme'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     post:
       operationId: recruteur_organismes_parametres_agents_create
       summary: Rattacher un agent à un organisme
@@ -549,42 +1235,140 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentOrganisme'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '409':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     put:
       operationId: recruteur_organismes_parametres_agents_update
       summary: Modifier ou revoquer un agent d'un organisme
@@ -619,36 +1403,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentOrganisme'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/parametres/agents/recherche:
     get:
       operationId: recruteur_organismes_parametres_agents_recherche_retrieve
@@ -679,36 +1547,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentRecherche'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organismes_parametres_etapes_list
@@ -732,24 +1684,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
@@ -758,6 +1766,20 @@ paths:
                 items:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     put:
       operationId: recruteur_organismes_parametres_etapes_update
       summary: Modifier les étapes de recrutement d'un organisme
@@ -798,24 +1820,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '200':
           content:
             application/json:
@@ -824,12 +1902,40 @@ paths:
                 items:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/parametres/etapes/init:
     post:
       operationId: recruteur_organismes_parametres_etapes_init_create
@@ -853,24 +1959,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '201':
           content:
             application/json:
@@ -879,6 +2041,20 @@ paths:
                 items:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements-actifs:
     get:
       operationId: recruteur_organismes_recrutements_actifs_list
@@ -919,36 +2095,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedRecrutementsActifsList'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements-archives:
     get:
       operationId: recruteur_organismes_recrutements_archives_list
@@ -989,36 +2249,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedRecrutementsArchivesList'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}:
     get:
       operationId: recruteur_organismes_recrutements_retrieve
@@ -1048,30 +2392,100 @@ paths:
               schema:
                 $ref: '#/components/schemas/RecrutementDetail'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/candidatures/etape:
     patch:
       operationId: recruteur_organismes_recrutements_candidatures_etape_partial_update
@@ -1112,30 +2526,100 @@ paths:
               schema:
                 $ref: '#/components/schemas/ChangerEtapeResultat'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes:
     get:
       operationId: recruteur_organismes_recrutements_etapes_list
@@ -1167,30 +2651,100 @@ paths:
                 items:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
     patch:
       operationId: recruteur_organismes_recrutements_etapes_partial_update
       summary: Modifier les étapes d'un recrutement
@@ -1239,36 +2793,120 @@ paths:
                 items:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes/init:
     post:
       operationId: recruteur_organismes_recrutements_etapes_init_create
@@ -1300,30 +2938,100 @@ paths:
                 items:
                   $ref: '#/components/schemas/EtapeRecrutement'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/kanban:
     get:
       operationId: recruteur_organismes_recrutements_kanban_retrieve
@@ -1353,30 +3061,100 @@ paths:
               schema:
                 $ref: '#/components/schemas/RecrutementDetailKanban'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/liste:
     get:
       operationId: recruteur_organismes_recrutements_liste_list
@@ -1422,36 +3200,120 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedCandidatureListeList'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /utilisateur/me:
     get:
       operationId: utilisateur_me_retrieve
@@ -1468,24 +3330,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/Utilisateur'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
 components:
   schemas:
     Agent:

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -28,24 +28,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/FakeTsOfferDetail'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/fake-ts/offersummaries:
     get:
       operationId: fake_ts_offersummaries_list
@@ -1085,18 +1141,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedFakeTsOfferSummaryList'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/token:
     post:
       operationId: token_create
@@ -1124,6 +1222,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenObtainPair'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/token/refresh:
     post:
       operationId: token_refresh_create
@@ -1151,6 +1263,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenRefresh'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/concours/upload:
     post:
       operationId: v1_concours_upload_create
@@ -1251,6 +1377,20 @@ paths:
                   description: Toutes les lignes correspondent à des enregistrements
                     existants
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
@@ -1287,6 +1427,20 @@ paths:
                   description: Le fichier ne peut pas être parsé,vérifiez le séparateur
                     (`;`) et l'encodage (UTF-8).
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
@@ -1305,6 +1459,20 @@ paths:
                   description: Le token dans le header `Authorization` est invalide
                     ou expiré.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
@@ -1317,6 +1485,20 @@ paths:
                   summary: Erreur serveur inattendue
                   description: Une erreur inattendue s'est produite côté serveur.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/metiers:
     get:
       operationId: v1_metiers_list
@@ -1424,6 +1606,20 @@ paths:
                   description: Les métiers possédant ce code domaine fonctionnel sont
                     retournés paginés
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
@@ -1436,6 +1632,20 @@ paths:
                   summary: Données invalides
                   description: Les données passées dans le payload sont incorrectes
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
@@ -1454,6 +1664,20 @@ paths:
                   description: Le token dans le header `Authorization` est invalide
                     ou expiré.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
@@ -1466,6 +1690,20 @@ paths:
                   summary: Erreur serveur inattendue
                   description: Une erreur inattendue s'est produite côté serveur.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/offres:
     get:
       operationId: v1_offres_list
@@ -2601,12 +2839,40 @@ paths:
                   description: Les offres d'emploi avec une date d'archivage sont
                     retournées paginées
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
@@ -2625,6 +2891,20 @@ paths:
                   description: Le token dans le header `Authorization` est invalide
                     ou expiré.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
@@ -2637,6 +2917,20 @@ paths:
                   summary: Erreur serveur inattendue
                   description: Une erreur inattendue s'est produite côté serveur.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/offres/archiver:
     post:
       operationId: v1_offres_archiver_create
@@ -2686,6 +2980,20 @@ paths:
                   summary: Offre archivée avec succès
                   description: L'offre correspondant à la référence a été archivée.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
@@ -2699,6 +3007,20 @@ paths:
                   summary: Champ obligatoire manquant
                   description: Le champ `reference` ou `source_id` est absent du corps.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
@@ -2717,12 +3039,40 @@ paths:
                   description: Le token dans le header `Authorization` est invalide
                     ou expiré.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArchiveOfferForbidden'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '404':
           content:
             application/json:
@@ -2735,6 +3085,20 @@ paths:
                   summary: Offre introuvable
                   description: Aucune offre ne correspond à la référence fournie.
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/offres/creer_modifier:
     post:
       operationId: v1_offres_creer_modifier_create
@@ -2775,30 +3139,100 @@ paths:
               schema:
                 $ref: '#/components/schemas/UpsertOffersResponse'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/UpsertOffersForbidden'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/offres/sources/{source_id}:
     get:
       operationId: v1_offres_sources_list
@@ -2859,18 +3293,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedOfferDetailResponseList'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OffersBySource401Error'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/organismes/creer_modifier:
     post:
       operationId: v1_organismes_creer_modifier_create
@@ -2894,24 +3370,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/UpsertOrganismesResponse'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '400':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '401':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
           description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
 components:
   schemas:
     ArchiveOffer401Error:

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -102,6 +102,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/fake-ts/offersummaries:
     get:
       operationId: fake_ts_offersummaries_list
@@ -1195,6 +1223,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/token:
     post:
       operationId: token_create
@@ -1236,6 +1292,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/token/refresh:
     post:
       operationId: token_refresh_create
@@ -1264,6 +1348,34 @@ paths:
                 $ref: '#/components/schemas/TokenRefresh'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -1499,6 +1611,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/metiers:
     get:
       operationId: v1_metiers_list
@@ -1691,6 +1831,34 @@ paths:
                   description: Une erreur inattendue s'est produite côté serveur.
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer
@@ -2931,6 +3099,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/offres/archiver:
     post:
       operationId: v1_offres_archiver_create
@@ -3099,6 +3295,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/offres/creer_modifier:
     post:
       operationId: v1_offres_creer_modifier_create
@@ -3233,6 +3457,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/offres/sources/{source_id}:
     get:
       operationId: v1_offres_sources_list
@@ -3347,6 +3599,34 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/v1/organismes/creer_modifier:
     post:
       operationId: v1_organismes_creer_modifier_create
@@ -3431,6 +3711,34 @@ paths:
                 $ref: '#/components/schemas/GenericError'
           description: ''
           headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
             X-RateLimit-Limit:
               schema:
                 type: integer

--- a/src/web/tests/shared/presentation/api/test_rate_limiting.py
+++ b/src/web/tests/shared/presentation/api/test_rate_limiting.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.throttling import UserRateThrottle
+
+HEALTH_HUEY_URL = "/api/health/huey"
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+
+
+class TestRateLimitingIntegration:
+    @patch.object(UserRateThrottle, "THROTTLE_RATES", {"user": "2/minute"})
+    def test_returns_429_once_rate_limit_is_exceeded(self, authenticated_client):
+        for _ in range(2):
+            response = authenticated_client.get(HEALTH_HUEY_URL)
+            assert response.status_code != status.HTTP_429_TOO_MANY_REQUESTS
+
+        response = authenticated_client.get(HEALTH_HUEY_URL)
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert "Retry-After" in response.headers
+        assert response.data["detail"].code == "throttled"


### PR DESCRIPTION
## 📝 Description

- Documente les headers `X-RateLimit-Limit`, `X-RateLimit-Remaining` et `X-RateLimit-Reset` dans le schéma OpenAPI. Ces headers sont posés par `RateLimitHeadersMiddleware` en dehors des vues, donc drf-spectacular ne pouvait pas les détecter automatiquement.
- Ajout d'un hook de postprocessing `postprocess_add_rate_limit_headers` (`presentation/api/openapi_hooks.py`) qui les injecte sur toutes les réponses documentées.
- Documente également la réponse `429` renvoyée par les throttle classes DRF (`AnonRateThrottle`, `NonApiKeyUserRateThrottle`, `ApiKeyRateThrottle`, `ApiKeyRateThrottleDaily`) une fois le rate limit dépassé : corps (`detail`), header `Retry-After` et headers `X-RateLimit-*`, via un second hook `postprocess_add_too_many_requests_response`.
- Ajout d'un test d'intégration bout en bout (`tests/shared/presentation/api/test_rate_limiting.py`) qui vérifie qu'une requête authentifiée reçoit bien un `429` une fois le quota consommé.
- Enregistrement des deux hooks dans `SPECTACULAR_SETTINGS["POSTPROCESSING_HOOKS"]`, en conservant le hook par défaut `drf_spectacular.hooks.postprocess_schema_enums` (nécessaire pour la déduplication des enums en composants réutilisables).
- Régénération des schémas générés (`schema.yaml`, `internal-schema.yaml`) et des types TypeScript (`api.d.ts`).

## 🏷️ Type de changement
- [x] 📚 Mise à jour de la documentation

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
- Lancer `mise run web:test -- tests/shared/presentation/api/test_rate_limiting.py -v`
- Générer le schéma public : `mise run web:manage -- spectacular --file presentation/static/api/schema.yaml --validate --fail-on-warn`, vérifier qu'une réponse `429` (avec `Retry-After` et `X-RateLimit-*`) apparaît sur chaque opération

## 📸 Captures d'écran (si applicable)

<img width="687" height="796" alt="Screenshot 2026-09-04 at 15 22 33" src="https://github.com/user-attachments/assets/e07099a4-f8ec-429b-87a9-0c3f01662849" />



## ✅ Liste de contrôle
- [x] 💅 J'ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J'ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J'ai pris en compte l'impact sur les performances, la sécurité et l'expérience utilisateur.
- [x] 👀 J'ai demandé une revue à une personne de l'équipe.