### PR TITLE
✨(recruteur) Affichage des membres d'un recrutement - back + interface

### DIFF
--- a/src/web/application/recruteur/services/list_recrutement_agents.py
+++ b/src/web/application/recruteur/services/list_recrutement_agents.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+
+from django.db.models import QuerySet
+
+from domain.identite.entities.utilisateurs import Utilisateur
+from domain.identite.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.identite.value_objects.organisme_action import OrganismeAction
+from domain.recruteur.errors.recrutement_errors import RecrutementInexistant
+from infrastructure.django_apps.recruteur.models.recrutement import (
+    RecrutementAgentModel,
+    RecrutementModel,
+)
+from infrastructure.repositories.recruteur.postgres_organisme_agent_repository import (
+    PostgresOrganismeAgentRepository,
+)
+from infrastructure.repositories.recruteur.postgres_organisme_repository import (
+    PostgresOrganismeRecruteurRepository,
+)
+from infrastructure.repositories.recruteur.postgres_recrutement_agent_repository import (  # noqa: E501
+    PostgresRecrutementAgentRepository,
+)
+
+
+def list_recrutement_agents(
+    *, organisme_id: UUID, recrutement_id: UUID, utilisateur: Utilisateur
+) -> QuerySet[RecrutementAgentModel]:
+    # TODO : to refactor in ADR-009 style once OrganismePermissionService is migrated
+    organisme_permission_service = OrganismePermissionService(
+        organisme_recruteur_repository=PostgresOrganismeRecruteurRepository(),
+        organisme_agent_repository=PostgresOrganismeAgentRepository(),
+        recrutement_agent_repository=PostgresRecrutementAgentRepository(),
+    )
+    organisme_permission_service.est_autorise(
+        action=OrganismeAction.LIST_RECRUTEMENT_AGENTS,
+        utilisateur=utilisateur,
+        organisme_id=organisme_id,
+    )
+
+    if not RecrutementModel.objects.filter(
+        pk=recrutement_id, organisme_id=organisme_id
+    ).exists():
+        raise RecrutementInexistant(recrutement_id)
+
+    return RecrutementAgentModel.objects.by_recrutement(recrutement_id)

--- a/src/web/domain/identite/services/organisme_permission_service.py
+++ b/src/web/domain/identite/services/organisme_permission_service.py
@@ -46,6 +46,7 @@ _AUTORISE_POUR_STAFF: frozenset[OrganismeAction] = frozenset(
         OrganismeAction.UPDATE_ORGANISME_AGENT,
         OrganismeAction.REVOKE_ORGANISME_AGENT,
         OrganismeAction.CREATE_AGENT,
+        OrganismeAction.LIST_RECRUTEMENT_AGENTS,
     }
 )
 
@@ -82,6 +83,9 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.UPDATE_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.REVOKE_ORGANISME_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
     OrganismeAction.CREATE_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
+    OrganismeAction.LIST_RECRUTEMENT_AGENTS: frozenset(
+        {AgentOrganismeRole.RESPONSABLE}
+    ),
 }
 
 # -------------------------------------

--- a/src/web/domain/identite/value_objects/organisme_action.py
+++ b/src/web/domain/identite/value_objects/organisme_action.py
@@ -20,3 +20,4 @@ class OrganismeAction(Enum):
     UPDATE_ORGANISME_AGENT = "update_organisme_agent"
     REVOKE_ORGANISME_AGENT = "revoke_organisme_agent"
     CREATE_AGENT = "create_agent"
+    LIST_RECRUTEMENT_AGENTS = "list_recrutement_agents"

