### PR TITLE
🔧(tooling) génerer les types TypeScript OpenApi en même temps que les schemas DRF

### DIFF
--- a/src/web/mise.toml
+++ b/src/web/mise.toml
@@ -204,6 +204,7 @@ depends = ["install:py"]
 run = [
   "python manage.py spectacular --file presentation/static/api/schema.yaml --validate",
   "DJANGO_SETTINGS_MODULE=config.settings.schema_internal python manage.py spectacular --file presentation/static/api/internal-schema.yaml --validate",
+  "pnpm run generate-types",
 ]
 
 [tasks."lint:schema"]


### PR DESCRIPTION
## 📝 Description
🎸 Génère automatiquement les types TypeScript à partir du schéma interne lors de `web:schema`, pour que `frontend/src/types/api.d.ts` reste synchronisé avec l'API sans étape manuelle.

## 🏷️ Type de changement
- [x] 🔧 Changement technique


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
