### PR TITLE
🐛(ingestion) met à jour upsert_at lors de la publication des organismes

### DIFF
--- a/src/ingestion/application/usecases/publish_organismes.py
+++ b/src/ingestion/application/usecases/publish_organismes.py
@@ -1,10 +1,12 @@
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from ddd.async_usecase_interface import IAsyncUsecase
 from referentiel.entities.organisme import Organisme
 
 from domain.gateways.publish_organismes_gateway import IPublishOrganismesGateway
+from domain.repositories.raw_organisme_repository import IRawOrganismeRepository
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +19,13 @@ class PublishOrganismesCommand:
 
 
 class PublishOrganismesUsecase(IAsyncUsecase[PublishOrganismesCommand, None]):
-    def __init__(self, publish_organismes_gateway: IPublishOrganismesGateway) -> None:
+    def __init__(
+        self,
+        publish_organismes_gateway: IPublishOrganismesGateway,
+        raw_organisme_repository: IRawOrganismeRepository,
+    ) -> None:
         self._gateway = publish_organismes_gateway
+        self._raw_organisme_repository = raw_organisme_repository
 
     async def execute(self, command: PublishOrganismesCommand) -> None:
         organismes = command.organismes
@@ -26,6 +33,10 @@ class PublishOrganismesUsecase(IAsyncUsecase[PublishOrganismesCommand, None]):
         for start in range(0, len(organismes), BATCH_SIZE):
             batch = organismes[start : start + BATCH_SIZE]
             await self._gateway.publish(batch)
+            await self._raw_organisme_repository.mark_as_upserted_batch(
+                [(organisme.referentiel, organisme.external_id) for organisme in batch],
+                datetime.now(tz=timezone.utc),
+            )
             total += len(batch)
 
         logger.info("Published %d organismes", total)

--- a/src/ingestion/domain/repositories/raw_organisme_repository.py
+++ b/src/ingestion/domain/repositories/raw_organisme_repository.py
@@ -16,3 +16,6 @@ class IRawOrganismeRepository(Protocol):
     async def mark_as_cleaned_batch(
         self, ids: list[UUID], cleaned_at: datetime
     ) -> None: ...
+    async def mark_as_upserted_batch(
+        self, referentiel_external_ids: list[tuple[str, str]], upsert_at: datetime
+    ) -> None: ...

--- a/src/ingestion/infrastructure/di/container.py
+++ b/src/ingestion/infrastructure/di/container.py
@@ -205,6 +205,7 @@ class Container(containers.DeclarativeContainer):
         providers.Factory(
             PublishOrganismesUsecase,
             publish_organismes_gateway=publish_organismes_gateway,
+            raw_organisme_repository=raw_organisme_repository,
         )
     )
 

--- a/src/ingestion/infrastructure/raw_organisme_repository.py
+++ b/src/ingestion/infrastructure/raw_organisme_repository.py
@@ -2,7 +2,7 @@ import asyncio
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import Engine, delete, or_, update
+from sqlalchemy import Engine, delete, or_, tuple_, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import Session, col, select
 
@@ -91,5 +91,30 @@ class RawOrganismeRepository(IRawOrganismeRepository):
                 update(RawOrganismeModel)
                 .where(col(RawOrganismeModel.id).in_(ids))
                 .values(cleaned_at=cleaned_at)
+            )
+            session.commit()
+
+    async def mark_as_upserted_batch(
+        self, referentiel_external_ids: list[tuple[str, str]], upsert_at: datetime
+    ) -> None:
+        if not referentiel_external_ids:
+            return
+        await asyncio.to_thread(
+            self._mark_as_upserted_batch_sync, referentiel_external_ids, upsert_at
+        )
+
+    def _mark_as_upserted_batch_sync(
+        self, referentiel_external_ids: list[tuple[str, str]], upsert_at: datetime
+    ) -> None:
+        with Session(self._engine) as session:
+            session.execute(
+                update(RawOrganismeModel)
+                .where(
+                    tuple_(
+                        col(RawOrganismeModel.referentiel),
+                        col(RawOrganismeModel.external_id),
+                    ).in_(referentiel_external_ids)
+                )
+                .values(upsert_at=upsert_at)
             )
             session.commit()

