### PR TITLE
✨(ingestion) expose les référentiels fake-ts via /referentials/{type}

### DIFF
--- a/src/web/presentation/ingestion/urls_fake_ts.py
+++ b/src/web/presentation/ingestion/urls_fake_ts.py
@@ -2,10 +2,16 @@ from django.urls import path
 
 from presentation.ingestion.views.offer_detail import OfferDetailView
 from presentation.ingestion.views.offer_summaries import OfferSummariesView
+from presentation.ingestion.views.referentials import ReferentialListView
 
 app_name = "ingestion_fake_ts"
 
 urlpatterns = [
     path("offersummaries", OfferSummariesView.as_view(), name="offer_summaries"),
     path("offers/getoffer", OfferDetailView.as_view(), name="offer_detail"),
+    path(
+        "referentials/<str:type>",
+        ReferentialListView.as_view(),
+        name="referentials_list",
+    ),
 ]

--- a/src/web/presentation/ingestion/urls_fake_ts.py
+++ b/src/web/presentation/ingestion/urls_fake_ts.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path("offersummaries", OfferSummariesView.as_view(), name="offer_summaries"),
     path("offers/getoffer", OfferDetailView.as_view(), name="offer_detail"),
     path(
-        "referentials/<str:type>",
+        "referentials/<str:referential_type>",
         ReferentialListView.as_view(),
         name="referentials_list",
     ),

