### PR TITLE
🔥(candidate) Désactivation du parcours candidat

### DIFF
--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -125,6 +125,7 @@ MIDDLEWARE = [
     "django.contrib.redirects.middleware.RedirectFallbackMiddleware",
     "presentation.middleware.api_request_logger.ApiRequestLoggerMiddleware",
     "presentation.middleware.rate_limit_headers.RateLimitHeadersMiddleware",
+    "presentation.middleware.candidate_redirect.CandidateRedirectMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/src/web/presentation/middleware/candidate_redirect.py
+++ b/src/web/presentation/middleware/candidate_redirect.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+
+CANDIDATE_URL_PREFIX = "/candidate/"
+CANDIDATE_EXTERNAL_REDIRECT_URL = "https://choisirleservicepublic.gouv.fr/nos-offres/"
+
+
+class CandidateRedirectMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        if not request.path.startswith(CANDIDATE_URL_PREFIX):
+            return self.get_response(request)
+
+        if request.headers.get("HX-Request"):
+            response = HttpResponse()
+            response["HX-Redirect"] = CANDIDATE_EXTERNAL_REDIRECT_URL
+            return response
+
+        return redirect(CANDIDATE_EXTERNAL_REDIRECT_URL, preserve_request=True)

--- a/src/web/tests/presentation/candidate/accessibility/test_candidate_flow_a11y.py
+++ b/src/web/tests/presentation/candidate/accessibility/test_candidate_flow_a11y.py
@@ -25,6 +25,11 @@ def _assert_no_violations(axe_results) -> None:
 
 
 @pytest.mark.accessibility
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestCandidateFlowAccessibility:
     def test_upload_page_has_no_axe_violations(
         self, page: Page, live_server, db

--- a/src/web/tests/presentation/candidate/e2e/test_cv_flow_keyboard.py
+++ b/src/web/tests/presentation/candidate/e2e/test_cv_flow_keyboard.py
@@ -17,6 +17,11 @@ from infrastructure.mappers.offer_mapper import OfferMapper
 
 
 @pytest.mark.e2e
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestCandidateFlowKeyboard:
     @patch(
         "application.candidate.usecases.match_cv_to_opportunities."

--- a/src/web/tests/presentation/candidate/e2e/test_cv_upload_flow.py
+++ b/src/web/tests/presentation/candidate/e2e/test_cv_upload_flow.py
@@ -11,6 +11,11 @@ from infrastructure.factories.referentiel.offer_factory import OfferFactory
 
 
 @pytest.mark.e2e
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestCVUploadFlow:
     @patch(
         "application.candidate.usecases.match_cv_to_opportunities."

--- a/src/web/tests/presentation/candidate/e2e/test_results_interaction.py
+++ b/src/web/tests/presentation/candidate/e2e/test_results_interaction.py
@@ -42,6 +42,11 @@ def fake_execute_filter_by_category_and_versant(
 
 
 @pytest.mark.e2e
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestResultsDrawer:
     @patch(
         "application.candidate.usecases.match_cv_to_opportunities."
@@ -145,6 +150,11 @@ class TestResultsDrawer:
 
 
 @pytest.mark.e2e
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestResultsPersistence:
     @patch(
         "application.candidate.usecases.match_cv_to_opportunities."
@@ -179,6 +189,11 @@ class TestResultsPersistence:
 
 
 @pytest.mark.e2e
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestResultsFilters:
     @patch(
         "application.candidate.usecases.match_cv_to_opportunities."
@@ -314,6 +329,11 @@ class TestResultsFilters:
 
 
 @pytest.mark.e2e
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestResultsPagination:
     @patch(
         "application.candidate.usecases.match_cv_to_opportunities."

--- a/src/web/tests/presentation/candidate/e2e/test_results_states.py
+++ b/src/web/tests/presentation/candidate/e2e/test_results_states.py
@@ -10,6 +10,11 @@ from infrastructure.factories.candidate.cv_metadata_factory import CVMetadataFac
 
 
 @pytest.mark.e2e
+@pytest.mark.skip(
+    reason="Candidate CV flow deactivated and redirected to "
+    "choisirleservicepublic.gouv.fr (#1402) — re-enable once the flow is "
+    "restored, or remove alongside the view code if it never comes back."
+)
 class TestResultsEmptyAndFailedStates:
     @patch(
         "application.candidate.usecases.match_cv_to_opportunities."

--- a/src/web/tests/presentation/candidate/views/conftest.py
+++ b/src/web/tests/presentation/candidate/views/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _bypass_candidate_redirect_middleware(settings):
+    settings.MIDDLEWARE = [
+        middleware
+        for middleware in settings.MIDDLEWARE
+        if middleware
+        != "presentation.middleware.candidate_redirect.CandidateRedirectMiddleware"
+    ]

--- a/src/web/tests/utils/test_candidate_redirect_middleware.py
+++ b/src/web/tests/utils/test_candidate_redirect_middleware.py
@@ -1,0 +1,70 @@
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from presentation.middleware.candidate_redirect import (
+    CANDIDATE_EXTERNAL_REDIRECT_URL,
+    CandidateRedirectMiddleware,
+)
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+def make_middleware(get_response=None):
+    get_response = get_response or MagicMock(return_value=HttpResponse())
+    middleware = CandidateRedirectMiddleware(get_response=get_response)
+    return middleware, get_response
+
+
+CANDIDATE_PATHS = [
+    "/candidate/cv-upload",
+    "/candidate/cv/11111111-1111-1111-1111-111111111111/results",
+    "/candidate/cv/11111111-1111-1111-1111-111111111111/offers/22222222-2222-2222-2222-222222222222/detail",
+    "/candidate/cv/11111111-1111-1111-1111-111111111111/concours/22222222-2222-2222-2222-222222222222/detail",
+]
+
+NON_CANDIDATE_PATHS = ["/", "/api/", "/utilisateur/"]
+
+
+class TestCandidateRedirectMiddleware:
+    @pytest.mark.parametrize("path", CANDIDATE_PATHS)
+    @pytest.mark.parametrize("http_method", ["get", "post"])
+    def test_candidate_path_returns_temporary_redirect(self, rf, http_method, path):
+        middleware, get_response = make_middleware()
+        request = getattr(rf, http_method)(path)
+
+        response = middleware(request)
+
+        assert response.status_code == HTTPStatus.TEMPORARY_REDIRECT
+        assert response["Location"] == CANDIDATE_EXTERNAL_REDIRECT_URL
+        get_response.assert_not_called()
+
+    @pytest.mark.parametrize("path", CANDIDATE_PATHS)
+    def test_htmx_request_gets_hx_redirect_header(self, rf, path):
+        middleware, get_response = make_middleware()
+        request = rf.get(path, HTTP_HX_REQUEST="true")
+
+        response = middleware(request)
+
+        assert response.status_code == HTTPStatus.OK
+        assert response["HX-Redirect"] == CANDIDATE_EXTERNAL_REDIRECT_URL
+        get_response.assert_not_called()
+
+    @pytest.mark.parametrize("path", NON_CANDIDATE_PATHS)
+    def test_non_candidate_path_is_unaffected(self, rf, path):
+        mock_response = HttpResponse()
+        middleware, get_response = make_middleware(
+            get_response=MagicMock(return_value=mock_response)
+        )
+        request = rf.get(path)
+
+        response = middleware(request)
+
+        assert response is mock_response
+        get_response.assert_called_once_with(request)


### PR DESCRIPTION
## 📝 Description
🎸 Toute requête sous `/candidate/` est redirigée en 307 vers `https://choisirleservicepublic.gouv.fr/nos-offres/` au lieu d'atteindre les vues existantes.

💡 possibilité d'éteindre l'instance `ocr` après la fusion

## 🏷️ Type de changement
- [x] 🥁 Changement breaking (modification ou fonctionnalité qui pourrait casser le fonctionnement existant) nécessitant une mise à jour de la documentation

## 🔧 Modifications
- Presentation : ajoute `CandidateRedirectMiddleware`, qui redirige toute requête `/candidate/*` en 307 (`HX-Redirect` si HTMX) vers l'offre externe, sans toucher aux 4 vues existantes (+ tests)
- Config / CI : enregistre le nouveau middleware en dernière position dans `MIDDLEWARE`
- Tests (candidate) : ajoute un `conftest.py` désactivant le middleware pour les tests de vues existants ; supprime les tests e2e/a11y du flux CV, désormais inatteignable

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
