### PR TITLE
🐛(ingestion) injecte l'env Scaleway dans les jobs cron

### DIFF
--- a/src/ingestion/cron.json
+++ b/src/ingestion/cron.json
@@ -1,11 +1,11 @@
 {
   "jobs": [
     {
-      "command": "5 4 * * 1 bash bin/archive_offers.py --source-id $DEFAULT_SOURCE_ID",
+      "command": "5 4 * * 1 bash -c 'source bin/inject_scaleway_env.sh && bin/archive_offers.py --source-id $DEFAULT_SOURCE_ID'",
       "size": "S"
     },
     {
-      "command": "0 6 * * 1 bash bin/organismes_pipeline.py",
+      "command": "0 6 * * 1 bash -c 'source bin/inject_scaleway_env.sh && bin/organismes_pipeline.py'",
       "size": "XL"
     }
   ]


### PR DESCRIPTION
## 📝 Description

Les jobs `cron.json` lançaient les scripts sans passer par `inject_scaleway_env.sh`, contrairement à web/worker, donc sans les secrets nécessaires (DB, etc.) en prod.

## 🏷️ Type de changement
- [x] 🐛 Correction de bug

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