--- a/src/ingestion/tests/integration/test_raw_organisme_repository.py
+++ b/src/ingestion/tests/integration/test_raw_organisme_repository.py
@@ -355,3 +355,38 @@ async def test_mark_as_cleaned_batch_with_empty_ids_is_noop(
 
     saved = _fetch(db_engine, REFERENTIEL, EXTERNAL_ID)
     assert saved.cleaned_at is None
+
+
+@pytest.mark.asyncio
+async def test_mark_as_upserted_batch_sets_upsert_at(
+    raw_organisme_repository, db_engine
+):
+    organisme = RawOrganisme(
+        referentiel=REFERENTIEL, millesime="2026-08-19", external_id=EXTERNAL_ID
+    )
+    await raw_organisme_repository.upsert_batch([organisme])
+    upsert_at = datetime.now(tz=timezone.utc)
+
+    await raw_organisme_repository.mark_as_upserted_batch(
+        [(REFERENTIEL, EXTERNAL_ID)], upsert_at
+    )
+
+    saved = _fetch(db_engine, REFERENTIEL, EXTERNAL_ID)
+    assert saved.upsert_at is not None
+
+
+@pytest.mark.asyncio
+async def test_mark_as_upserted_batch_with_empty_list_is_noop(
+    raw_organisme_repository, db_engine
+):
+    organisme = RawOrganisme(
+        referentiel=REFERENTIEL, millesime="2026-08-19", external_id=EXTERNAL_ID
+    )
+    await raw_organisme_repository.upsert_batch([organisme])
+
+    await raw_organisme_repository.mark_as_upserted_batch(
+        [], datetime.now(tz=timezone.utc)
+    )
+
+    saved = _fetch(db_engine, REFERENTIEL, EXTERNAL_ID)
+    assert saved.upsert_at is None

--- a/src/ingestion/tests/shared_fixtures.py
+++ b/src/ingestion/tests/shared_fixtures.py
@@ -258,10 +258,22 @@ def archive_offer_usecase(mock_raw_offer_repository: MagicMock) -> ArchiveOfferU
 
 
 @pytest.fixture
-def publish_organismes_usecase() -> PublishOrganismesUsecase:
+def mock_raw_organisme_repository() -> MagicMock:
+    mock_repo = MagicMock()
+    mock_repo.mark_as_upserted_batch = AsyncMock()
+    return mock_repo
+
+
+@pytest.fixture
+def publish_organismes_usecase(
+    mock_raw_organisme_repository: MagicMock,
+) -> PublishOrganismesUsecase:
     container = Container()
     container.config.from_dict(
         {"web_base_url": WEB_BASE_URL, "web_api_key": WEB_API_KEY, "database_url": None}
+    )
+    container.raw_organisme_repository.override(
+        providers.Object(mock_raw_organisme_repository)
     )
     usecase = container.publish_organismes_usecase()
     assert usecase is not None

--- a/src/ingestion/tests/unit/test_publish_organismes_usecase.py
+++ b/src/ingestion/tests/unit/test_publish_organismes_usecase.py
@@ -11,15 +11,18 @@ from application.usecases.publish_organismes import (
     PublishOrganismesUsecase,
 )
 from domain.gateways.publish_organismes_gateway import IPublishOrganismesGateway
+from domain.repositories.raw_organisme_repository import IRawOrganismeRepository
 
 
-def _organisme() -> Organisme:
+def _organisme(external_id: str = "ext-1", referentiel: str = "FINESS") -> Organisme:
     return Organisme.build(
         entity_id=uuid4(),
         nom="Mairie de Test",
         versant=Verse.FPT,
         localisation=None,
         siret=SIRET(code="26060047300342"),
+        external_id=external_id,
+        referentiel=referentiel,
     )
 
 
@@ -31,8 +34,18 @@ def mock_gateway():
 
 
 @pytest.fixture
-def usecase(mock_gateway):
-    return PublishOrganismesUsecase(publish_organismes_gateway=mock_gateway)
+def mock_raw_organisme_repository():
+    repository = MagicMock(spec=IRawOrganismeRepository)
+    repository.mark_as_upserted_batch = AsyncMock()
+    return repository
+
+
+@pytest.fixture
+def usecase(mock_gateway, mock_raw_organisme_repository):
+    return PublishOrganismesUsecase(
+        publish_organismes_gateway=mock_gateway,
+        raw_organisme_repository=mock_raw_organisme_repository,
+    )
 
 
 @pytest.mark.asyncio
@@ -70,3 +83,28 @@ async def test_execute_propagates_gateway_error(usecase, mock_gateway):
 
     with pytest.raises(RuntimeError, match="API down"):
         await usecase.execute(PublishOrganismesCommand(organismes=[_organisme()]))
+
+
+@pytest.mark.asyncio
+async def test_execute_marks_raw_organismes_as_upserted(
+    usecase, mock_raw_organisme_repository
+):
+    organisme = _organisme(external_id="ext-1", referentiel="FINESS")
+
+    await usecase.execute(PublishOrganismesCommand(organismes=[organisme]))
+
+    mock_raw_organisme_repository.mark_as_upserted_batch.assert_awaited_once()
+    args = mock_raw_organisme_repository.mark_as_upserted_batch.await_args.args
+    assert args[0] == [("FINESS", "ext-1")]
+
+
+@pytest.mark.asyncio
+async def test_execute_does_not_mark_upserted_when_publish_fails(
+    usecase, mock_gateway, mock_raw_organisme_repository
+):
+    mock_gateway.publish.side_effect = RuntimeError("API down")
+
+    with pytest.raises(RuntimeError):
+        await usecase.execute(PublishOrganismesCommand(organismes=[_organisme()]))
+
+    mock_raw_organisme_repository.mark_as_upserted_batch.assert_not_awaited()


### PR DESCRIPTION
## 📝 Description
`publish_organismes_usecase` ne mettait pas à jour `upsert_at` en base après publication, contrairement à `clean_raw_organismes_usecase` qui met à jour `cleaned_at`.

- `PublishOrganismesUsecase` prend maintenant `IRawOrganismeRepository` et appelle `mark_as_upserted_batch` après chaque batch publié avec succès, en faisant
correspondre les organismes publiés aux `raw_organismes` via le couple `(referentiel, external_id)`.
- Ajout de `mark_as_upserted_batch` à `IRawOrganismeRepository` / `RawOrganismeRepository`.
- Câblage dans le conteneur DI.
- Tests unitaires et d'intégration ajoutés/mis à jour.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
