### PR TITLE
⚡️(ingestion) reduce peak memory in the organismes pipeline

### DIFF
--- a/src/ingestion/application/usecases/clean_raw_organismes.py
+++ b/src/ingestion/application/usecases/clean_raw_organismes.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone
+from itertools import chain
 
 from pydantic import ValidationError
 from referentiel.entities.organisme import Organisme
@@ -22,8 +23,9 @@ class CleanRawOrganismesUsecase:
         self._raw_organisme_repository = raw_organisme_repository
 
     async def execute(self, referentiel: str) -> list[Organisme]:
-        organismes: list[Organisme] = []
         total_raw = 0
+        total_cleaned = 0
+        deduped_organismes: list[Organisme] = []
 
         while True:
             raw_batch = await self._raw_organisme_repository.find_uncleaned(
@@ -33,6 +35,7 @@ class CleanRawOrganismesUsecase:
                 break
 
             cleaned_ids = []
+            cleaned_batch: list[Organisme] = []
             for raw_organisme in raw_batch:
                 cleaned_ids.append(raw_organisme.id)
                 try:
@@ -51,23 +54,27 @@ class CleanRawOrganismesUsecase:
                     )
                     continue
                 if organisme is not None:
-                    organismes.append(organisme)
+                    cleaned_batch.append(organisme)
 
             await self._raw_organisme_repository.mark_as_cleaned_batch(
                 cleaned_ids, datetime.now(tz=timezone.utc)
             )
             total_raw += len(raw_batch)
+            total_cleaned += len(cleaned_batch)
+
+            # Dedupe per batch: bounds memory by unique SIRETs, not raw count.
+            deduped_organismes = self._organismes_cleaner.dedupe_by_siret(
+                chain(deduped_organismes, cleaned_batch)
+            )
 
             if len(raw_batch) < BATCH_SIZE:
                 break
-
-        deduped_organismes = self._organismes_cleaner.dedupe_by_siret(organismes)
 
         logger.info(
             "Cleaned %d raw organismes into %d organismes (%d after SIRET dedup) "
             "for referentiel %s",
             total_raw,
-            len(organismes),
+            total_cleaned,
             len(deduped_organismes),
             referentiel,
         )

--- a/src/ingestion/bin/organismes_pipeline.py
+++ b/src/ingestion/bin/organismes_pipeline.py
@@ -3,8 +3,6 @@ import argparse
 import asyncio
 import logging
 
-from referentiel.entities.organisme import Organisme
-
 from application.usecases.import_organismes import ImportOrganismesCommand
 from application.usecases.publish_organismes import PublishOrganismesCommand
 from domain.value_objects.organisme_referentiel import OrganismeReferentiel
@@ -36,7 +34,6 @@ async def _run(referentiel: OrganismeReferentiel | None = None) -> None:
         [referentiel] if referentiel is not None else list(OrganismeReferentiel)
     )
 
-    organismes: list[Organisme] = []
     for current_referentiel in referentiels:
         use_case = import_organismes_usecase_for(container, current_referentiel)
         import_result = await use_case.execute(
@@ -49,17 +46,19 @@ async def _run(referentiel: OrganismeReferentiel | None = None) -> None:
             )
             continue
 
-        organismes += await container.clean_raw_organismes_usecase().execute(
+        organismes = await container.clean_raw_organismes_usecase().execute(
             import_result.referentiel
         )
+        if not organismes:
+            logger.info(
+                "No organismes to publish for referentiel %s, skipping publish",
+                import_result.referentiel,
+            )
+            continue
 
-    if not organismes:
-        logger.info("No organismes to publish, skipping publish")
-        return
-
-    await container.publish_organismes_usecase().execute(
-        PublishOrganismesCommand(organismes=organismes)
-    )
+        await container.publish_organismes_usecase().execute(
+            PublishOrganismesCommand(organismes=organismes)
+        )
 
 
 def main() -> None:

--- a/src/ingestion/cron.json
+++ b/src/ingestion/cron.json
@@ -6,7 +6,7 @@
     },
     {
       "command": "0 6 * * 1 bash bin/organismes_pipeline.py",
-      "size": "S"
+      "size": "XL"
     }
   ]
 }

--- a/src/ingestion/domain/gateways/organismes_cleaner.py
+++ b/src/ingestion/domain/gateways/organismes_cleaner.py
@@ -1,4 +1,4 @@
-from typing import Optional, Protocol
+from typing import Iterable, Optional, Protocol
 
 from referentiel.entities.organisme import Organisme
 
@@ -8,4 +8,4 @@ from domain.entities.raw_organisme import RawOrganisme
 class IOrganismesCleaner(Protocol):
     def clean(self, raw_organisme: RawOrganisme) -> Optional[Organisme]: ...
 
-    def dedupe_by_siret(self, organismes: list[Organisme]) -> list[Organisme]: ...
+    def dedupe_by_siret(self, organismes: Iterable[Organisme]) -> list[Organisme]: ...

--- a/src/ingestion/infrastructure/gateways/organismes_cleaner.py
+++ b/src/ingestion/infrastructure/gateways/organismes_cleaner.py
@@ -3,7 +3,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 from uuid import UUID, uuid4, uuid5
 
 from pydantic import BaseModel, ValidationError, field_validator
@@ -85,7 +85,7 @@ class OrganismesCleaner:
             return self._clean_dila(raw_organisme)
         return None
 
-    def dedupe_by_siret(self, organismes: list[Organisme]) -> list[Organisme]:
+    def dedupe_by_siret(self, organismes: Iterable[Organisme]) -> list[Organisme]:
         best_by_siret: dict[SIRET, Organisme] = {}
         for organisme in organismes:
             current_best = best_by_siret.get(organisme.siret)


### PR DESCRIPTION
## 📝 Description

- Publie chaque référentiel (FINESS, GIPCDG, DILA) dès qu'il est nettoyé au lieu d'accumuler les organismes de tous les référentiels avant de publier
- Déduplique par SIRET progressivement, batch par batch, au lieu de construire la liste complète des organismes nettoyés avant déduplication

Ces deux changements font que la mémoire pic dépend désormais de la taille d'un batch et du nombre de SIRET uniques, plutôt que du nombre total d'enregistrements bruts — corrige les OOM en production sur les gros référentiels comme FINESS.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
