### PR TITLE
✨(recruteur) drop agent identity fields

### DIFF
--- a/src/web/application/identite/usecases/create_agent.py
+++ b/src/web/application/identite/usecases/create_agent.py
@@ -17,12 +17,12 @@ from domain.identite.services.organisme_permission_service import (
 from domain.identite.value_objects.organisme_action import OrganismeAction
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CreateAgentInput:
     email: EmailStr
-    prenom: str
-    nom: str
-    intitule_poste: str
+    prenom: str = ""
+    nom: str = ""
+    intitule_poste: str = ""
     organisme_id: UUID
     utilisateur: Utilisateur
 

--- a/src/web/application/identite/usecases/create_agent.py
+++ b/src/web/application/identite/usecases/create_agent.py
@@ -17,12 +17,9 @@ from domain.identite.services.organisme_permission_service import (
 from domain.identite.value_objects.organisme_action import OrganismeAction
 
 
-@dataclass(kw_only=True)
+@dataclass
 class CreateAgentInput:
     email: EmailStr
-    prenom: str = ""
-    nom: str = ""
-    intitule_poste: str = ""
     organisme_id: UUID
     utilisateur: Utilisateur
 
@@ -58,18 +55,11 @@ class CreateAgentUsecase:
             )
         except UtilisateurNexistePas:
             agent_utilisateur = self.utilisateur_repository.create(
-                Utilisateur(
-                    email=input_data.email,
-                    prenom=input_data.prenom,
-                    nom=input_data.nom,
-                )
+                Utilisateur(email=input_data.email)
             )
 
         agent = Agent.create(
             email=input_data.email,
-            prenom=input_data.prenom,
-            nom=input_data.nom,
-            intitule_poste=input_data.intitule_poste,
             user_id=agent_utilisateur.entity_id,
         )
 

--- a/src/web/domain/identite/entities/agent.py
+++ b/src/web/domain/identite/entities/agent.py
@@ -19,10 +19,10 @@ class Agent(AggregateRoot):
     def create(
         cls,
         email: EmailStr,
-        prenom: str,
-        nom: str,
-        intitule_poste: str,
         user_id: UUID,
+        prenom: str = "",
+        nom: str = "",
+        intitule_poste: str = "",
     ) -> "Agent":
         return cls(
             entity_id=user_id,

--- a/src/web/domain/identite/entities/utilisateurs.py
+++ b/src/web/domain/identite/entities/utilisateurs.py
@@ -9,8 +9,8 @@ from domain.identite.value_objects.organisme_role import OrganismeRole
 @dataclass(kw_only=True)
 class Utilisateur(Entity):
     email: EmailStr
-    prenom: str
-    nom: str
+    prenom: str = ""
+    nom: str = ""
     is_superuser: bool = False
     is_staff: bool = False
     organisme_roles: list[OrganismeRole] = field(default_factory=list)

--- a/src/web/domain/identite/events/agent_events.py
+++ b/src/web/domain/identite/events/agent_events.py
@@ -8,7 +8,7 @@ from pydantic import EmailStr
 @dataclass(frozen=True)
 class ProfilAgentCree(DomainEvent):
     email: EmailStr
-    prenom: str
-    nom: str
-    intitule_poste: str
     user_id: UUID
+    prenom: str = ""
+    nom: str = ""
+    intitule_poste: str = ""

--- a/src/web/frontend/src/types/api.d.ts
+++ b/src/web/frontend/src/types/api.d.ts
@@ -446,9 +446,6 @@ export interface components {
         CreateAgent: {
             /** Format: email */
             email: string;
-            prenom: string;
-            nom: string;
-            intitule_poste: string;
             /** Format: uuid */
             organisme_id: string;
         };
@@ -847,9 +844,6 @@ export interface components {
             /** Format: uuid */
             agent_id: string;
             role: components["schemas"]["RoleEnum"];
-            nom?: string;
-            prenom?: string;
-            poste?: string;
             /** Format: date-time */
             date_revocation?: string;
         };

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -148,9 +148,6 @@ class CandidatureListeSerializer(serializers.Serializer):
 
 class CreateAgentSerializer(serializers.Serializer):
     email = serializers.EmailField()
-    prenom = serializers.CharField()
-    nom = serializers.CharField()
-    intitule_poste = serializers.CharField()
     organisme_id = serializers.UUIDField()
 
 

--- a/src/web/presentation/recruteur/serializers.py
+++ b/src/web/presentation/recruteur/serializers.py
@@ -191,9 +191,6 @@ class UpdateAgentOrganismeSerializer(serializers.Serializer):
     role = serializers.ChoiceField(
         choices=[(r.value, r.value) for r in AgentOrganismeRole]
     )
-    nom = serializers.CharField(required=False)
-    prenom = serializers.CharField(required=False)
-    poste = serializers.CharField(required=False)
     date_revocation = serializers.DateTimeField(required=False)
 
 

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -3278,21 +3278,12 @@ components:
         email:
           type: string
           format: email
-        prenom:
-          type: string
-        nom:
-          type: string
-        intitule_poste:
-          type: string
         organisme_id:
           type: string
           format: uuid
       required:
       - email
-      - intitule_poste
-      - nom
       - organisme_id
-      - prenom
     CreateOrganisme:
       type: object
       properties:
@@ -4142,12 +4133,6 @@ components:
           format: uuid
         role:
           $ref: '#/components/schemas/RoleEnum'
-        nom:
-          type: string
-        prenom:
-          type: string
-        poste:
-          type: string
         date_revocation:
           type: string
           format: date-time

--- a/src/web/tests/application/identite/test_create_agent.py
+++ b/src/web/tests/application/identite/test_create_agent.py
@@ -57,9 +57,6 @@ def usecase_fixture(permission_service, agent_repository, utilisateur_repository
 def _input() -> CreateAgentInput:
     return CreateAgentInput(
         email=fake.email(),
-        prenom=fake.first_name(),
-        nom=fake.last_name(),
-        intitule_poste=fake.job(),
         organisme_id=uuid4(),
         utilisateur=UtilisateurFactory.create_entity(),
     )

--- a/src/web/tests/infrastructure/identite/test_create_agent.py
+++ b/src/web/tests/infrastructure/identite/test_create_agent.py
@@ -41,9 +41,6 @@ def organisme_id_fixture(db):
 def test_create_agent(identite_integration_container, organisme_id):
     input_data = CreateAgentInput(
         email=fake.email(),
-        prenom=fake.first_name(),
-        nom=fake.last_name(),
-        intitule_poste=fake.bothify("MAT-####"),
         organisme_id=organisme_id,
         utilisateur=STAFF_UTILISATEUR,
     )
@@ -51,20 +48,6 @@ def test_create_agent(identite_integration_container, organisme_id):
     result = identite_integration_container.create_agent_usecase().execute(input_data)
 
     assert result.email == input_data.email
-    assert result.prenom == input_data.prenom
-    assert result.nom == input_data.nom
-    assert result.intitule_poste == input_data.intitule_poste
-
-
-def test_create_agent_without_identity(identite_integration_container, organisme_id):
-    input_data = CreateAgentInput(
-        email=fake.email(),
-        organisme_id=organisme_id,
-        utilisateur=STAFF_UTILISATEUR,
-    )
-
-    identite_integration_container.create_agent_usecase().execute(input_data)
-
     utilisateur = UserModel.objects.get(email=input_data.email)
     assert utilisateur.first_name == ""
     assert utilisateur.last_name == ""
@@ -75,9 +58,6 @@ def test_create_agent_with_existing_user(identite_integration_container, organis
     existing_user = UtilisateurDjangoFactory(email=fake.email())
     input_data = CreateAgentInput(
         email=existing_user.email,
-        prenom=fake.first_name(),
-        nom=fake.last_name(),
-        intitule_poste=fake.bothify("MAT-####"),
         organisme_id=organisme_id,
         utilisateur=STAFF_UTILISATEUR,
     )
@@ -91,9 +71,6 @@ def test_cannot_create_agent_twice(identite_integration_container, organisme_id)
     existing_agent = AgentDjangoFactory()
     input_data = CreateAgentInput(
         email=existing_agent.utilisateur.email,
-        prenom=fake.first_name(),
-        nom=fake.last_name(),
-        intitule_poste=fake.bothify("MAT-####"),
         organisme_id=organisme_id,
         utilisateur=STAFF_UTILISATEUR,
     )

--- a/src/web/tests/infrastructure/identite/test_create_agent.py
+++ b/src/web/tests/infrastructure/identite/test_create_agent.py
@@ -5,6 +5,7 @@ from application.identite.usecases.create_agent import CreateAgentInput
 from config.app_config import AppConfig
 from domain.identite.errors.agent_errors import ProfilAgentExisteDeja
 from infrastructure.di.identite.identite_container import IdentiteContainer
+from infrastructure.django_apps.users.models import UserModel
 from infrastructure.factories.identite.agent_django_factory import (
     AgentDjangoFactory,
 )
@@ -53,6 +54,21 @@ def test_create_agent(identite_integration_container, organisme_id):
     assert result.prenom == input_data.prenom
     assert result.nom == input_data.nom
     assert result.intitule_poste == input_data.intitule_poste
+
+
+def test_create_agent_without_identity(identite_integration_container, organisme_id):
+    input_data = CreateAgentInput(
+        email=fake.email(),
+        organisme_id=organisme_id,
+        utilisateur=STAFF_UTILISATEUR,
+    )
+
+    identite_integration_container.create_agent_usecase().execute(input_data)
+
+    utilisateur = UserModel.objects.get(email=input_data.email)
+    assert utilisateur.first_name == ""
+    assert utilisateur.last_name == ""
+    assert utilisateur.profil_agent.intitule_poste == ""
 
 
 def test_create_agent_with_existing_user(identite_integration_container, organisme_id):

--- a/src/web/tests/presentation/recruteur/test_views_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_agents.py
@@ -41,9 +41,6 @@ class TestAgentsView:
         organisme_id = uuid4()
         body = {
             "email": agent.email,
-            "prenom": agent.prenom,
-            "nom": agent.nom,
-            "intitule_poste": agent.intitule_poste,
             "organisme_id": str(organisme_id),
         }
 
@@ -54,6 +51,9 @@ class TestAgentsView:
         assert called_input.email == agent.email
         assert called_input.organisme_id == organisme_id
         assert called_input.utilisateur is not None
+        assert called_input.prenom == ""
+        assert called_input.nom == ""
+        assert called_input.intitule_poste == ""
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == {
             "agent_id": str(agent.entity_id),
@@ -63,7 +63,7 @@ class TestAgentsView:
             "intitule_poste": agent.intitule_poste,
         }
 
-    def test_post_missing_field_returns_bad_request(
+    def test_post_missing_organisme_returns_bad_request(
         self, container, authenticated_client
     ):
         response = authenticated_client.post(AGENTS_URL, {"email": fake.email()})
@@ -114,9 +114,6 @@ class TestAgentsView:
         container.create_agent_usecase.return_value = mock_usecase
         body = {
             "email": fake.email(),
-            "prenom": fake.first_name(),
-            "nom": fake.last_name(),
-            "intitule_poste": fake.job(),
             "organisme_id": str(uuid4()),
         }
 

--- a/src/web/tests/presentation/recruteur/test_views_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_agents.py
@@ -51,9 +51,6 @@ class TestAgentsView:
         assert called_input.email == agent.email
         assert called_input.organisme_id == organisme_id
         assert called_input.utilisateur is not None
-        assert called_input.prenom == ""
-        assert called_input.nom == ""
-        assert called_input.intitule_poste == ""
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == {
             "agent_id": str(agent.entity_id),

--- a/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_organisme_agents.py
@@ -231,8 +231,6 @@ class TestOrganismeAgentsView:
             data={
                 "agent_id": str(autre_agent.utilisateur_id),
                 "role": AgentOrganismeRole.RESPONSABLE.value,
-                # ignored: role update only, not persisted by this usecase yet
-                "poste": "Directeur des recrutements",
             },
             format="json",
         )
@@ -241,7 +239,6 @@ class TestOrganismeAgentsView:
         data = response.json()
         assert data["agent_id"] == str(autre_agent.utilisateur_id)
         assert data["role"] == AgentOrganismeRole.RESPONSABLE.value
-        assert data["poste"] == "Recruteur"
         assert (
             OrganismeAgentModel.objects.get(
                 organisme_id=organisme.id, agent_id=autre_agent.utilisateur_id


### PR DESCRIPTION
## 📝 Description
L'identité d'un agent (prénom, nom, intitulé de poste) proviendra des claims ProConnect à la première connexion, elle n'est plus saisie ni modifiée par un administrateur. Retrait des champs du contrat d'écriture pour que l'API ne puisse structurellement plus les porter.

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