--- a/src/web/presentation/ingestion/views/referentials.py
+++ b/src/web/presentation/ingestion/views/referentials.py
@@ -53,7 +53,7 @@ REFERENTIAL_TYPES = {
     tags=["fake-ts"],
     parameters=[
         OpenApiParameter(
-            name="type",
+            name="referential_type",
             type=OpenApiTypes.STR,
             location=OpenApiParameter.PATH,
             enum=sorted(REFERENTIAL_TYPES),
@@ -68,11 +68,11 @@ class ReferentialListView(APIView):
     authentication_classes = [JWTAuthentication]
     serializer_class = FakeTsCodedObjectSerializer
 
-    def get(self, request, type):
-        build_items = REFERENTIAL_TYPES.get(type)
+    def get(self, request, referential_type):
+        build_items = REFERENTIAL_TYPES.get(referential_type)
         if build_items is None:
             serializer = GenericErrorSerializer(
-                {"error": f"Référentiel inconnu : {type}."}
+                {"error": f"Référentiel inconnu : {referential_type}."}
             )
             return Response(serializer.data, status=status.HTTP_404_NOT_FOUND)
 
@@ -83,7 +83,7 @@ class ReferentialListView(APIView):
                 "label": label,
                 "active": True,
                 "parentCode": None,
-                "type": type,
+                "type": referential_type,
                 "parentType": "",
                 "hasChildren": False,
             }

--- a/src/web/presentation/ingestion/views/referentials.py
+++ b/src/web/presentation/ingestion/views/referentials.py
@@ -1,0 +1,93 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from referentiel.value_objects.area import GeographicalArea
+from referentiel.value_objects.category import Category
+from referentiel.value_objects.contract_type import ContractType
+from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
+from referentiel.value_objects.verse import Verse
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from presentation.api.serializers import GenericErrorSerializer
+from presentation.ingestion.serializers import (
+    COUNTRY_NAMES,
+    DEPARTMENT_NAMES,
+    DOMAIN_NAMES,
+    REGION_NAMES,
+    FakeTsCodedObjectSerializer,
+)
+
+
+def _enum_items(enum_cls):
+    return [(member.name, member.label) for member in enum_cls]
+
+
+def _code_names_items(names):
+    return sorted(names.items())
+
+
+REFERENTIAL_TYPES = {
+    "area": lambda: _enum_items(GeographicalArea),
+    "contract_type": lambda: _enum_items(ContractType),
+    "country": lambda: _code_names_items(COUNTRY_NAMES),
+    "department": lambda: _code_names_items(DEPARTMENT_NAMES),
+    "domain": lambda: _code_names_items(DOMAIN_NAMES),
+    "experience_level": lambda: _enum_items(ExperienceLevel),
+    "management": lambda: _enum_items(Management),
+    "offer_family_category": lambda: _enum_items(Category),
+    "region": lambda: _code_names_items(REGION_NAMES),
+    "verse": lambda: _enum_items(Verse),
+    "working_place": lambda: _enum_items(WorkingPlace),
+}
+
+
+@extend_schema(
+    summary="Valeurs d'un référentiel (format Talentsoft)",
+    description=(
+        "Liste les valeurs possibles d'un référentiel utilisé par l'API "
+        "fake-ts, au format objet codé Talentsoft."
+    ),
+    tags=["fake-ts"],
+    parameters=[
+        OpenApiParameter(
+            name="type",
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.PATH,
+            enum=sorted(REFERENTIAL_TYPES),
+        ),
+    ],
+    responses={
+        200: FakeTsCodedObjectSerializer(many=True),
+        404: GenericErrorSerializer,
+    },
+)
+class ReferentialListView(APIView):
+    authentication_classes = [JWTAuthentication]
+    serializer_class = FakeTsCodedObjectSerializer
+
+    def get(self, request, type):
+        build_items = REFERENTIAL_TYPES.get(type)
+        if build_items is None:
+            serializer = GenericErrorSerializer(
+                {"error": f"Référentiel inconnu : {type}."}
+            )
+            return Response(serializer.data, status=status.HTTP_404_NOT_FOUND)
+
+        data = [
+            {
+                "code": None,
+                "clientCode": client_code,
+                "label": label,
+                "active": True,
+                "parentCode": None,
+                "type": type,
+                "parentType": "",
+                "hasChildren": False,
+            }
+            for client_code, label in build_items()
+        ]
+
+        return Response(self.serializer_class(data, many=True).data)

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -1251,7 +1251,7 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
-  /api/fake-ts/referentials/{type}:
+  /api/fake-ts/referentials/{referential_type}:
     get:
       operationId: fake_ts_referentials_list
       description: Liste les valeurs possibles d'un référentiel utilisé par l'API
@@ -1259,7 +1259,7 @@ paths:
       summary: Valeurs d'un référentiel (format Talentsoft)
       parameters:
       - in: path
-        name: type
+        name: referential_type
         schema:
           type: string
           enum:

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -1251,6 +1251,105 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+  /api/fake-ts/referentials/{type}:
+    get:
+      operationId: fake_ts_referentials_list
+      description: Liste les valeurs possibles d'un référentiel utilisé par l'API
+        fake-ts, au format objet codé Talentsoft.
+      summary: Valeurs d'un référentiel (format Talentsoft)
+      parameters:
+      - in: path
+        name: type
+        schema:
+          type: string
+          enum:
+          - area
+          - contract_type
+          - country
+          - department
+          - domain
+          - experience_level
+          - management
+          - offer_family_category
+          - region
+          - verse
+          - working_place
+        required: true
+      tags:
+      - fake-ts
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FakeTsCodedObject'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /api/token:
     post:
       operationId: token_create

--- a/src/web/tests/presentation/ingestion/views/test_referentials.py
+++ b/src/web/tests/presentation/ingestion/views/test_referentials.py
@@ -1,0 +1,106 @@
+import pytest
+from django.urls import reverse
+from referentiel.value_objects.area import GeographicalArea
+from referentiel.value_objects.category import Category
+from referentiel.value_objects.contract_type import ContractType
+from referentiel.value_objects.experience_level import ExperienceLevel
+from referentiel.value_objects.offer_conditions import Management, WorkingPlace
+from referentiel.value_objects.verse import Verse
+from rest_framework import status
+
+from presentation.ingestion.serializers import (
+    COUNTRY_NAMES,
+    DEPARTMENT_NAMES,
+    DOMAIN_NAMES,
+    REGION_NAMES,
+    FakeTsCodedObjectSerializer,
+)
+from tests.utils.openapi_test_utils import assert_matches_openapi_schema
+
+
+@pytest.mark.parametrize(
+    "referential_type,enum_cls",
+    [
+        ("verse", Verse),
+        ("area", GeographicalArea),
+        ("management", Management),
+        ("working_place", WorkingPlace),
+        ("contract_type", ContractType),
+        ("offer_family_category", Category),
+        ("experience_level", ExperienceLevel),
+    ],
+)
+def test_returns_all_enum_members(authenticated_client, referential_type, enum_cls):
+    url = reverse(
+        "ingestion_fake_ts:referentials_list", kwargs={"type": referential_type}
+    )
+
+    response = authenticated_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == len(list(enum_cls))
+    assert {item["clientCode"] for item in data} == {e.name for e in enum_cls}
+    assert {item["label"] for item in data} == {e.label for e in enum_cls}
+    assert all(item["type"] == referential_type for item in data)
+    assert all(item["active"] is True for item in data)
+
+
+@pytest.mark.parametrize(
+    "referential_type,names",
+    [
+        ("country", COUNTRY_NAMES),
+        ("region", REGION_NAMES),
+        ("department", DEPARTMENT_NAMES),
+        ("domain", DOMAIN_NAMES),
+    ],
+)
+def test_returns_all_code_names(authenticated_client, referential_type, names):
+    url = reverse(
+        "ingestion_fake_ts:referentials_list", kwargs={"type": referential_type}
+    )
+
+    response = authenticated_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == len(names)
+    assert {item["clientCode"] for item in data} == set(names.keys())
+    assert {item["label"] for item in data} == set(names.values())
+    assert all(item["type"] == referential_type for item in data)
+    assert all(item["active"] is True for item in data)
+
+
+def test_unauthenticated_access(api_client):
+    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "verse"})
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_unknown_referential_returns_404(authenticated_client):
+    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "unknown"})
+
+    response = authenticated_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_response_has_no_undeclared_fields(authenticated_client):
+    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "verse"})
+
+    response = authenticated_client.get(url)
+    result = response.json()[0]
+
+    assert set(result.keys()) == set(FakeTsCodedObjectSerializer().fields.keys())
+
+
+def test_response_matches_openapi_schema(authenticated_client):
+    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "verse"})
+
+    response = authenticated_client.get(url)
+
+    assert_matches_openapi_schema(
+        response.json(), "/api/fake-ts/referentials/{type}", method="get"
+    )