--- a/src/web/frontend/src/types/api.d.ts
+++ b/src/web/frontend/src/types/api.d.ts
@@ -307,6 +307,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/parametres/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Liste des agents ayant un rôle sur un recrutement */
+        get: operations["recruteur_organismes_recrutements_parametres_agents_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/utilisateur/me": {
         parameters: {
             query?: never;
@@ -659,6 +676,21 @@ export interface components {
             previous?: string | null;
             results: components["schemas"]["CandidatureListe"][];
         };
+        PaginatedRecrutementAgentList: {
+            /** @example 123 */
+            count: number;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?page=4
+             */
+            next?: string | null;
+            /**
+             * Format: uri
+             * @example http://api.example.org/accounts/?page=2
+             */
+            previous?: string | null;
+            results: components["schemas"]["RecrutementAgent"][];
+        };
         PaginatedRecrutementsActifsList: {
             /** @example 1 */
             count: number;
@@ -697,6 +729,16 @@ export interface components {
         PatchedEditerNote: {
             message?: string;
         };
+        RecrutementAgent: {
+            /** Format: uuid */
+            agent_id: string;
+            nom: string;
+            prenom: string;
+            poste: string;
+            /** Format: email */
+            email: string;
+            recrutement_role: components["schemas"]["RecrutementRoleEnum"];
+        };
         RecrutementDetail: {
             /** Format: uuid */
             offer_id: string;
@@ -714,6 +756,13 @@ export interface components {
             offer_id: string;
             etapes: components["schemas"]["EtapeRecrutementDetailedCandidatures"][];
         };
+        /**
+         * @description * `responsable` - responsable
+         *     * `recruteur` - recruteur
+         *     * `contributeur` - contributeur
+         * @enum {string}
+         */
+        RecrutementRoleEnum: "responsable" | "recruteur" | "contributeur";
         RecrutementsActifs: {
             /** Format: uuid */
             offer_id: string;
@@ -3536,6 +3585,113 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            401: {
+                headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenError"];
+                };
+            };
+            403: {
+                headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            404: {
+                headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+            /** @description Nombre maximal d'appels autorisés dépassé. */
+            429: {
+                headers: {
+                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+                    "Retry-After"?: number;
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Request was throttled. Expected available in 42 seconds. */
+                        detail?: string;
+                    };
+                };
+            };
+            500: {
+                headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
+        };
+    };
+    recruteur_organismes_recrutements_parametres_agents_list: {
+        parameters: {
+            query?: {
+                /** @description Un numéro de page de l'ensemble des résultats. */
+                page?: number;
+            };
+            header?: never;
+            path: {
+                organisme_uuid: string;
+                recrutement_uuid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Nombre d'appels restants sur la fenêtre courante. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedRecrutementAgentList"];
                 };
             };
             401: {

--- a/src/web/infrastructure/django_apps/recruteur/models/recrutement.py
+++ b/src/web/infrastructure/django_apps/recruteur/models/recrutement.py
@@ -41,6 +41,15 @@ class RecrutementModel(models.Model):
         return str(self.offre)
 
 
+class RecrutementAgentQuerySet(models.QuerySet):
+    def by_recrutement(self, recrutement_id) -> "RecrutementAgentQuerySet":
+        return (
+            self.select_related("agent__utilisateur")
+            .filter(recrutement_id=recrutement_id)
+            .order_by("created_at")
+        )
+
+
 class RecrutementAgentModel(BaseDatedModel):
     recrutement = models.ForeignKey(
         RecrutementModel,
@@ -54,6 +63,8 @@ class RecrutementAgentModel(BaseDatedModel):
         choices=[(r.value, r.value) for r in AgentRecrutementRole],
         default=AgentRecrutementRole.CONTRIBUTEUR.value,
     )
+
+    objects = RecrutementAgentQuerySet.as_manager()
 
     class Meta:
         db_table = "recrutement_agent"

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -6,7 +6,13 @@ from rest_framework import serializers
 from domain.recruteur.value_objects.categorie_etapes_recrutement import (
     CategorieEtapeRecrutement,
 )
-from domain.recruteur.value_objects.roles import AgentOrganismeRole
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
+from infrastructure.django_apps.recruteur.models.recrutement import (
+    RecrutementAgentModel,
+)
 from infrastructure.django_apps.users.models import ProfilAgentModel
 from presentation.commons.serializers import LocalisationSerializer, OrganismeSerializer
 
@@ -207,6 +213,26 @@ class AgentRechercheSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProfilAgentModel
         fields = ["agent_id", "email", "prenom", "nom", "intitule_poste"]
+
+
+# ---------------------------------------------------------------------------
+# Serializer pour les agents rattachés à un recrutement
+# ---------------------------------------------------------------------------
+
+
+class RecrutementAgentSerializer(serializers.ModelSerializer):
+    agent_id = serializers.UUIDField(source="agent.utilisateur.username")
+    nom = serializers.CharField(source="agent.utilisateur.last_name")
+    prenom = serializers.CharField(source="agent.utilisateur.first_name")
+    poste = serializers.CharField(source="agent.intitule_poste")
+    email = serializers.EmailField(source="agent.utilisateur.email")
+    recrutement_role = serializers.ChoiceField(
+        source="role", choices=[(r.value, r.value) for r in AgentRecrutementRole]
+    )
+
+    class Meta:
+        model = RecrutementAgentModel
+        fields = ["agent_id", "nom", "prenom", "poste", "email", "recrutement_role"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/web/presentation/recruteur/urls.py
+++ b/src/web/presentation/recruteur/urls.py
@@ -17,6 +17,9 @@ from presentation.recruteur.views.organisme_detail import (
 from presentation.recruteur.views.organismes import (
     OrganismesView,
 )
+from presentation.recruteur.views.recrutement_agents import (
+    RecrutementAgentsView,
+)
 from presentation.recruteur.views.recrutement_detail import (
     RecrutementCandidaturesEtapeView,
     RecrutementDetailView,
@@ -109,6 +112,11 @@ urlpatterns = [
         "organismes/<uuid:organisme_uuid>/recrutements/<uuid:recrutement_uuid>/etapes/init",
         InitRecrutementEtapeView.as_view(),
         name="organisme-recrutement-etapes-init",
+    ),
+    path(
+        "organismes/<uuid:organisme_uuid>/recrutements/<uuid:recrutement_uuid>/parametres/agents",
+        RecrutementAgentsView.as_view(),
+        name="organisme-recrutement-parametres-agents",
     ),
     path(
         "candidatures/<uuid:candidature_uuid>/notes",

--- a/src/web/presentation/recruteur/views/recrutement_agents.py
+++ b/src/web/presentation/recruteur/views/recrutement_agents.py
@@ -1,0 +1,57 @@
+from django.http import Http404
+from drf_spectacular.utils import extend_schema
+from rest_framework import exceptions, status
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from application.recruteur.services.list_recrutement_agents import (
+    list_recrutement_agents,
+)
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
+from domain.identite.errors.organisme_permission_errors import (
+    AccesOrganismeRefuse,
+    OperationOrganismeRefusee,
+)
+from domain.recruteur.errors.recrutement_errors import RecrutementInexistant
+from presentation.api.serializers import GenericErrorSerializer, generic_response_format
+from presentation.recruteur.mappers import UtilisateurMapper
+from presentation.recruteur.serializers import RecrutementAgentSerializer
+
+
+@extend_schema(
+    summary="Liste des agents ayant un rôle sur un recrutement",
+    tags=["recruteur"],
+    responses={
+        **generic_response_format,
+        200: RecrutementAgentSerializer(many=True),
+    },
+)
+class RecrutementAgentsView(ListAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = RecrutementAgentSerializer
+
+    def get_queryset(self):
+        return list_recrutement_agents(
+            organisme_id=self.kwargs["organisme_uuid"],
+            recrutement_id=self.kwargs["recrutement_uuid"],
+            utilisateur=UtilisateurMapper().to_domain(self.request),
+        )
+
+    def handle_exception(self, exc: Exception) -> Response:
+        if isinstance(exc, (AccesOrganismeRefuse, OperationOrganismeRefusee)):
+            return Response(
+                GenericErrorSerializer({"error": str(exc)}).data,
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        if isinstance(exc, (OrganismeNexistePas, RecrutementInexistant)):
+            return Response(
+                GenericErrorSerializer({"error": str(exc)}).data,
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        if isinstance(exc, (exceptions.APIException, Http404)):
+            return super().handle_exception(exc)
+        return Response(
+            GenericErrorSerializer({"error": "Unexpected error"}).data,
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -4014,6 +4014,163 @@ paths:
                 type: integer
               description: Timestamp Unix (secondes) auquel la fenêtre courante se
                 réinitialise.
+  /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/parametres/agents:
+    get:
+      operationId: recruteur_organismes_recrutements_parametres_agents_list
+      summary: Liste des agents ayant un rôle sur un recrutement
+      parameters:
+      - in: path
+        name: organisme_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - name: page
+        required: false
+        in: query
+        description: Un numéro de page de l'ensemble des résultats.
+        schema:
+          type: integer
+      - in: path
+        name: recrutement_uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - recruteur
+      security:
+      - jwtAuth: []
+      - cookieAuth: []
+      responses:
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenError'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRecrutementAgentList'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
+        '429':
+          description: Nombre maximal d'appels autorisés dépassé.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: Request was throttled. Expected available in 42 seconds.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: Nombre d'appels restants sur la fenêtre courante.
+            X-RateLimit-Reset:
+              schema:
+                type: integer
+              description: Timestamp Unix (secondes) auquel la fenêtre courante se
+                réinitialise.
   /utilisateur/me:
     get:
       operationId: utilisateur_me_retrieve
@@ -4869,6 +5026,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CandidatureListe'
+    PaginatedRecrutementAgentList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecrutementAgent'
     PaginatedRecrutementsActifsList:
       type: object
       required:
@@ -4930,6 +5110,30 @@ components:
       properties:
         message:
           type: string
+    RecrutementAgent:
+      type: object
+      properties:
+        agent_id:
+          type: string
+          format: uuid
+        nom:
+          type: string
+        prenom:
+          type: string
+        poste:
+          type: string
+        email:
+          type: string
+          format: email
+        recrutement_role:
+          $ref: '#/components/schemas/RecrutementRoleEnum'
+      required:
+      - agent_id
+      - email
+      - nom
+      - poste
+      - prenom
+      - recrutement_role
     RecrutementDetail:
       type: object
       properties:
@@ -4975,6 +5179,16 @@ components:
       required:
       - etapes
       - offer_id
+    RecrutementRoleEnum:
+      enum:
+      - responsable
+      - recruteur
+      - contributeur
+      type: string
+      description: |-
+        * `responsable` - responsable
+        * `recruteur` - recruteur
+        * `contributeur` - contributeur
     RecrutementsActifs:
       type: object
       properties:

--- a/src/web/tests/domain/identite/test_organisme_permission_service.py
+++ b/src/web/tests/domain/identite/test_organisme_permission_service.py
@@ -44,6 +44,7 @@ RESPONSABLE_ACTIONS = [
     OrganismeAction.UPDATE_ORGANISME_AGENT,
     OrganismeAction.REVOKE_ORGANISME_AGENT,
     OrganismeAction.CREATE_AGENT,
+    OrganismeAction.LIST_RECRUTEMENT_AGENTS,
 ]
 STAFF_BYPASS_ACTIONS = [
     OrganismeAction.GET_ORGANISME,
@@ -55,6 +56,7 @@ STAFF_BYPASS_ACTIONS = [
     OrganismeAction.UPDATE_ORGANISME_AGENT,
     OrganismeAction.REVOKE_ORGANISME_AGENT,
     OrganismeAction.CREATE_AGENT,
+    OrganismeAction.LIST_RECRUTEMENT_AGENTS,
 ]
 
 

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_agents.py
@@ -1,0 +1,177 @@
+from uuid import uuid4
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
+from infrastructure.factories.identite.agent_django_factory import AgentDjangoFactory
+from infrastructure.factories.identite.organisme_django_factory import (
+    OrganismeDjangoFactory,
+    create_organisme_with_agent,
+)
+from infrastructure.factories.identite.utilisateur_django_factory import (
+    UtilisateurDjangoFactory,
+)
+from infrastructure.factories.recruteur.recrutement_django_factory import (
+    RecrutementAgentDjangoFactory,
+    RecrutementDjangoFactory,
+)
+
+NOMBRE_AGENTS_ATTENDU = 2
+NOMBRE_REQUETES_ATTENDU = (
+    2  # authentification
+    + 1  # organisme
+    + 1  # agent's role
+    + 1  # matching recrutement with organisme
+    + 2  # pagination : count + page
+)
+
+
+def _url(organisme_uuid, recrutement_uuid):
+    return reverse(
+        "recruteur:organisme-recrutement-parametres-agents",
+        kwargs={"organisme_uuid": organisme_uuid, "recrutement_uuid": recrutement_uuid},
+    )
+
+
+def _unknown_organisme_ids(organisme):
+    return uuid4(), uuid4()
+
+
+def _unknown_recrutement_ids(organisme):
+    return organisme.id, uuid4()
+
+
+def _recrutement_from_another_organisme_ids(organisme):
+    autre_organisme = OrganismeDjangoFactory()
+    recrutement = RecrutementDjangoFactory(organisme=autre_organisme)
+    return organisme.id, recrutement.pk
+
+
+class TestRecrutementAgentsView:
+    def test_anonymous_access_is_unauthorized(self, api_client):
+        response = api_client.get(_url(uuid4(), uuid4()))
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_responsable_lists_recrutement_agents(
+        self, authenticated_client, test_user
+    ):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE,
+            utilisateur=test_user,
+        )
+        membre = AgentDjangoFactory()
+        recrutement = RecrutementDjangoFactory(
+            organisme=organisme,
+            agent_link__agent=membre,
+            agent_link__role=AgentRecrutementRole.RESPONSABLE.value,
+        )
+
+        response = authenticated_client.get(_url(organisme.id, recrutement.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["count"] == 1
+        assert body["results"] == [
+            {
+                "agent_id": str(membre.utilisateur_id),
+                "nom": membre.utilisateur.last_name,
+                "prenom": membre.utilisateur.first_name,
+                "poste": membre.intitule_poste,
+                "email": membre.utilisateur.email,
+                "recrutement_role": AgentRecrutementRole.RESPONSABLE.value,
+            }
+        ]
+
+    def test_lists_every_agent_of_the_recrutement(
+        self, authenticated_client, test_user
+    ):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE,
+            utilisateur=test_user,
+        )
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+        RecrutementAgentDjangoFactory(
+            recrutement=recrutement, role=AgentRecrutementRole.CONTRIBUTEUR.value
+        )
+
+        response = authenticated_client.get(_url(organisme.id, recrutement.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        assert len(results) == NOMBRE_AGENTS_ATTENDU
+        assert {r["recrutement_role"] for r in results} == {
+            AgentRecrutementRole.CONTRIBUTEUR.value
+        }
+
+    def test_staff_can_list_without_organisme_role(self, api_client):
+        staff_user = UtilisateurDjangoFactory(is_staff=True)
+        refresh = RefreshToken.for_user(staff_user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+        organisme = OrganismeDjangoFactory()
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+        response = api_client.get(_url(organisme.id, recrutement.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+
+    @pytest.mark.parametrize(
+        "role",
+        [AgentOrganismeRole.MEMBRE, None],
+        ids=["membre_role", "no_organisme_role"],
+    )
+    def test_is_forbidden_for(self, authenticated_client, test_user, role):
+        if role is None:
+            organisme = OrganismeDjangoFactory()
+        else:
+            _, organisme = create_organisme_with_agent(role=role, utilisateur=test_user)
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+        response = authenticated_client.get(_url(organisme.id, recrutement.pk))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        "build_ids",
+        [
+            _unknown_organisme_ids,
+            _unknown_recrutement_ids,
+            _recrutement_from_another_organisme_ids,
+        ],
+        ids=[
+            "unknown_organisme",
+            "unknown_recrutement",
+            "recrutement_from_another_organisme",
+        ],
+    )
+    def test_returns_404_for(self, authenticated_client, test_user, build_ids):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE,
+            utilisateur=test_user,
+        )
+        organisme_uuid, recrutement_uuid = build_ids(organisme)
+
+        response = authenticated_client.get(_url(organisme_uuid, recrutement_uuid))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_does_not_trigger_n_plus_one_queries(
+        self, authenticated_client, test_user, django_assert_num_queries
+    ):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE,
+            utilisateur=test_user,
+        )
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+        RecrutementAgentDjangoFactory.create_batch(5, recrutement=recrutement)
+
+        with django_assert_num_queries(NOMBRE_REQUETES_ATTENDU):
+            response = authenticated_client.get(_url(organisme.id, recrutement.pk))
+
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## 📝 Description
🎸 Ajoute un endpoint permettant d'afficher la liste des agents rattachés à un recrutement, avec leur rôle, pour les responsables d'organisme

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
- Domain : ajoute l'action `LIST_RECRUTEMENT_AGENTS`, réservée aux responsables d'organisme (staff inclus), dans `OrganismeAction` et `OrganismePermissionService` 
- Application : ajoute le service `list_recrutement_agents`, qui vérifie les droits puis renvoie le queryset des agents d'un recrutement
- Infrastructure : ajoute `RecrutementAgentQuerySet.by_recrutement` (avec `select_related` pour éviter le N+1) sur `RecrutementAgentModel`
- Presentation : ajoute `RecrutementAgentSerializer`, la vue `RecrutementAgentsView` 
- Presentation : dans `openapi_hooks.py`, désambiguïse les champs `role` pour drf-spectacular via `ENUM_NAME_OVERRIDES`
- Schéma OpenAPI interne régénéré
 
## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
