### PR TITLE
♻️(recruteur) ADR-009, utiliser les factory Django dans le seed recruteur

### DIFF
--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -66,12 +66,18 @@ _SEED_SENTINEL_EMAIL = "marie.dupont.gouv.fr@yopmail.com"
 _ORGANISME_SIRET = "21050023700354"
 _ORGANISME_UUID = UUID("00000000-0000-0000-0000-000000000000")
 
-# Organismes supplémentaires : le second sert à éprouver la bascule d'organisme,
-# le troisième reste sans recrutement pour éprouver l'état vide.
 _BRIANCON_UUID = UUID("00000000-0000-0000-0000-000000000001")
 _CHU_UUID = UUID("00000000-0000-0000-0000-000000000002")
 
-_ORGANISMES_SECONDAIRES_SPECS = [
+# Organismes du seed : le second sert à éprouver la bascule d'organisme,
+# le troisième reste sans recrutement pour éprouver l'état vide.
+_ORGANISMES_SPECS = [
+    {
+        "entity_id": _ORGANISME_UUID,
+        "nom": "Ministère de la Transition Écologique",
+        "versant": Verse.FPE,
+        "siret": _ORGANISME_SIRET,
+    },
     {
         "entity_id": _BRIANCON_UUID,
         "nom": "Commune de Briançon",
@@ -86,12 +92,8 @@ _ORGANISMES_SECONDAIRES_SPECS = [
     },
 ]
 
-_ALL_SEED_ORGANISME_UUIDS = [_ORGANISME_UUID] + [
-    spec["entity_id"] for spec in _ORGANISMES_SECONDAIRES_SPECS
-]
-_ALL_SEED_ORGANISME_SIRETS = [_ORGANISME_SIRET] + [
-    spec["siret"] for spec in _ORGANISMES_SECONDAIRES_SPECS
-]
+_ALL_SEED_ORGANISME_UUIDS = [spec["entity_id"] for spec in _ORGANISMES_SPECS]
+_ALL_SEED_ORGANISME_SIRETS = [spec["siret"] for spec in _ORGANISMES_SPECS]
 
 _AGENTS_SPECS = [
     {"prenom": "Marie", "nom": "Dupont", "email": _SEED_SENTINEL_EMAIL},
@@ -290,18 +292,8 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         # -------------------------------------------------------------- #
         # Organisme recruteur                                            #
         # -------------------------------------------------------------- #
-        organisme = OrganismeDjangoFactory(
-            id=_ORGANISME_UUID,
-            nom="Ministère de la Transition Écologique",
-            versant=Verse.FPE.value,
-            siret=_ORGANISME_SIRET,
-            gestion_ats=False,
-            etapes=EtapeRecrutementFactory.create_entity_batch(),
-        )
-
-        organismes = {_ORGANISME_UUID: organisme}
-        for spec in _ORGANISMES_SECONDAIRES_SPECS:
-            organismes[spec["entity_id"]] = OrganismeDjangoFactory(
+        organismes = {
+            spec["entity_id"]: OrganismeDjangoFactory(
                 id=spec["entity_id"],
                 nom=spec["nom"],
                 versant=spec["versant"].value,
@@ -309,6 +301,9 @@ def seed_recruteur_datas(force: bool = False) -> dict:
                 gestion_ats=False,
                 etapes=EtapeRecrutementFactory.create_entity_batch(),
             )
+            for spec in _ORGANISMES_SPECS
+        }
+        organisme = organismes[_ORGANISME_UUID]
 
         # -------------------------------------------------------------- #
         # Métiers                                                        #

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -206,7 +206,7 @@ _OFFRES_ACTIVES_SPECS = [
     },
     {
         "title": "Chargé de mission",
-        "reference": "REF-2025-006",
+        "reference": "REF-2025-007",
         "external_id": "SEED-ACTIF-007",
         "verse": Verse.FPE.value,
         "category": Category.A.value,

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -168,11 +168,6 @@ def _delete_seed_data() -> None:
     ).values_list("id", flat=True)
     RecrutementModel.objects.filter(offre_id__in=seed_offre_ids).delete()  # type: ignore[attr-defined]
 
-    seed_usernames = list(
-        UserModel.objects.filter(email__in=_ALL_SEED_EMAILS).values_list(
-            "username", flat=True
-        )
-    )
     OrganismeAgentModel.objects.filter(
         organisme_id__in=_ALL_SEED_ORGANISME_UUIDS
     ).delete()

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -504,7 +504,7 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         "status": "seeded",
         "organisme_id": str(organisme.id),
         "nb_offres_actives": len(offres_actives),
-        "nb_offres_archivees": 3,
+        "nb_offres_archivees": len(offres_archivees),
         "nb_candidats": len(candidats),
         "nb_agents": len(agents),
         "nb_recrutements": len(recrutements),

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -1,13 +1,17 @@
 import os
 import secrets
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import UUID
 
+from django.utils import timezone
+from factory.django import Password
 from referentiel.value_objects.category import Category
-from referentiel.value_objects.siret import SIRET
 from referentiel.value_objects.verse import Verse
 
 from domain.candidate.value_objects.statut_candidature import StatutCandidature
+from domain.recruteur.value_objects.categorie_etapes_recrutement import (
+    CategorieEtapeRecrutement,
+)
 from domain.recruteur.value_objects.roles import (
     AgentOrganismeRole,
     AgentRecrutementRole,
@@ -18,7 +22,6 @@ from infrastructure.django_apps.recruteur.models.organisme import (
     OrganismeModel,
 )
 from infrastructure.django_apps.recruteur.models.recrutement import (
-    RecrutementAgentModel,
     RecrutementModel,
 )
 from infrastructure.django_apps.referentiel.models.metier import MetierModel
@@ -28,17 +31,33 @@ from infrastructure.django_apps.users.models import (
     ProfilCandidatModel,
     UserModel,
 )
-from infrastructure.factories.candidate.candidature_factory import CandidatureFactory
-from infrastructure.factories.identite.agent_factory import AgentFactory
-from infrastructure.factories.identite.candidat_factory import CandidatFactory
-from infrastructure.factories.identite.organisme_factory import OrganismeFactory
-from infrastructure.factories.identite.utilisateur_factory import UtilisateurFactory
+from infrastructure.factories.candidate.candidature_django_factory import (
+    CandidatureDjangoFactory,
+)
+from infrastructure.factories.identite.agent_django_factory import AgentDjangoFactory
+from infrastructure.factories.identite.candidat_django_factory import (
+    CandidatDjangoFactory,
+)
+from infrastructure.factories.identite.organisme_django_factory import (
+    OrganismeAgentDjangoFactory,
+    OrganismeDjangoFactory,
+)
+from infrastructure.factories.identite.utilisateur_django_factory import (
+    UtilisateurDjangoFactory,
+)
 from infrastructure.factories.recruteur.etapes_recrutement_factory import (
     EtapeRecrutementFactory,
 )
-from infrastructure.factories.recruteur.recrutement_factory import RecrutementFactory
-from infrastructure.factories.referentiel.metier_factory import MetierFactory
-from infrastructure.factories.referentiel.offer_factory import OfferFactory
+from infrastructure.factories.recruteur.recrutement_django_factory import (
+    RecrutementAgentDjangoFactory,
+    RecrutementDjangoFactory,
+)
+from infrastructure.factories.referentiel.metier_django_factory import (
+    MetierDjangoFactory,
+)
+from infrastructure.factories.referentiel.offer_django_factory import (
+    OfferDjangoFactory,
+)
 
 # Sentinelle pour l'idempotence : si cet email existe, le seed a déjà tourné.
 _SEED_SENTINEL_EMAIL = "marie.dupont.gouv.fr@yopmail.com"
@@ -177,53 +196,36 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # ------------------------------------------------------------------ #
     # Organisme recruteur                                                #
     # ------------------------------------------------------------------ #
-    organisme = OrganismeFactory.create_model(
-        entity_id=_ORGANISME_UUID,
+    organisme = OrganismeDjangoFactory(
+        id=_ORGANISME_UUID,
         nom="Ministère de la Transition Écologique",
-        versant=Verse.FPE,
-        siret=SIRET(code=_ORGANISME_SIRET),
-    )
-    default_etapes_entities = EtapeRecrutementFactory.create_entity_batch()
-
-    OrganismeModel.objects.filter(id=_ORGANISME_UUID).update(
-        etapes=[
-            {
-                "entity_id": str(e.entity_id),
-                "categorie": e.categorie.value,
-                "nom": e.nom,
-            }
-            for e in default_etapes_entities
-        ]
+        versant=Verse.FPE.value,
+        siret=_ORGANISME_SIRET,
+        gestion_ats=False,
+        etapes=EtapeRecrutementFactory.create_entity_batch(),
     )
 
+    organismes = {_ORGANISME_UUID: organisme}
     for spec in _ORGANISMES_SECONDAIRES_SPECS:
-        OrganismeFactory.create_model(
-            entity_id=spec["entity_id"],
+        organismes[spec["entity_id"]] = OrganismeDjangoFactory(
+            id=spec["entity_id"],
             nom=spec["nom"],
-            versant=spec["versant"],
-            siret=SIRET(code=spec["siret"]),
-        )
-        OrganismeModel.objects.filter(id=spec["entity_id"]).update(
-            etapes=[
-                {
-                    "entity_id": str(e.entity_id),
-                    "categorie": e.categorie.value,
-                    "nom": e.nom,
-                }
-                for e in EtapeRecrutementFactory.create_entity_batch()
-            ]
+            versant=spec["versant"].value,
+            siret=spec["siret"],
+            gestion_ats=False,
+            etapes=EtapeRecrutementFactory.create_entity_batch(),
         )
 
     # ------------------------------------------------------------------ #
     # Métiers                                                            #
     # ------------------------------------------------------------------ #
-    MetierFactory.create_model(
-        libelle="Chargé de mission numérique",
+    MetierDjangoFactory(
+        libelle_long="Chargé de mission numérique",
         domaine_fonctionnel_code="NUM",
         offer_family_code="ERNUM001",
     )
-    MetierFactory.create_model(
-        libelle="Juriste droit public",
+    MetierDjangoFactory(
+        libelle_long="Juriste droit public",
         domaine_fonctionnel_code="JUR",
         offer_family_code="ERJUR001",
     )
@@ -234,7 +236,12 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # Mot de passe généré à chaque seed (visible dans les logs de déploiement)
     seed_password = os.environ.get("SEED_USER_PASSWORD") or secrets.token_urlsafe(16)
     agents = [
-        AgentFactory.create_model(password=seed_password, username=None, **spec)
+        AgentDjangoFactory(
+            utilisateur__first_name=spec["prenom"],
+            utilisateur__last_name=spec["nom"],
+            utilisateur__email=spec["email"],
+            utilisateur__password=Password(seed_password),
+        )
         for spec in _AGENTS_SPECS
     ]
 
@@ -250,21 +257,20 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         (_BRIANCON_UUID, 4, AgentOrganismeRole.RESPONSABLE),
     ]
     for organisme_uuid, agent_index, role in _ATTACHEMENTS:
-        OrganismeAgentModel(
-            id=uuid4(),
-            organisme_id=organisme_uuid,
-            agent_id=agents[agent_index].utilisateur_id,  # type: ignore[attr-defined]
+        OrganismeAgentDjangoFactory(
+            organisme=organismes[organisme_uuid],
+            agent=agents[agent_index],
             role=role.value,
-        ).save()
+        )
 
     # ------------------------------------------------------------------ #
     # Administrateur (staff, hors organisme)                             #
     # ------------------------------------------------------------------ #
-    admin = UtilisateurFactory.create_model(
-        password=seed_password,
+    admin = UtilisateurDjangoFactory(
+        password=Password(seed_password),
         is_staff=True,
-        prenom=_ADMIN_SPEC["prenom"],
-        nom=_ADMIN_SPEC["nom"],
+        first_name=_ADMIN_SPEC["prenom"],
+        last_name=_ADMIN_SPEC["nom"],
         email=_ADMIN_SPEC["email"],
     )
 
@@ -272,60 +278,60 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # Offres actives (6)                                                 #
     # ------------------------------------------------------------------ #
     offres_actives = [
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Chargé de mission numérique",
             reference="REF-2025-001",
             external_id="SEED-ACTIF-001",
-            verse=Verse.FPE,
-            category=Category.A,
+            verse=Verse.FPE.value,
+            category=Category.A.value,
             publication_date=datetime(2025, 6, 22, tzinfo=UTC),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Responsable RH",
             reference="REF-2025-002",
             external_id="SEED-ACTIF-002",
-            verse=Verse.FPE,
-            category=Category.A,
+            verse=Verse.FPE.value,
+            category=Category.A.value,
             publication_date=datetime(2025, 6, 22, tzinfo=UTC),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Ingénieur infrastructure cloud",
             reference="REF-2025-003",
             external_id="SEED-ACTIF-003",
-            verse=Verse.FPE,
-            category=Category.A,
+            verse=Verse.FPE.value,
+            category=Category.A.value,
             publication_date=datetime(2025, 6, 21, tzinfo=UTC),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Juriste droit public",
             reference="REF-2025-004",
             external_id="SEED-ACTIF-004",
-            verse=Verse.FPT,
-            category=Category.A,
+            verse=Verse.FPT.value,
+            category=Category.A.value,
             publication_date=datetime(2025, 6, 21, tzinfo=UTC),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Chargé de communication",
             reference="REF-2025-005",
             external_id="SEED-ACTIF-005",
-            verse=Verse.FPE,
-            category=Category.B,
+            verse=Verse.FPE.value,
+            category=Category.B.value,
             publication_date=datetime(2025, 6, 2, tzinfo=UTC),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Analyste budgétaire",
             reference="REF-2025-006",
             external_id="SEED-ACTIF-006",
-            verse=Verse.FPE,
-            category=Category.A,
+            verse=Verse.FPE.value,
+            category=Category.A.value,
             publication_date=datetime(2025, 6, 1, tzinfo=UTC),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Chargé de mission",
             reference="REF-2025-006",
             external_id="SEED-ACTIF-007",
-            verse=Verse.FPE,
-            category=Category.A,
+            verse=Verse.FPE.value,
+            category=Category.A.value,
             publication_date=datetime(2025, 6, 1, tzinfo=UTC),
         ),
     ]
@@ -334,32 +340,32 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # Offres archivées (3)                                               #
     # ------------------------------------------------------------------ #
     offres_archivees = [
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Directeur des systèmes d'information",
             reference="REF-2024-A01",
             external_id="SEED-ARCHIVE-001",
-            verse=Verse.FPE,
-            category=Category.A,
+            verse=Verse.FPE.value,
+            category=Category.A.value,
             publication_date=datetime(2024, 12, 1, tzinfo=UTC),
-            archived_at=datetime(2025, 3, 1),
+            archived_at=timezone.make_aware(datetime(2025, 3, 1)),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Chef de projet transformation numérique",
             reference="REF-2024-A02",
             external_id="SEED-ARCHIVE-002",
-            verse=Verse.FPE,
-            category=Category.A,
+            verse=Verse.FPE.value,
+            category=Category.A.value,
             publication_date=datetime(2024, 11, 15, tzinfo=UTC),
-            archived_at=datetime(2025, 2, 15),
+            archived_at=timezone.make_aware(datetime(2025, 2, 15)),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Conseiller en mobilité professionnelle",
             reference="REF-2024-A03",
             external_id="SEED-ARCHIVE-003",
-            verse=Verse.FPT,
-            category=Category.B,
+            verse=Verse.FPT.value,
+            category=Category.B.value,
             publication_date=datetime(2024, 10, 1, tzinfo=UTC),
-            archived_at=datetime(2025, 1, 15),
+            archived_at=timezone.make_aware(datetime(2025, 1, 15)),
         ),
     ]
 
@@ -367,20 +373,20 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # Offres du second organisme                                         #
     # ------------------------------------------------------------------ #
     offres_briancon = [
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Agent technique polyvalent",
             reference="REF-2025-B01",
             external_id="SEED-B-ACTIF-001",
-            verse=Verse.FPT,
-            category=Category.C,
+            verse=Verse.FPT.value,
+            category=Category.C.value,
             publication_date=datetime(2025, 5, 12, tzinfo=UTC),
         ),
-        OfferFactory.create_model(
+        OfferDjangoFactory(
             title="Responsable des services techniques",
             reference="REF-2025-B02",
             external_id="SEED-B-ACTIF-002",
-            verse=Verse.FPT,
-            category=Category.B,
+            verse=Verse.FPT.value,
+            category=Category.B.value,
             publication_date=datetime(2025, 5, 20, tzinfo=UTC),
         ),
     ]
@@ -389,76 +395,78 @@ def seed_recruteur_datas(force: bool = False) -> dict:
     # Candidats (8)                                                      #
     # ------------------------------------------------------------------ #
     candidats = [
-        CandidatFactory.create_model(password=seed_password, username=None, **spec)
+        CandidatDjangoFactory(
+            utilisateur__first_name=spec["prenom"],
+            utilisateur__last_name=spec["nom"],
+            utilisateur__email=spec["email"],
+            utilisateur__password=Password(seed_password),
+        )
         for spec in _CANDIDATS_SPECS
     ]
 
     # ------------------------------------------------------------------ #
     # Recrutements (1 / offre active et archivée): étapes + responsables #
     # ------------------------------------------------------------------ #
-    marie_id = agents[0].utilisateur_id  # type: ignore[attr-defined]
-    paul_id = agents[1].utilisateur_id  # type: ignore[attr-defined]
-    claire_id = agents[2].utilisateur_id  # type: ignore[attr-defined]
-    marc_id = agents[4].utilisateur_id  # type: ignore[attr-defined]
+    marie = agents[0]
+    paul = agents[1]
+    claire = agents[2]
+    marc = agents[4]
 
-    recrutements_specs: list[
-        tuple[UUID, OfferModel, UUID, tuple[UUID, AgentRecrutementRole] | None]
-    ] = [
+    recrutements_specs = [
         (
             _ORGANISME_UUID,
             offres_actives[0],
-            marie_id,
-            (paul_id, AgentRecrutementRole.RECRUTEUR),
+            marie,
+            (paul, AgentRecrutementRole.RECRUTEUR),
         ),
         (
             _ORGANISME_UUID,
             offres_actives[1],
-            marie_id,
-            (paul_id, AgentRecrutementRole.RECRUTEUR),
+            marie,
+            (paul, AgentRecrutementRole.RECRUTEUR),
         ),
         (
             _ORGANISME_UUID,
             offres_actives[2],
-            marie_id,
-            (paul_id, AgentRecrutementRole.RECRUTEUR),
+            marie,
+            (paul, AgentRecrutementRole.RECRUTEUR),
         ),
         (
             _ORGANISME_UUID,
             offres_actives[3],
-            claire_id,
-            (paul_id, AgentRecrutementRole.CONTRIBUTEUR),
+            claire,
+            (paul, AgentRecrutementRole.CONTRIBUTEUR),
         ),
-        (_ORGANISME_UUID, offres_actives[4], claire_id, None),
-        (_ORGANISME_UUID, offres_actives[5], claire_id, None),
+        (_ORGANISME_UUID, offres_actives[4], claire, None),
+        (_ORGANISME_UUID, offres_actives[5], claire, None),
         (
             _ORGANISME_UUID,
             offres_actives[6],
-            marie_id,
-            (paul_id, AgentRecrutementRole.RECRUTEUR),
+            marie,
+            (paul, AgentRecrutementRole.RECRUTEUR),
         ),
-        (_ORGANISME_UUID, offres_archivees[0], claire_id, None),
-        (_ORGANISME_UUID, offres_archivees[1], claire_id, None),
-        (_ORGANISME_UUID, offres_archivees[2], claire_id, None),
-        (_BRIANCON_UUID, offres_briancon[0], marc_id, None),
-        (_BRIANCON_UUID, offres_briancon[1], marc_id, None),
+        (_ORGANISME_UUID, offres_archivees[0], claire, None),
+        (_ORGANISME_UUID, offres_archivees[1], claire, None),
+        (_ORGANISME_UUID, offres_archivees[2], claire, None),
+        (_BRIANCON_UUID, offres_briancon[0], marc, None),
+        (_BRIANCON_UUID, offres_briancon[1], marc, None),
     ]
 
     recrutements = []
-    for organisme_uuid, offre, responsable_id, extra_agent in recrutements_specs:
-        recrutement = RecrutementFactory.create_model(
-            offre_id=offre.id,
-            organisme_id=organisme_uuid,
-            agent_id=responsable_id,
-            agent_role=AgentRecrutementRole.RESPONSABLE,
+    for organisme_uuid, offre, responsable, extra_agent in recrutements_specs:
+        recrutement = RecrutementDjangoFactory(
+            offre=offre,
+            organisme=organismes[organisme_uuid],
+            agent_link__agent=responsable,
+            agent_link__role=AgentRecrutementRole.RESPONSABLE.value,
         )
         if extra_agent is not None:
-            extra_agent_id, extra_agent_role = extra_agent
-            RecrutementAgentModel(
-                id=uuid4(),
+            extra_agent_model, extra_agent_role = extra_agent
+            RecrutementAgentDjangoFactory(
                 recrutement=recrutement,
-                agent_id=extra_agent_id,
+                agent=extra_agent_model,
                 role=extra_agent_role.value,
-            ).save()
+            )
         recrutements.append(recrutement)
 
     # ------------------------------------------------------------------ #
@@ -477,11 +485,19 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         (candidats[7], offres_actives[5], StatutCandidature.INITIAL),
     ]
 
+    recrutements_by_offre_id = {
+        r.pk: r  # type: ignore[attr-defined]
+        for r in recrutements
+    }
     for candidat_model, offre_model, statut in candidatures_specs:
-        CandidatureFactory.create_model(
-            candidat_id=candidat_model.to_entity().entity_id,
-            offre_id=offre_model.id,
-            statut=statut,
+        recrutement = recrutements_by_offre_id[offre_model.id]
+        etape = recrutement.etapes.get(  # type: ignore[attr-defined]
+            categorie=CategorieEtapeRecrutement.ENTREE.value
+        )
+        CandidatureDjangoFactory(
+            candidat=candidat_model,
+            etape=etape,
+            statut=statut.value,
         )
 
     return {

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -234,31 +234,31 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         seed_password = os.environ.get("SEED_USER_PASSWORD") or secrets.token_urlsafe(
             16
         )
-        agents = [
-            AgentDjangoFactory(
+        agents = {
+            spec["prenom"]: AgentDjangoFactory(
                 utilisateur__first_name=spec["prenom"],
                 utilisateur__last_name=spec["nom"],
                 utilisateur__email=spec["email"],
                 utilisateur__password=Password(seed_password),
             )
             for spec in _AGENTS_SPECS
-        ]
+        }
 
         # Marie est responsable du premier organisme, Paul et Claire en sont membres.
         # Marc est membre du premier et responsable du second : c'est lui qui permet
         # d'éprouver la bascule d'organisme et l'apparition des pages de paramètres.
         # David ne l'est d'aucun, pour éprouver la navigation vide et le refus d'accès.
         _ATTACHEMENTS = [
-            (_ORGANISME_UUID, 0, AgentOrganismeRole.RESPONSABLE),
-            (_ORGANISME_UUID, 1, AgentOrganismeRole.MEMBRE),
-            (_ORGANISME_UUID, 2, AgentOrganismeRole.MEMBRE),
-            (_ORGANISME_UUID, 4, AgentOrganismeRole.MEMBRE),
-            (_BRIANCON_UUID, 4, AgentOrganismeRole.RESPONSABLE),
+            (_ORGANISME_UUID, "Marie", AgentOrganismeRole.RESPONSABLE),
+            (_ORGANISME_UUID, "Paul", AgentOrganismeRole.MEMBRE),
+            (_ORGANISME_UUID, "Claire", AgentOrganismeRole.MEMBRE),
+            (_ORGANISME_UUID, "Marc", AgentOrganismeRole.MEMBRE),
+            (_BRIANCON_UUID, "Marc", AgentOrganismeRole.RESPONSABLE),
         ]
-        for organisme_uuid, agent_index, role in _ATTACHEMENTS:
+        for organisme_uuid, agent_prenom, role in _ATTACHEMENTS:
             OrganismeAgentDjangoFactory(
                 organisme=organismes[organisme_uuid],
-                agent=agents[agent_index],
+                agent=agents[agent_prenom],
                 role=role.value,
             )
 
@@ -406,10 +406,10 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         # -------------------------------------------------------------- #
         # Recrutements (1 / offre active et archivée): étapes + responsables
         # -------------------------------------------------------------- #
-        marie = agents[0]
-        paul = agents[1]
-        claire = agents[2]
-        marc = agents[4]
+        marie = agents["Marie"]
+        paul = agents["Paul"]
+        claire = agents["Claire"]
+        marc = agents["Marc"]
 
         recrutements_specs = [
             (

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -155,6 +155,114 @@ _SEED_OFFER_EXTERNAL_IDS = [
 
 _SEED_METIER_OFFER_FAMILY_CODES = ["ERNUM001", "ERJUR001"]
 
+_OFFRES_ACTIVES_SPECS = [
+    {
+        "title": "Chargé de mission numérique",
+        "reference": "REF-2025-001",
+        "external_id": "SEED-ACTIF-001",
+        "verse": Verse.FPE.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2025, 6, 22, tzinfo=UTC),
+    },
+    {
+        "title": "Responsable RH",
+        "reference": "REF-2025-002",
+        "external_id": "SEED-ACTIF-002",
+        "verse": Verse.FPE.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2025, 6, 22, tzinfo=UTC),
+    },
+    {
+        "title": "Ingénieur infrastructure cloud",
+        "reference": "REF-2025-003",
+        "external_id": "SEED-ACTIF-003",
+        "verse": Verse.FPE.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2025, 6, 21, tzinfo=UTC),
+    },
+    {
+        "title": "Juriste droit public",
+        "reference": "REF-2025-004",
+        "external_id": "SEED-ACTIF-004",
+        "verse": Verse.FPT.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2025, 6, 21, tzinfo=UTC),
+    },
+    {
+        "title": "Chargé de communication",
+        "reference": "REF-2025-005",
+        "external_id": "SEED-ACTIF-005",
+        "verse": Verse.FPE.value,
+        "category": Category.B.value,
+        "publication_date": datetime(2025, 6, 2, tzinfo=UTC),
+    },
+    {
+        "title": "Analyste budgétaire",
+        "reference": "REF-2025-006",
+        "external_id": "SEED-ACTIF-006",
+        "verse": Verse.FPE.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2025, 6, 1, tzinfo=UTC),
+    },
+    {
+        "title": "Chargé de mission",
+        "reference": "REF-2025-006",
+        "external_id": "SEED-ACTIF-007",
+        "verse": Verse.FPE.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2025, 6, 1, tzinfo=UTC),
+    },
+]
+
+_OFFRES_ARCHIVEES_SPECS = [
+    {
+        "title": "Directeur des systèmes d'information",
+        "reference": "REF-2024-A01",
+        "external_id": "SEED-ARCHIVE-001",
+        "verse": Verse.FPE.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2024, 12, 1, tzinfo=UTC),
+        "archived_at": timezone.make_aware(datetime(2025, 3, 1)),
+    },
+    {
+        "title": "Chef de projet transformation numérique",
+        "reference": "REF-2024-A02",
+        "external_id": "SEED-ARCHIVE-002",
+        "verse": Verse.FPE.value,
+        "category": Category.A.value,
+        "publication_date": datetime(2024, 11, 15, tzinfo=UTC),
+        "archived_at": timezone.make_aware(datetime(2025, 2, 15)),
+    },
+    {
+        "title": "Conseiller en mobilité professionnelle",
+        "reference": "REF-2024-A03",
+        "external_id": "SEED-ARCHIVE-003",
+        "verse": Verse.FPT.value,
+        "category": Category.B.value,
+        "publication_date": datetime(2024, 10, 1, tzinfo=UTC),
+        "archived_at": timezone.make_aware(datetime(2025, 1, 15)),
+    },
+]
+
+_OFFRES_BRIANCON_SPECS = [
+    {
+        "title": "Agent technique polyvalent",
+        "reference": "REF-2025-B01",
+        "external_id": "SEED-B-ACTIF-001",
+        "verse": Verse.FPT.value,
+        "category": Category.C.value,
+        "publication_date": datetime(2025, 5, 12, tzinfo=UTC),
+    },
+    {
+        "title": "Responsable des services techniques",
+        "reference": "REF-2025-B02",
+        "external_id": "SEED-B-ACTIF-002",
+        "verse": Verse.FPT.value,
+        "category": Category.B.value,
+        "publication_date": datetime(2025, 5, 20, tzinfo=UTC),
+    },
+]
+
 
 def _delete_seed_data() -> None:
     seed_usernames = list(
@@ -276,118 +384,20 @@ def seed_recruteur_datas(force: bool = False) -> dict:
         # -------------------------------------------------------------- #
         # Offres actives (6)                                             #
         # -------------------------------------------------------------- #
-        offres_actives = [
-            OfferDjangoFactory(
-                title="Chargé de mission numérique",
-                reference="REF-2025-001",
-                external_id="SEED-ACTIF-001",
-                verse=Verse.FPE.value,
-                category=Category.A.value,
-                publication_date=datetime(2025, 6, 22, tzinfo=UTC),
-            ),
-            OfferDjangoFactory(
-                title="Responsable RH",
-                reference="REF-2025-002",
-                external_id="SEED-ACTIF-002",
-                verse=Verse.FPE.value,
-                category=Category.A.value,
-                publication_date=datetime(2025, 6, 22, tzinfo=UTC),
-            ),
-            OfferDjangoFactory(
-                title="Ingénieur infrastructure cloud",
-                reference="REF-2025-003",
-                external_id="SEED-ACTIF-003",
-                verse=Verse.FPE.value,
-                category=Category.A.value,
-                publication_date=datetime(2025, 6, 21, tzinfo=UTC),
-            ),
-            OfferDjangoFactory(
-                title="Juriste droit public",
-                reference="REF-2025-004",
-                external_id="SEED-ACTIF-004",
-                verse=Verse.FPT.value,
-                category=Category.A.value,
-                publication_date=datetime(2025, 6, 21, tzinfo=UTC),
-            ),
-            OfferDjangoFactory(
-                title="Chargé de communication",
-                reference="REF-2025-005",
-                external_id="SEED-ACTIF-005",
-                verse=Verse.FPE.value,
-                category=Category.B.value,
-                publication_date=datetime(2025, 6, 2, tzinfo=UTC),
-            ),
-            OfferDjangoFactory(
-                title="Analyste budgétaire",
-                reference="REF-2025-006",
-                external_id="SEED-ACTIF-006",
-                verse=Verse.FPE.value,
-                category=Category.A.value,
-                publication_date=datetime(2025, 6, 1, tzinfo=UTC),
-            ),
-            OfferDjangoFactory(
-                title="Chargé de mission",
-                reference="REF-2025-006",
-                external_id="SEED-ACTIF-007",
-                verse=Verse.FPE.value,
-                category=Category.A.value,
-                publication_date=datetime(2025, 6, 1, tzinfo=UTC),
-            ),
-        ]
+        offres_actives = [OfferDjangoFactory(**spec) for spec in _OFFRES_ACTIVES_SPECS]
 
         # -------------------------------------------------------------- #
         # Offres archivées (3)                                           #
         # -------------------------------------------------------------- #
         offres_archivees = [
-            OfferDjangoFactory(
-                title="Directeur des systèmes d'information",
-                reference="REF-2024-A01",
-                external_id="SEED-ARCHIVE-001",
-                verse=Verse.FPE.value,
-                category=Category.A.value,
-                publication_date=datetime(2024, 12, 1, tzinfo=UTC),
-                archived_at=timezone.make_aware(datetime(2025, 3, 1)),
-            ),
-            OfferDjangoFactory(
-                title="Chef de projet transformation numérique",
-                reference="REF-2024-A02",
-                external_id="SEED-ARCHIVE-002",
-                verse=Verse.FPE.value,
-                category=Category.A.value,
-                publication_date=datetime(2024, 11, 15, tzinfo=UTC),
-                archived_at=timezone.make_aware(datetime(2025, 2, 15)),
-            ),
-            OfferDjangoFactory(
-                title="Conseiller en mobilité professionnelle",
-                reference="REF-2024-A03",
-                external_id="SEED-ARCHIVE-003",
-                verse=Verse.FPT.value,
-                category=Category.B.value,
-                publication_date=datetime(2024, 10, 1, tzinfo=UTC),
-                archived_at=timezone.make_aware(datetime(2025, 1, 15)),
-            ),
+            OfferDjangoFactory(**spec) for spec in _OFFRES_ARCHIVEES_SPECS
         ]
 
         # -------------------------------------------------------------- #
         # Offres du second organisme                                     #
         # -------------------------------------------------------------- #
         offres_briancon = [
-            OfferDjangoFactory(
-                title="Agent technique polyvalent",
-                reference="REF-2025-B01",
-                external_id="SEED-B-ACTIF-001",
-                verse=Verse.FPT.value,
-                category=Category.C.value,
-                publication_date=datetime(2025, 5, 12, tzinfo=UTC),
-            ),
-            OfferDjangoFactory(
-                title="Responsable des services techniques",
-                reference="REF-2025-B02",
-                external_id="SEED-B-ACTIF-002",
-                verse=Verse.FPT.value,
-                category=Category.B.value,
-                publication_date=datetime(2025, 5, 20, tzinfo=UTC),
-            ),
+            OfferDjangoFactory(**spec) for spec in _OFFRES_BRIANCON_SPECS
         ]
 
         # -------------------------------------------------------------- #

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -138,21 +138,6 @@ _ALL_SEED_EMAILS = [
     s["email"] for s in _AGENTS_SPECS + _CANDIDATS_SPECS + [_ADMIN_SPEC]
 ]
 
-_SEED_OFFER_EXTERNAL_IDS = [
-    "SEED-ACTIF-001",
-    "SEED-ACTIF-002",
-    "SEED-ACTIF-003",
-    "SEED-ACTIF-004",
-    "SEED-ACTIF-005",
-    "SEED-ACTIF-006",
-    "SEED-ACTIF-007",
-    "SEED-B-ACTIF-001",
-    "SEED-B-ACTIF-002",
-    "SEED-ARCHIVE-001",
-    "SEED-ARCHIVE-002",
-    "SEED-ARCHIVE-003",
-]
-
 _SEED_METIER_OFFER_FAMILY_CODES = ["ERNUM001", "ERJUR001"]
 
 _OFFRES_ACTIVES_SPECS = [
@@ -272,8 +257,12 @@ def _delete_seed_data() -> None:
     )
     CandidatureModel.objects.filter(candidat_id__in=seed_usernames).delete()
 
+    seed_offer_specs = (
+        _OFFRES_ACTIVES_SPECS + _OFFRES_ARCHIVEES_SPECS + _OFFRES_BRIANCON_SPECS
+    )
+    seed_offer_external_ids = [spec["external_id"] for spec in seed_offer_specs]
     seed_offre_ids = OfferModel.objects.filter(
-        external_id__in=_SEED_OFFER_EXTERNAL_IDS
+        external_id__in=seed_offer_external_ids
     ).values_list("id", flat=True)
     RecrutementModel.objects.filter(offre_id__in=seed_offre_ids).delete()  # type: ignore[attr-defined]
 
@@ -284,7 +273,7 @@ def _delete_seed_data() -> None:
     ProfilCandidatModel.objects.filter(utilisateur_id__in=seed_usernames).delete()
     UserModel.objects.filter(email__in=_ALL_SEED_EMAILS).delete()
 
-    OfferModel.objects.filter(external_id__in=_SEED_OFFER_EXTERNAL_IDS).delete()
+    OfferModel.objects.filter(external_id__in=seed_offer_external_ids).delete()
     MetierModel.objects.filter(
         offer_family_code__in=_SEED_METIER_OFFER_FAMILY_CODES
     ).delete()

--- a/src/web/infrastructure/factories/seed_recruteur_datas.py
+++ b/src/web/infrastructure/factories/seed_recruteur_datas.py
@@ -3,6 +3,7 @@ import secrets
 from datetime import UTC, datetime
 from uuid import UUID
 
+from django.db import transaction
 from django.utils import timezone
 from factory.django import Password
 from referentiel.value_objects.category import Category
@@ -188,321 +189,324 @@ def seed_recruteur_datas(force: bool = False) -> dict:
             return {"status": "already_seeded"}
         _delete_seed_data()
 
-    # ------------------------------------------------------------------ #
-    # Organisme recruteur                                                #
-    # ------------------------------------------------------------------ #
-    organisme = OrganismeDjangoFactory(
-        id=_ORGANISME_UUID,
-        nom="Ministère de la Transition Écologique",
-        versant=Verse.FPE.value,
-        siret=_ORGANISME_SIRET,
-        gestion_ats=False,
-        etapes=EtapeRecrutementFactory.create_entity_batch(),
-    )
-
-    organismes = {_ORGANISME_UUID: organisme}
-    for spec in _ORGANISMES_SECONDAIRES_SPECS:
-        organismes[spec["entity_id"]] = OrganismeDjangoFactory(
-            id=spec["entity_id"],
-            nom=spec["nom"],
-            versant=spec["versant"].value,
-            siret=spec["siret"],
+    with transaction.atomic():
+        # -------------------------------------------------------------- #
+        # Organisme recruteur                                            #
+        # -------------------------------------------------------------- #
+        organisme = OrganismeDjangoFactory(
+            id=_ORGANISME_UUID,
+            nom="Ministère de la Transition Écologique",
+            versant=Verse.FPE.value,
+            siret=_ORGANISME_SIRET,
             gestion_ats=False,
             etapes=EtapeRecrutementFactory.create_entity_batch(),
         )
 
-    # ------------------------------------------------------------------ #
-    # Métiers                                                            #
-    # ------------------------------------------------------------------ #
-    MetierDjangoFactory(
-        libelle_long="Chargé de mission numérique",
-        domaine_fonctionnel_code="NUM",
-        offer_family_code="ERNUM001",
-    )
-    MetierDjangoFactory(
-        libelle_long="Juriste droit public",
-        domaine_fonctionnel_code="JUR",
-        offer_family_code="ERJUR001",
-    )
-
-    # ------------------------------------------------------------------ #
-    # Agents / recruteurs                                                #
-    # ------------------------------------------------------------------ #
-    # Mot de passe généré à chaque seed (visible dans les logs de déploiement)
-    seed_password = os.environ.get("SEED_USER_PASSWORD") or secrets.token_urlsafe(16)
-    agents = [
-        AgentDjangoFactory(
-            utilisateur__first_name=spec["prenom"],
-            utilisateur__last_name=spec["nom"],
-            utilisateur__email=spec["email"],
-            utilisateur__password=Password(seed_password),
-        )
-        for spec in _AGENTS_SPECS
-    ]
-
-    # Marie est responsable du premier organisme, Paul et Claire en sont membres.
-    # Marc est membre du premier et responsable du second : c'est lui qui permet
-    # d'éprouver la bascule d'organisme et l'apparition des pages de paramètres.
-    # David ne l'est d'aucun, pour éprouver la navigation vide et le refus d'accès.
-    _ATTACHEMENTS = [
-        (_ORGANISME_UUID, 0, AgentOrganismeRole.RESPONSABLE),
-        (_ORGANISME_UUID, 1, AgentOrganismeRole.MEMBRE),
-        (_ORGANISME_UUID, 2, AgentOrganismeRole.MEMBRE),
-        (_ORGANISME_UUID, 4, AgentOrganismeRole.MEMBRE),
-        (_BRIANCON_UUID, 4, AgentOrganismeRole.RESPONSABLE),
-    ]
-    for organisme_uuid, agent_index, role in _ATTACHEMENTS:
-        OrganismeAgentDjangoFactory(
-            organisme=organismes[organisme_uuid],
-            agent=agents[agent_index],
-            role=role.value,
-        )
-
-    # ------------------------------------------------------------------ #
-    # Administrateur (staff, hors organisme)                             #
-    # ------------------------------------------------------------------ #
-    admin = UtilisateurDjangoFactory(
-        password=Password(seed_password),
-        is_staff=True,
-        first_name=_ADMIN_SPEC["prenom"],
-        last_name=_ADMIN_SPEC["nom"],
-        email=_ADMIN_SPEC["email"],
-    )
-
-    # ------------------------------------------------------------------ #
-    # Offres actives (6)                                                 #
-    # ------------------------------------------------------------------ #
-    offres_actives = [
-        OfferDjangoFactory(
-            title="Chargé de mission numérique",
-            reference="REF-2025-001",
-            external_id="SEED-ACTIF-001",
-            verse=Verse.FPE.value,
-            category=Category.A.value,
-            publication_date=datetime(2025, 6, 22, tzinfo=UTC),
-        ),
-        OfferDjangoFactory(
-            title="Responsable RH",
-            reference="REF-2025-002",
-            external_id="SEED-ACTIF-002",
-            verse=Verse.FPE.value,
-            category=Category.A.value,
-            publication_date=datetime(2025, 6, 22, tzinfo=UTC),
-        ),
-        OfferDjangoFactory(
-            title="Ingénieur infrastructure cloud",
-            reference="REF-2025-003",
-            external_id="SEED-ACTIF-003",
-            verse=Verse.FPE.value,
-            category=Category.A.value,
-            publication_date=datetime(2025, 6, 21, tzinfo=UTC),
-        ),
-        OfferDjangoFactory(
-            title="Juriste droit public",
-            reference="REF-2025-004",
-            external_id="SEED-ACTIF-004",
-            verse=Verse.FPT.value,
-            category=Category.A.value,
-            publication_date=datetime(2025, 6, 21, tzinfo=UTC),
-        ),
-        OfferDjangoFactory(
-            title="Chargé de communication",
-            reference="REF-2025-005",
-            external_id="SEED-ACTIF-005",
-            verse=Verse.FPE.value,
-            category=Category.B.value,
-            publication_date=datetime(2025, 6, 2, tzinfo=UTC),
-        ),
-        OfferDjangoFactory(
-            title="Analyste budgétaire",
-            reference="REF-2025-006",
-            external_id="SEED-ACTIF-006",
-            verse=Verse.FPE.value,
-            category=Category.A.value,
-            publication_date=datetime(2025, 6, 1, tzinfo=UTC),
-        ),
-        OfferDjangoFactory(
-            title="Chargé de mission",
-            reference="REF-2025-006",
-            external_id="SEED-ACTIF-007",
-            verse=Verse.FPE.value,
-            category=Category.A.value,
-            publication_date=datetime(2025, 6, 1, tzinfo=UTC),
-        ),
-    ]
-
-    # ------------------------------------------------------------------ #
-    # Offres archivées (3)                                               #
-    # ------------------------------------------------------------------ #
-    offres_archivees = [
-        OfferDjangoFactory(
-            title="Directeur des systèmes d'information",
-            reference="REF-2024-A01",
-            external_id="SEED-ARCHIVE-001",
-            verse=Verse.FPE.value,
-            category=Category.A.value,
-            publication_date=datetime(2024, 12, 1, tzinfo=UTC),
-            archived_at=timezone.make_aware(datetime(2025, 3, 1)),
-        ),
-        OfferDjangoFactory(
-            title="Chef de projet transformation numérique",
-            reference="REF-2024-A02",
-            external_id="SEED-ARCHIVE-002",
-            verse=Verse.FPE.value,
-            category=Category.A.value,
-            publication_date=datetime(2024, 11, 15, tzinfo=UTC),
-            archived_at=timezone.make_aware(datetime(2025, 2, 15)),
-        ),
-        OfferDjangoFactory(
-            title="Conseiller en mobilité professionnelle",
-            reference="REF-2024-A03",
-            external_id="SEED-ARCHIVE-003",
-            verse=Verse.FPT.value,
-            category=Category.B.value,
-            publication_date=datetime(2024, 10, 1, tzinfo=UTC),
-            archived_at=timezone.make_aware(datetime(2025, 1, 15)),
-        ),
-    ]
-
-    # ------------------------------------------------------------------ #
-    # Offres du second organisme                                         #
-    # ------------------------------------------------------------------ #
-    offres_briancon = [
-        OfferDjangoFactory(
-            title="Agent technique polyvalent",
-            reference="REF-2025-B01",
-            external_id="SEED-B-ACTIF-001",
-            verse=Verse.FPT.value,
-            category=Category.C.value,
-            publication_date=datetime(2025, 5, 12, tzinfo=UTC),
-        ),
-        OfferDjangoFactory(
-            title="Responsable des services techniques",
-            reference="REF-2025-B02",
-            external_id="SEED-B-ACTIF-002",
-            verse=Verse.FPT.value,
-            category=Category.B.value,
-            publication_date=datetime(2025, 5, 20, tzinfo=UTC),
-        ),
-    ]
-
-    # ------------------------------------------------------------------ #
-    # Candidats (8)                                                      #
-    # ------------------------------------------------------------------ #
-    candidats = [
-        CandidatDjangoFactory(
-            utilisateur__first_name=spec["prenom"],
-            utilisateur__last_name=spec["nom"],
-            utilisateur__email=spec["email"],
-            utilisateur__password=Password(seed_password),
-        )
-        for spec in _CANDIDATS_SPECS
-    ]
-
-    # ------------------------------------------------------------------ #
-    # Recrutements (1 / offre active et archivée): étapes + responsables #
-    # ------------------------------------------------------------------ #
-    marie = agents[0]
-    paul = agents[1]
-    claire = agents[2]
-    marc = agents[4]
-
-    recrutements_specs = [
-        (
-            _ORGANISME_UUID,
-            offres_actives[0],
-            marie,
-            (paul, AgentRecrutementRole.RECRUTEUR),
-        ),
-        (
-            _ORGANISME_UUID,
-            offres_actives[1],
-            marie,
-            (paul, AgentRecrutementRole.RECRUTEUR),
-        ),
-        (
-            _ORGANISME_UUID,
-            offres_actives[2],
-            marie,
-            (paul, AgentRecrutementRole.RECRUTEUR),
-        ),
-        (
-            _ORGANISME_UUID,
-            offres_actives[3],
-            claire,
-            (paul, AgentRecrutementRole.CONTRIBUTEUR),
-        ),
-        (_ORGANISME_UUID, offres_actives[4], claire, None),
-        (_ORGANISME_UUID, offres_actives[5], claire, None),
-        (
-            _ORGANISME_UUID,
-            offres_actives[6],
-            marie,
-            (paul, AgentRecrutementRole.RECRUTEUR),
-        ),
-        (_ORGANISME_UUID, offres_archivees[0], claire, None),
-        (_ORGANISME_UUID, offres_archivees[1], claire, None),
-        (_ORGANISME_UUID, offres_archivees[2], claire, None),
-        (_BRIANCON_UUID, offres_briancon[0], marc, None),
-        (_BRIANCON_UUID, offres_briancon[1], marc, None),
-    ]
-
-    recrutements = []
-    for organisme_uuid, offre, responsable, extra_agent in recrutements_specs:
-        recrutement = RecrutementDjangoFactory(
-            offre=offre,
-            organisme=organismes[organisme_uuid],
-            agent_link__agent=responsable,
-            agent_link__role=AgentRecrutementRole.RESPONSABLE.value,
-        )
-        if extra_agent is not None:
-            extra_agent_model, extra_agent_role = extra_agent
-            RecrutementAgentDjangoFactory(
-                recrutement=recrutement,
-                agent=extra_agent_model,
-                role=extra_agent_role.value,
+        organismes = {_ORGANISME_UUID: organisme}
+        for spec in _ORGANISMES_SECONDAIRES_SPECS:
+            organismes[spec["entity_id"]] = OrganismeDjangoFactory(
+                id=spec["entity_id"],
+                nom=spec["nom"],
+                versant=spec["versant"].value,
+                siret=spec["siret"],
+                gestion_ats=False,
+                etapes=EtapeRecrutementFactory.create_entity_batch(),
             )
-        recrutements.append(recrutement)
 
-    # ------------------------------------------------------------------ #
-    # Candidatures                                                       #
-    # ------------------------------------------------------------------ #
-    candidatures_specs = [
-        (candidats[0], offres_actives[0], StatutCandidature.SOUMISE),
-        (candidats[1], offres_actives[0], StatutCandidature.INITIAL),
-        (candidats[2], offres_actives[0], StatutCandidature.SOUMISE),
-        (candidats[0], offres_actives[1], StatutCandidature.SOUMISE),
-        (candidats[3], offres_actives[1], StatutCandidature.INITIAL),
-        (candidats[4], offres_actives[2], StatutCandidature.SOUMISE),
-        (candidats[5], offres_actives[3], StatutCandidature.SOUMISE),
-        (candidats[6], offres_actives[3], StatutCandidature.INITIAL),
-        (candidats[1], offres_actives[4], StatutCandidature.SOUMISE),
-        (candidats[7], offres_actives[5], StatutCandidature.INITIAL),
-    ]
-
-    recrutements_by_offre_id = {
-        r.pk: r  # type: ignore[attr-defined]
-        for r in recrutements
-    }
-    for candidat_model, offre_model, statut in candidatures_specs:
-        recrutement = recrutements_by_offre_id[offre_model.id]
-        etape = recrutement.etapes.get(  # type: ignore[attr-defined]
-            categorie=CategorieEtapeRecrutement.ENTREE.value
+        # -------------------------------------------------------------- #
+        # Métiers                                                        #
+        # -------------------------------------------------------------- #
+        MetierDjangoFactory(
+            libelle_long="Chargé de mission numérique",
+            domaine_fonctionnel_code="NUM",
+            offer_family_code="ERNUM001",
         )
-        CandidatureDjangoFactory(
-            candidat=candidat_model,
-            etape=etape,
-            statut=statut.value,
+        MetierDjangoFactory(
+            libelle_long="Juriste droit public",
+            domaine_fonctionnel_code="JUR",
+            offer_family_code="ERJUR001",
         )
 
-    return {
-        "status": "seeded",
-        "organisme_id": str(organisme.id),
-        "nb_offres_actives": len(offres_actives),
-        "nb_offres_archivees": len(offres_archivees),
-        "nb_candidats": len(candidats),
-        "nb_agents": len(agents),
-        "nb_recrutements": len(recrutements),
-        "seed_password": seed_password,
-        "admin_email": admin.email,
-    }
+        # -------------------------------------------------------------- #
+        # Agents / recruteurs                                            #
+        # -------------------------------------------------------------- #
+        # Mot de passe généré à chaque seed (visible dans les logs de déploiement)
+        seed_password = os.environ.get("SEED_USER_PASSWORD") or secrets.token_urlsafe(
+            16
+        )
+        agents = [
+            AgentDjangoFactory(
+                utilisateur__first_name=spec["prenom"],
+                utilisateur__last_name=spec["nom"],
+                utilisateur__email=spec["email"],
+                utilisateur__password=Password(seed_password),
+            )
+            for spec in _AGENTS_SPECS
+        ]
+
+        # Marie est responsable du premier organisme, Paul et Claire en sont membres.
+        # Marc est membre du premier et responsable du second : c'est lui qui permet
+        # d'éprouver la bascule d'organisme et l'apparition des pages de paramètres.
+        # David ne l'est d'aucun, pour éprouver la navigation vide et le refus d'accès.
+        _ATTACHEMENTS = [
+            (_ORGANISME_UUID, 0, AgentOrganismeRole.RESPONSABLE),
+            (_ORGANISME_UUID, 1, AgentOrganismeRole.MEMBRE),
+            (_ORGANISME_UUID, 2, AgentOrganismeRole.MEMBRE),
+            (_ORGANISME_UUID, 4, AgentOrganismeRole.MEMBRE),
+            (_BRIANCON_UUID, 4, AgentOrganismeRole.RESPONSABLE),
+        ]
+        for organisme_uuid, agent_index, role in _ATTACHEMENTS:
+            OrganismeAgentDjangoFactory(
+                organisme=organismes[organisme_uuid],
+                agent=agents[agent_index],
+                role=role.value,
+            )
+
+        # -------------------------------------------------------------- #
+        # Administrateur (staff, hors organisme)                         #
+        # -------------------------------------------------------------- #
+        admin = UtilisateurDjangoFactory(
+            password=Password(seed_password),
+            is_staff=True,
+            first_name=_ADMIN_SPEC["prenom"],
+            last_name=_ADMIN_SPEC["nom"],
+            email=_ADMIN_SPEC["email"],
+        )
+
+        # -------------------------------------------------------------- #
+        # Offres actives (6)                                             #
+        # -------------------------------------------------------------- #
+        offres_actives = [
+            OfferDjangoFactory(
+                title="Chargé de mission numérique",
+                reference="REF-2025-001",
+                external_id="SEED-ACTIF-001",
+                verse=Verse.FPE.value,
+                category=Category.A.value,
+                publication_date=datetime(2025, 6, 22, tzinfo=UTC),
+            ),
+            OfferDjangoFactory(
+                title="Responsable RH",
+                reference="REF-2025-002",
+                external_id="SEED-ACTIF-002",
+                verse=Verse.FPE.value,
+                category=Category.A.value,
+                publication_date=datetime(2025, 6, 22, tzinfo=UTC),
+            ),
+            OfferDjangoFactory(
+                title="Ingénieur infrastructure cloud",
+                reference="REF-2025-003",
+                external_id="SEED-ACTIF-003",
+                verse=Verse.FPE.value,
+                category=Category.A.value,
+                publication_date=datetime(2025, 6, 21, tzinfo=UTC),
+            ),
+            OfferDjangoFactory(
+                title="Juriste droit public",
+                reference="REF-2025-004",
+                external_id="SEED-ACTIF-004",
+                verse=Verse.FPT.value,
+                category=Category.A.value,
+                publication_date=datetime(2025, 6, 21, tzinfo=UTC),
+            ),
+            OfferDjangoFactory(
+                title="Chargé de communication",
+                reference="REF-2025-005",
+                external_id="SEED-ACTIF-005",
+                verse=Verse.FPE.value,
+                category=Category.B.value,
+                publication_date=datetime(2025, 6, 2, tzinfo=UTC),
+            ),
+            OfferDjangoFactory(
+                title="Analyste budgétaire",
+                reference="REF-2025-006",
+                external_id="SEED-ACTIF-006",
+                verse=Verse.FPE.value,
+                category=Category.A.value,
+                publication_date=datetime(2025, 6, 1, tzinfo=UTC),
+            ),
+            OfferDjangoFactory(
+                title="Chargé de mission",
+                reference="REF-2025-006",
+                external_id="SEED-ACTIF-007",
+                verse=Verse.FPE.value,
+                category=Category.A.value,
+                publication_date=datetime(2025, 6, 1, tzinfo=UTC),
+            ),
+        ]
+
+        # -------------------------------------------------------------- #
+        # Offres archivées (3)                                           #
+        # -------------------------------------------------------------- #
+        offres_archivees = [
+            OfferDjangoFactory(
+                title="Directeur des systèmes d'information",
+                reference="REF-2024-A01",
+                external_id="SEED-ARCHIVE-001",
+                verse=Verse.FPE.value,
+                category=Category.A.value,
+                publication_date=datetime(2024, 12, 1, tzinfo=UTC),
+                archived_at=timezone.make_aware(datetime(2025, 3, 1)),
+            ),
+            OfferDjangoFactory(
+                title="Chef de projet transformation numérique",
+                reference="REF-2024-A02",
+                external_id="SEED-ARCHIVE-002",
+                verse=Verse.FPE.value,
+                category=Category.A.value,
+                publication_date=datetime(2024, 11, 15, tzinfo=UTC),
+                archived_at=timezone.make_aware(datetime(2025, 2, 15)),
+            ),
+            OfferDjangoFactory(
+                title="Conseiller en mobilité professionnelle",
+                reference="REF-2024-A03",
+                external_id="SEED-ARCHIVE-003",
+                verse=Verse.FPT.value,
+                category=Category.B.value,
+                publication_date=datetime(2024, 10, 1, tzinfo=UTC),
+                archived_at=timezone.make_aware(datetime(2025, 1, 15)),
+            ),
+        ]
+
+        # -------------------------------------------------------------- #
+        # Offres du second organisme                                     #
+        # -------------------------------------------------------------- #
+        offres_briancon = [
+            OfferDjangoFactory(
+                title="Agent technique polyvalent",
+                reference="REF-2025-B01",
+                external_id="SEED-B-ACTIF-001",
+                verse=Verse.FPT.value,
+                category=Category.C.value,
+                publication_date=datetime(2025, 5, 12, tzinfo=UTC),
+            ),
+            OfferDjangoFactory(
+                title="Responsable des services techniques",
+                reference="REF-2025-B02",
+                external_id="SEED-B-ACTIF-002",
+                verse=Verse.FPT.value,
+                category=Category.B.value,
+                publication_date=datetime(2025, 5, 20, tzinfo=UTC),
+            ),
+        ]
+
+        # -------------------------------------------------------------- #
+        # Candidats (8)                                                  #
+        # -------------------------------------------------------------- #
+        candidats = [
+            CandidatDjangoFactory(
+                utilisateur__first_name=spec["prenom"],
+                utilisateur__last_name=spec["nom"],
+                utilisateur__email=spec["email"],
+                utilisateur__password=Password(seed_password),
+            )
+            for spec in _CANDIDATS_SPECS
+        ]
+
+        # -------------------------------------------------------------- #
+        # Recrutements (1 / offre active et archivée): étapes + responsables
+        # -------------------------------------------------------------- #
+        marie = agents[0]
+        paul = agents[1]
+        claire = agents[2]
+        marc = agents[4]
+
+        recrutements_specs = [
+            (
+                _ORGANISME_UUID,
+                offres_actives[0],
+                marie,
+                (paul, AgentRecrutementRole.RECRUTEUR),
+            ),
+            (
+                _ORGANISME_UUID,
+                offres_actives[1],
+                marie,
+                (paul, AgentRecrutementRole.RECRUTEUR),
+            ),
+            (
+                _ORGANISME_UUID,
+                offres_actives[2],
+                marie,
+                (paul, AgentRecrutementRole.RECRUTEUR),
+            ),
+            (
+                _ORGANISME_UUID,
+                offres_actives[3],
+                claire,
+                (paul, AgentRecrutementRole.CONTRIBUTEUR),
+            ),
+            (_ORGANISME_UUID, offres_actives[4], claire, None),
+            (_ORGANISME_UUID, offres_actives[5], claire, None),
+            (
+                _ORGANISME_UUID,
+                offres_actives[6],
+                marie,
+                (paul, AgentRecrutementRole.RECRUTEUR),
+            ),
+            (_ORGANISME_UUID, offres_archivees[0], claire, None),
+            (_ORGANISME_UUID, offres_archivees[1], claire, None),
+            (_ORGANISME_UUID, offres_archivees[2], claire, None),
+            (_BRIANCON_UUID, offres_briancon[0], marc, None),
+            (_BRIANCON_UUID, offres_briancon[1], marc, None),
+        ]
+
+        recrutements = []
+        for organisme_uuid, offre, responsable, extra_agent in recrutements_specs:
+            recrutement = RecrutementDjangoFactory(
+                offre=offre,
+                organisme=organismes[organisme_uuid],
+                agent_link__agent=responsable,
+                agent_link__role=AgentRecrutementRole.RESPONSABLE.value,
+            )
+            if extra_agent is not None:
+                extra_agent_model, extra_agent_role = extra_agent
+                RecrutementAgentDjangoFactory(
+                    recrutement=recrutement,
+                    agent=extra_agent_model,
+                    role=extra_agent_role.value,
+                )
+            recrutements.append(recrutement)
+
+        # -------------------------------------------------------------- #
+        # Candidatures                                                   #
+        # -------------------------------------------------------------- #
+        candidatures_specs = [
+            (candidats[0], offres_actives[0], StatutCandidature.SOUMISE),
+            (candidats[1], offres_actives[0], StatutCandidature.INITIAL),
+            (candidats[2], offres_actives[0], StatutCandidature.SOUMISE),
+            (candidats[0], offres_actives[1], StatutCandidature.SOUMISE),
+            (candidats[3], offres_actives[1], StatutCandidature.INITIAL),
+            (candidats[4], offres_actives[2], StatutCandidature.SOUMISE),
+            (candidats[5], offres_actives[3], StatutCandidature.SOUMISE),
+            (candidats[6], offres_actives[3], StatutCandidature.INITIAL),
+            (candidats[1], offres_actives[4], StatutCandidature.SOUMISE),
+            (candidats[7], offres_actives[5], StatutCandidature.INITIAL),
+        ]
+
+        recrutements_by_offre_id = {
+            r.pk: r  # type: ignore[attr-defined]
+            for r in recrutements
+        }
+        for candidat_model, offre_model, statut in candidatures_specs:
+            recrutement = recrutements_by_offre_id[offre_model.id]
+            etape = recrutement.etapes.get(  # type: ignore[attr-defined]
+                categorie=CategorieEtapeRecrutement.ENTREE.value
+            )
+            CandidatureDjangoFactory(
+                candidat=candidat_model,
+                etape=etape,
+                statut=statut.value,
+            )
+
+        return {
+            "status": "seeded",
+            "organisme_id": str(organisme.id),
+            "nb_offres_actives": len(offres_actives),
+            "nb_offres_archivees": len(offres_archivees),
+            "nb_candidats": len(candidats),
+            "nb_agents": len(agents),
+            "nb_recrutements": len(recrutements),
+            "seed_password": seed_password,
+            "admin_email": admin.email,
+        }


### PR DESCRIPTION
## 📝 Description
🎸 Fait migrer le script de seed recruteur (`seed_recruteur_datas`) vers les `DjangoModelFactory` (factory_boy) déjà utilisées dans les tests, en remplacement des anciennes factories basées sur des entités de domaine mappées et des `Model(...).save()` bruts — cohérent avec la stratégie de test factory_boy d'ADR-002/ADR-009 
🎸 Complété par une passe de nettoyage : 
* robustesse (transaction atomique), 
* suppression de duplications de données (specs d'offres et d'organismes pilotées par des listes, ids d'offres dérivés des specs plutôt que dupliqués à la main)
* correction de bugs préexistants : compteur d'offres archivées codé en dur, référence d'offre dupliquée

## 🏷️ Type de changement
- [x] ♻️ Refactorisation


## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