--- a/src/web/tests/presentation/ingestion/views/test_referentials.py
+++ b/src/web/tests/presentation/ingestion/views/test_referentials.py
@@ -32,7 +32,8 @@ from tests.utils.openapi_test_utils import assert_matches_openapi_schema
 )
 def test_returns_all_enum_members(authenticated_client, referential_type, enum_cls):
     url = reverse(
-        "ingestion_fake_ts:referentials_list", kwargs={"type": referential_type}
+        "ingestion_fake_ts:referentials_list",
+        kwargs={"referential_type": referential_type},
     )
 
     response = authenticated_client.get(url)
@@ -57,7 +58,8 @@ def test_returns_all_enum_members(authenticated_client, referential_type, enum_c
 )
 def test_returns_all_code_names(authenticated_client, referential_type, names):
     url = reverse(
-        "ingestion_fake_ts:referentials_list", kwargs={"type": referential_type}
+        "ingestion_fake_ts:referentials_list",
+        kwargs={"referential_type": referential_type},
     )
 
     response = authenticated_client.get(url)
@@ -72,7 +74,9 @@ def test_returns_all_code_names(authenticated_client, referential_type, names):
 
 
 def test_unauthenticated_access(api_client):
-    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "verse"})
+    url = reverse(
+        "ingestion_fake_ts:referentials_list", kwargs={"referential_type": "verse"}
+    )
 
     response = api_client.get(url)
 
@@ -80,7 +84,9 @@ def test_unauthenticated_access(api_client):
 
 
 def test_unknown_referential_returns_404(authenticated_client):
-    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "unknown"})
+    url = reverse(
+        "ingestion_fake_ts:referentials_list", kwargs={"referential_type": "unknown"}
+    )
 
     response = authenticated_client.get(url)
 
@@ -88,7 +94,9 @@ def test_unknown_referential_returns_404(authenticated_client):
 
 
 def test_response_has_no_undeclared_fields(authenticated_client):
-    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "verse"})
+    url = reverse(
+        "ingestion_fake_ts:referentials_list", kwargs={"referential_type": "verse"}
+    )
 
     response = authenticated_client.get(url)
     result = response.json()[0]
@@ -97,10 +105,12 @@ def test_response_has_no_undeclared_fields(authenticated_client):
 
 
 def test_response_matches_openapi_schema(authenticated_client):
-    url = reverse("ingestion_fake_ts:referentials_list", kwargs={"type": "verse"})
+    url = reverse(
+        "ingestion_fake_ts:referentials_list", kwargs={"referential_type": "verse"}
+    )
 
     response = authenticated_client.get(url)
 
     assert_matches_openapi_schema(
-        response.json(), "/api/fake-ts/referentials/{type}", method="get"
+        response.json(), "/api/fake-ts/referentials/{referential_type}", method="get"
     )


### PR DESCRIPTION
## 📝 Description

Ajoute un endpoint générique GET /api/fake-ts/referentials/{type} qui liste les valeurs possibles des référentiels utilisés par l'API fake-ts (verse, area, management, working_place, contract_type, offer_family_category, experience_level, domain, country, region, department), au format objet codé Talentsoft.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

<img width="1183" height="560" alt="Screenshot 2026-09-07 at 16 07 24" src="https://github.com/user-attachments/assets/286c80bb-5bd9-4ca4-aeeb-80eb1bc64f59" />


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
