### PR TITLE
♻️(tooling) reuse the front types task in web:schema

### DIFF
--- a/src/web/frontend/mise.toml
+++ b/src/web/frontend/mise.toml
@@ -56,8 +56,8 @@ depends = [
 
 [tasks.types]
 alias = "front:types"
-description = "Regenerate the internal OpenAPI schema and the frontend TypeScript types"
-depends = [ "//src/web:schema" ]
+description = "Regenerate the frontend TypeScript types from the internal OpenAPI schema"
+depends = [ "//src/web:install:js" ]
 run = "pnpm run generate-types"
 
 [tasks.storybook]

--- a/src/web/mise.toml
+++ b/src/web/mise.toml
@@ -199,12 +199,12 @@ run = [
 
 [tasks.schema]
 alias = "web:schema"
-description = "Regenerate the public and internal OpenAPI schemas"
+description = "Regenerate the public and internal OpenAPI schemas, then the frontend types"
 depends = ["install:py"]
+depends_post = ["//src/web/frontend:types"]
 run = [
   "python manage.py spectacular --file presentation/static/api/schema.yaml --validate",
   "DJANGO_SETTINGS_MODULE=config.settings.schema_internal python manage.py spectacular --file presentation/static/api/internal-schema.yaml --validate",
-  "pnpm run generate-types",
 ]
 
 [tasks."lint:schema"]


### PR DESCRIPTION
## 📝 Description
🎸 Suite de #1398. La génération des types ts reste déclenchée par web:schema, mais passe par la tâche front:types existante. Déclare aussi queront:types dépend de //src/web:install:js au lieu de //src/web:schema, pour éviter un aller-retour entre les deux tâches et ajoute une dépendance dont elle a besoin

## 🏷️ Type de changement
- [ ] 🐛 Correction de bug
- [ ] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [ ] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation
- [ ] 📚 Mise à jour de la documentation
- [x] ♻️ Refactorisation
- [ ] 🔧 Changement technique

## 🏝️ Comment tester (si applicable)
- mise run web:schema
- mise run front:types