### PR TITLE
♻️(api) factorise les headers X-RateLimit-* en components OpenAPI

### DIFF
--- a/src/web/frontend/src/types/api.d.ts
+++ b/src/web/frontend/src/types/api.d.ts
@@ -894,7 +894,16 @@ export interface components {
     responses: never;
     parameters: never;
     requestBodies: never;
-    headers: never;
+    headers: {
+        /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
+        "X-RateLimit-Limit": number;
+        /** @description Nombre d'appels restants sur la fenêtre courante. */
+        "X-RateLimit-Remaining": number;
+        /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
+        "X-RateLimit-Reset": number;
+        /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
+        "Retry-After": number;
+    };
     pathItems: never;
 }
 export type $defs = Record<string, never>;
@@ -916,12 +925,9 @@ export interface operations {
         responses: {
             201: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -930,12 +936,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -944,12 +947,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -958,12 +958,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -972,12 +969,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -987,14 +981,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1006,12 +996,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1033,12 +1020,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1047,12 +1031,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1062,14 +1043,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1081,12 +1058,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1114,12 +1088,9 @@ export interface operations {
         responses: {
             201: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1128,12 +1099,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1142,12 +1110,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1156,12 +1121,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1171,14 +1133,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1190,12 +1148,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1219,24 +1174,18 @@ export interface operations {
             /** @description No response body */
             204: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content?: never;
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1245,12 +1194,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1260,14 +1206,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1279,12 +1221,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1313,12 +1252,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1327,12 +1263,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1341,12 +1274,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1356,14 +1286,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1375,12 +1301,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1400,12 +1323,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1414,12 +1334,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1428,12 +1345,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1442,12 +1356,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1457,14 +1368,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1476,12 +1383,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1507,12 +1411,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1521,12 +1422,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1535,12 +1433,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1549,12 +1444,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1563,12 +1455,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1578,14 +1467,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1597,12 +1482,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1624,12 +1506,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1638,12 +1517,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1652,12 +1528,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1666,12 +1539,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1681,14 +1551,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1700,12 +1566,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1733,12 +1596,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1747,12 +1607,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1761,12 +1618,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1775,12 +1629,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1789,12 +1640,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1804,14 +1652,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1823,12 +1667,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1850,12 +1691,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1864,12 +1702,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1878,12 +1713,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1892,12 +1724,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1907,14 +1736,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1926,12 +1751,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1959,12 +1781,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1973,12 +1792,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1987,12 +1803,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2001,12 +1814,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2015,12 +1825,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2030,14 +1837,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2049,12 +1852,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2082,12 +1882,9 @@ export interface operations {
         responses: {
             201: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2096,12 +1893,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2110,12 +1904,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2124,12 +1915,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2138,12 +1926,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2152,12 +1937,9 @@ export interface operations {
             };
             409: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2167,14 +1949,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2186,12 +1964,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2215,12 +1990,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2229,12 +2001,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2243,12 +2012,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2257,12 +2023,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2271,12 +2034,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2286,14 +2046,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2305,12 +2061,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2332,12 +2085,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2346,12 +2096,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2360,12 +2107,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2374,12 +2118,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2389,14 +2130,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2408,12 +2145,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2441,12 +2175,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2455,12 +2186,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2469,12 +2197,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2483,12 +2208,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2497,12 +2219,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2512,14 +2231,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2531,12 +2246,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2558,12 +2270,9 @@ export interface operations {
         responses: {
             201: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2572,12 +2281,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2586,12 +2292,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2600,12 +2303,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2615,14 +2315,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2634,12 +2330,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2666,12 +2359,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2680,12 +2370,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2694,12 +2381,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2708,12 +2392,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2722,12 +2403,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2737,14 +2415,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2756,12 +2430,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2788,12 +2459,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2802,12 +2470,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2816,12 +2481,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2830,12 +2492,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2844,12 +2503,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2859,14 +2515,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2878,12 +2530,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2906,12 +2555,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2920,12 +2566,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2934,12 +2577,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2948,12 +2588,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2963,14 +2600,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2982,12 +2615,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3016,12 +2646,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3030,12 +2657,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3044,12 +2668,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3058,12 +2679,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3073,14 +2691,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3092,12 +2706,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3120,12 +2731,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3134,12 +2742,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3148,12 +2753,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3162,12 +2764,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3177,14 +2776,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3196,12 +2791,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3230,12 +2822,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3244,12 +2833,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3258,12 +2844,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3272,12 +2855,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3286,12 +2866,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3301,14 +2878,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3320,12 +2893,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3348,12 +2918,9 @@ export interface operations {
         responses: {
             201: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3362,12 +2929,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3376,12 +2940,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3390,12 +2951,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3405,14 +2963,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3424,12 +2978,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3452,12 +3003,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3466,12 +3014,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3480,12 +3025,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3494,12 +3036,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3509,14 +3048,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3528,12 +3063,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3561,12 +3093,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3575,12 +3104,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3589,12 +3115,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3603,12 +3126,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3617,12 +3137,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3632,14 +3149,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3651,12 +3164,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3682,12 +3192,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3696,12 +3203,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3710,12 +3214,9 @@ export interface operations {
             };
             403: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3724,12 +3225,9 @@ export interface operations {
             };
             404: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3739,14 +3237,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3758,12 +3252,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3783,12 +3274,9 @@ export interface operations {
         responses: {
             200: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3797,12 +3285,9 @@ export interface operations {
             };
             400: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3811,12 +3296,9 @@ export interface operations {
             };
             401: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3826,14 +3308,10 @@ export interface operations {
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {
-                    /** @description Nombre de secondes à attendre avant de pouvoir réessayer. */
-                    "Retry-After"?: number;
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "Retry-After": components["headers"]["Retry-After"];
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -3845,12 +3323,9 @@ export interface operations {
             };
             500: {
                 headers: {
-                    /** @description Nombre maximal d'appels autorisés sur la fenêtre courante. */
-                    "X-RateLimit-Limit"?: number;
-                    /** @description Nombre d'appels restants sur la fenêtre courante. */
-                    "X-RateLimit-Remaining"?: number;
-                    /** @description Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise. */
-                    "X-RateLimit-Reset"?: number;
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
                     [name: string]: unknown;
                 };
                 content: {

--- a/src/web/presentation/api/openapi_hooks.py
+++ b/src/web/presentation/api/openapi_hooks.py
@@ -31,13 +31,6 @@ _RATE_LIMIT_HEADER_REFS = {name: _header_ref(name) for name in _RATE_LIMIT_HEADE
 
 
 def postprocess_add_rate_limit_headers(result, **kwargs):
-    """Document the `X-RateLimit-*` headers set by RateLimitHeadersMiddleware.
-
-    These headers are added dynamically by a middleware rather than by the
-    views themselves, so drf-spectacular cannot pick them up automatically.
-    They're registered once under `components.headers` and referenced from
-    every response to avoid inlining a copy of the spec everywhere.
-    """
     components_headers = result.setdefault("components", {}).setdefault("headers", {})
     for name, spec in _RATE_LIMIT_HEADERS.items():
         components_headers.setdefault(name, dict(spec))
@@ -76,12 +69,6 @@ _TOO_MANY_REQUESTS_RESPONSE = {
 
 
 def postprocess_add_too_many_requests_response(result, **kwargs):
-    """Document the `429` response returned once an endpoint's rate limit is hit.
-
-    Every endpoint goes through DRF's DEFAULT_THROTTLE_CLASSES (see
-    REST_FRAMEWORK settings), which can raise a 429 regardless of what the
-    view itself declares, so drf-spectacular cannot pick it up automatically.
-    """
     components_headers = result.setdefault("components", {}).setdefault("headers", {})
     components_headers.setdefault("Retry-After", dict(_RETRY_AFTER_HEADER))
 

--- a/src/web/presentation/api/openapi_hooks.py
+++ b/src/web/presentation/api/openapi_hooks.py
@@ -17,19 +17,37 @@ _RATE_LIMIT_HEADERS = {
     },
 }
 
+_RETRY_AFTER_HEADER = {
+    "schema": {"type": "integer"},
+    "description": "Nombre de secondes à attendre avant de pouvoir réessayer.",
+}
+
+
+def _header_ref(name):
+    return {"$ref": f"#/components/headers/{name}"}
+
+
+_RATE_LIMIT_HEADER_REFS = {name: _header_ref(name) for name in _RATE_LIMIT_HEADERS}
+
 
 def postprocess_add_rate_limit_headers(result, **kwargs):
     """Document the `X-RateLimit-*` headers set by RateLimitHeadersMiddleware.
 
     These headers are added dynamically by a middleware rather than by the
     views themselves, so drf-spectacular cannot pick them up automatically.
+    They're registered once under `components.headers` and referenced from
+    every response to avoid inlining a copy of the spec everywhere.
     """
+    components_headers = result.setdefault("components", {}).setdefault("headers", {})
+    for name, spec in _RATE_LIMIT_HEADERS.items():
+        components_headers.setdefault(name, dict(spec))
+
     for path in result.get("paths", {}).values():
         for operation in path.values():
             for response in operation.get("responses", {}).values():
                 headers = response.setdefault("headers", {})
-                for name, spec in _RATE_LIMIT_HEADERS.items():
-                    headers.setdefault(name, dict(spec))
+                for name, ref in _RATE_LIMIT_HEADER_REFS.items():
+                    headers.setdefault(name, dict(ref))
     return result
 
 
@@ -51,11 +69,8 @@ _TOO_MANY_REQUESTS_RESPONSE = {
         },
     },
     "headers": {
-        "Retry-After": {
-            "schema": {"type": "integer"},
-            "description": "Nombre de secondes à attendre avant de pouvoir réessayer.",
-        },
-        **{name: dict(spec) for name, spec in _RATE_LIMIT_HEADERS.items()},
+        "Retry-After": _header_ref("Retry-After"),
+        **_RATE_LIMIT_HEADER_REFS,
     },
 }
 
@@ -67,6 +82,9 @@ def postprocess_add_too_many_requests_response(result, **kwargs):
     REST_FRAMEWORK settings), which can raise a 429 regardless of what the
     view itself declares, so drf-spectacular cannot pick it up automatically.
     """
+    components_headers = result.setdefault("components", {}).setdefault("headers", {})
+    components_headers.setdefault("Retry-After", dict(_RETRY_AFTER_HEADER))
+
     for path in result.get("paths", {}).values():
         for operation in path.values():
             responses = operation.get("responses")

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -33,18 +33,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -53,18 +46,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -73,18 +59,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -93,18 +72,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '201':
           content:
             application/json:
@@ -113,18 +85,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -133,18 +98,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -157,22 +115,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/candidatures/{candidature_uuid}/notes:
     get:
       operationId: recruteur_candidatures_notes_list
@@ -200,18 +149,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -220,18 +162,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -240,18 +175,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -264,22 +192,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     post:
       operationId: recruteur_candidatures_notes_create
       summary: Ajouter une note à une candidature
@@ -316,18 +235,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -336,18 +248,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -356,18 +261,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -376,18 +274,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -396,18 +287,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -420,22 +304,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/candidatures/{candidature_uuid}/notes/{note_uuid}:
     patch:
       operationId: recruteur_candidatures_notes_partial_update
@@ -478,18 +353,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -498,18 +366,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -518,18 +379,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -538,18 +392,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -562,22 +409,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     delete:
       operationId: recruteur_candidatures_notes_destroy
       summary: Supprimer une note d'une candidature
@@ -604,18 +442,11 @@ paths:
           description: No response body
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -624,18 +455,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -644,18 +468,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -664,18 +481,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -688,22 +498,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes:
     get:
       operationId: recruteur_organismes_list
@@ -722,18 +523,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -742,18 +536,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -762,18 +549,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -782,18 +562,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -804,18 +577,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -828,22 +594,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     post:
       operationId: recruteur_organismes_create
       summary: Créer un organisme
@@ -873,18 +630,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -893,18 +643,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -913,18 +656,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -933,18 +669,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -953,18 +682,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -973,18 +695,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -997,22 +712,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}:
     get:
       operationId: recruteur_organismes_retrieve
@@ -1038,18 +744,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -1058,18 +757,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -1078,18 +770,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1098,18 +783,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -1118,18 +796,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1142,22 +813,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     put:
       operationId: recruteur_organismes_update
       summary: Modifier un organisme
@@ -1194,18 +856,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -1214,18 +869,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -1234,18 +882,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1254,18 +895,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -1274,18 +908,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -1294,18 +921,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1318,22 +938,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/parametres/agents:
     get:
       operationId: recruteur_organismes_parametres_agents_list
@@ -1359,18 +970,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -1379,18 +983,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -1399,18 +996,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1419,18 +1009,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -1441,18 +1024,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1465,22 +1041,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     post:
       operationId: recruteur_organismes_parametres_agents_create
       summary: Rattacher un agent à un organisme
@@ -1517,18 +1084,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -1537,18 +1097,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -1557,18 +1110,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1577,18 +1123,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '201':
           content:
             application/json:
@@ -1597,18 +1136,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -1617,18 +1149,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '409':
           content:
             application/json:
@@ -1637,18 +1162,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1661,22 +1179,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     put:
       operationId: recruteur_organismes_parametres_agents_update
       summary: Modifier ou revoquer un agent d'un organisme
@@ -1713,18 +1222,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -1733,18 +1235,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -1753,18 +1248,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1773,18 +1261,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -1793,18 +1274,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -1813,18 +1287,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1837,22 +1304,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/parametres/agents/recherche:
     get:
       operationId: recruteur_organismes_parametres_agents_recherche_retrieve
@@ -1885,18 +1343,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -1905,18 +1356,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -1925,18 +1369,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1945,18 +1382,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -1965,18 +1395,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -1985,18 +1408,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -2009,22 +1425,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/parametres/etapes:
     get:
       operationId: recruteur_organismes_parametres_etapes_list
@@ -2050,18 +1457,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -2070,18 +1470,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -2090,18 +1483,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -2110,18 +1496,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -2132,18 +1511,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -2156,22 +1528,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     put:
       operationId: recruteur_organismes_parametres_etapes_update
       summary: Modifier les étapes de recrutement d'un organisme
@@ -2214,18 +1577,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -2234,18 +1590,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -2254,18 +1603,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -2274,18 +1616,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -2296,18 +1631,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -2316,18 +1644,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -2340,22 +1661,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/parametres/etapes/init:
     post:
       operationId: recruteur_organismes_parametres_etapes_init_create
@@ -2381,18 +1693,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -2401,18 +1706,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -2421,18 +1719,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -2441,18 +1732,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '201':
           content:
             application/json:
@@ -2463,18 +1747,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -2487,22 +1764,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements-actifs:
     get:
       operationId: recruteur_organismes_recrutements_actifs_list
@@ -2545,18 +1813,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -2565,18 +1826,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -2585,18 +1839,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -2605,18 +1852,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -2625,18 +1865,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -2645,18 +1878,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -2669,22 +1895,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements-archives:
     get:
       operationId: recruteur_organismes_recrutements_archives_list
@@ -2727,18 +1944,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -2747,18 +1957,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -2767,18 +1970,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -2787,18 +1983,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -2807,18 +1996,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -2827,18 +2009,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -2851,22 +2026,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}:
     get:
       operationId: recruteur_organismes_recrutements_retrieve
@@ -2898,18 +2064,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -2918,18 +2077,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -2938,18 +2090,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -2958,18 +2103,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -2978,18 +2116,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3002,22 +2133,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/candidatures/etape:
     patch:
       operationId: recruteur_organismes_recrutements_candidatures_etape_partial_update
@@ -3060,18 +2182,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -3080,18 +2195,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3100,18 +2208,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -3120,18 +2221,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3140,18 +2234,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3164,22 +2251,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes:
     get:
       operationId: recruteur_organismes_recrutements_etapes_list
@@ -3213,18 +2291,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3233,18 +2304,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -3253,18 +2317,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -3273,18 +2330,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3293,18 +2343,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3317,22 +2360,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
     patch:
       operationId: recruteur_organismes_recrutements_etapes_partial_update
       summary: Modifier les étapes d'un recrutement
@@ -3383,18 +2417,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -3403,18 +2430,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3423,18 +2443,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -3443,18 +2456,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -3463,18 +2469,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3483,18 +2482,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3507,22 +2499,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/etapes/init:
     post:
       operationId: recruteur_organismes_recrutements_etapes_init_create
@@ -3556,18 +2539,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3576,18 +2552,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -3596,18 +2565,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -3616,18 +2578,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3636,18 +2591,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3660,22 +2608,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/kanban:
     get:
       operationId: recruteur_organismes_recrutements_kanban_retrieve
@@ -3707,18 +2646,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3727,18 +2659,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -3747,18 +2672,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -3767,18 +2685,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3787,18 +2698,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3811,22 +2715,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/liste:
     get:
       operationId: recruteur_organismes_recrutements_liste_list
@@ -3874,18 +2769,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -3894,18 +2782,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3914,18 +2795,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -3934,18 +2808,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -3954,18 +2821,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3974,18 +2834,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3998,22 +2851,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /recruteur/organismes/{organisme_uuid}/recrutements/{recrutement_uuid}/parametres/agents:
     get:
       operationId: recruteur_organismes_recrutements_parametres_agents_list
@@ -4051,18 +2895,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -4071,18 +2908,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -4091,18 +2921,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -4111,18 +2934,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '200':
           content:
             application/json:
@@ -4131,18 +2947,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -4155,22 +2964,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /utilisateur/me:
     get:
       operationId: utilisateur_me_retrieve
@@ -4189,18 +2989,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -4209,18 +3002,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -4229,18 +3015,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -4249,18 +3028,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -4273,22 +3045,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
 components:
   schemas:
     Agent:
@@ -5476,6 +4239,23 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  headers:
+    X-RateLimit-Limit:
+      schema:
+        type: integer
+      description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+    X-RateLimit-Remaining:
+      schema:
+        type: integer
+      description: Nombre d'appels restants sur la fenêtre courante.
+    X-RateLimit-Reset:
+      schema:
+        type: integer
+      description: Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise.
+    Retry-After:
+      schema:
+        type: integer
+      description: Nombre de secondes à attendre avant de pouvoir réessayer.
 tags:
 - name: utilisateurs
   description: Gestion des utilisateurs

--- a/src/web/presentation/static/api/schema.yaml
+++ b/src/web/presentation/static/api/schema.yaml
@@ -30,18 +30,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -50,18 +43,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -70,18 +56,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -90,18 +69,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -114,22 +86,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/fake-ts/offersummaries:
     get:
       operationId: fake_ts_offersummaries_list
@@ -1171,18 +1134,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -1191,18 +1147,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1211,18 +1160,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1235,22 +1177,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/fake-ts/referentials/{referential_type}:
     get:
       operationId: fake_ts_referentials_list
@@ -1290,18 +1223,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -1310,18 +1236,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1334,22 +1253,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/token:
     post:
       operationId: token_create
@@ -1379,18 +1289,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1403,22 +1306,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/token/refresh:
     post:
       operationId: token_refresh_create
@@ -1448,18 +1342,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1472,22 +1359,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/v1/concours/upload:
     post:
       operationId: v1_concours_upload_create
@@ -1590,18 +1468,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -1640,18 +1511,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -1672,18 +1536,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1698,18 +1555,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1722,22 +1572,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/v1/metiers:
     get:
       operationId: v1_metiers_list
@@ -1847,18 +1688,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -1873,18 +1707,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -1905,18 +1732,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -1931,18 +1751,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -1955,22 +1768,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/v1/offres:
     get:
       operationId: v1_offres_list
@@ -3108,18 +2912,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -3128,18 +2925,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3160,18 +2950,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3186,18 +2969,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3210,22 +2986,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/v1/offres/archiver:
     post:
       operationId: v1_offres_archiver_create
@@ -3277,18 +3044,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -3304,18 +3064,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3336,18 +3089,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -3356,18 +3102,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '404':
           content:
             application/json:
@@ -3382,18 +3121,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3406,22 +3138,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/v1/offres/creer_modifier:
     post:
       operationId: v1_offres_creer_modifier_create
@@ -3464,18 +3187,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -3484,18 +3200,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3504,18 +3213,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '403':
           content:
             application/json:
@@ -3524,18 +3226,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3544,18 +3239,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3568,22 +3256,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/v1/offres/sources/{source_id}:
     get:
       operationId: v1_offres_sources_list
@@ -3646,18 +3325,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3666,18 +3338,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3686,18 +3351,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3710,22 +3368,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
   /api/v1/organismes/creer_modifier:
     post:
       operationId: v1_organismes_creer_modifier_create
@@ -3751,18 +3400,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '400':
           content:
             application/json:
@@ -3771,18 +3413,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '401':
           content:
             application/json:
@@ -3791,18 +3426,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '500':
           content:
             application/json:
@@ -3811,18 +3439,11 @@ paths:
           description: ''
           headers:
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:
@@ -3835,22 +3456,13 @@ paths:
                     example: Request was throttled. Expected available in 42 seconds.
           headers:
             Retry-After:
-              schema:
-                type: integer
-              description: Nombre de secondes à attendre avant de pouvoir réessayer.
+              $ref: '#/components/headers/Retry-After'
             X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Limit'
             X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: Nombre d'appels restants sur la fenêtre courante.
+              $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
-              schema:
-                type: integer
-              description: Timestamp Unix (secondes) auquel la fenêtre courante se
-                réinitialise.
+              $ref: '#/components/headers/X-RateLimit-Reset'
 components:
   schemas:
     ArchiveOffer401Error:
@@ -5702,6 +5314,23 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  headers:
+    X-RateLimit-Limit:
+      schema:
+        type: integer
+      description: Nombre maximal d'appels autorisés sur la fenêtre courante.
+    X-RateLimit-Remaining:
+      schema:
+        type: integer
+      description: Nombre d'appels restants sur la fenêtre courante.
+    X-RateLimit-Reset:
+      schema:
+        type: integer
+      description: Timestamp Unix (secondes) auquel la fenêtre courante se réinitialise.
+    Retry-After:
+      schema:
+        type: integer
+      description: Nombre de secondes à attendre avant de pouvoir réessayer.
 tags:
 - name: token
   description: Gestion de l'authentification


### PR DESCRIPTION
## 📝 Description

Les headers de rate limiting étaient inlinés dans chaque réponse par `postprocess_add_rate_limit_headers`, créant de nombreux doublons dans `schema.yaml` et `internal-schema.yaml`. Ils sont désormais déclarés une seule fois sous `components.headers` et référencés via `$ref`.

## 🏷️ Type de changement
- [x] ♻️ Refactorisation
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
