### PR TITLE
♻️(tooling) mutualiser le backup DB Scaleway entre web et ingestion

### DIFF
--- a/bin/backup-db-to-scaleway.sh
+++ b/bin/backup-db-to-scaleway.sh
@@ -3,39 +3,48 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# backup-db-to-scaleway.sh — Fetch the latest Scalingo backup of the
-# csplab-web PostgreSQL database and archive it to Scaleway Object Storage.
+# backup-db-to-scaleway.sh <service> — Fetch the latest Scalingo backup of a
+# csplab-{service} PostgreSQL database and archive it to Scaleway Object
+# Storage. Shared by every service's cron job (see each service's cron.json).
 #
 # Required env vars (fetched from Scaleway Secret Manager under
-# /web/{SCALEWAY_ENV} when SCALEWAY_ENV is set):
+# /{service}/{SCALEWAY_ENV} when SCALEWAY_ENV is set):
 #   DB_BACKUP_SCALINGO_API_TOKEN            Scalingo API token
-#   DB_BACKUP_SCALINGO_POSTGRESQL_ADDON_ID  UUID of the PostgreSQL addon (scalingo --app csplab-web addons)
+#   DB_BACKUP_SCALINGO_POSTGRESQL_ADDON_ID  UUID of the PostgreSQL addon (scalingo --app csplab-{service} addons)
 #   DB_BACKUP_SCW_ACCESS_KEY_ID             Scaleway access key
 #   DB_BACKUP_SCW_SECRET_ACCESS_KEY         Scaleway secret key
 #   DB_BACKUP_SCW_BUCKET                    Target bucket name
 #
 # Optional env vars:
-#   DB_BACKUP_SCALINGO_APP   Scalingo app name (default: csplab-web)
+#   DB_BACKUP_SCALINGO_APP   Scalingo app name (default: csplab-{service})
 #   DB_BACKUP_SCW_REGION     Scaleway region (default: fr-par)
 #   DB_BACKUP_SCW_ENDPOINT   Scaleway S3 endpoint (default: https://s3.${DB_BACKUP_SCW_REGION}.scw.cloud)
 #
 # Requires the `scalingo` and `aws` CLIs to be installed and authenticated.
 # ---------------------------------------------------------------------------
 
-# No-op unless SCALEWAY_ENV is set (same pattern as bin/inject_scaleway_env.sh):
-# pulls every secret under /web/{SCALEWAY_ENV} and exports it, so these
-# DB_BACKUP_-scoped credentials live in Secret Manager alongside the rest of
-# the web app's config instead of being set by hand.
+SERVICE="${1:?usage: backup-db-to-scaleway.sh <service>}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# No-op unless SCALEWAY_ENV is set (same pattern as each service's
+# bin/inject_scaleway_env.sh): pulls every secret under /{service}/{SCALEWAY_ENV}
+# and exports it, so these DB_BACKUP_-scoped credentials live in Secret
+# Manager alongside the rest of the service's config instead of being set by hand.
 if [ -n "${SCALEWAY_ENV:-}" ]; then
   if [ "$SCALEWAY_ENV" = "prod" ] && [ -z "${SCALINGO_APPLICATION_ID:-}" ]; then
     echo "SCALEWAY_ENV=prod is only allowed on Scalingo (SCALINGO_APPLICATION_ID not set)" >&2
     exit 1
   fi
-  scaleway_env="$(python -m scaleway_secrets.fetch web)"
+  if command -v uv >/dev/null 2>&1; then
+    scaleway_env="$(uv run -q --project "$ROOT_DIR/libs/scaleway_secrets" python -m scaleway_secrets.fetch "$SERVICE")"
+  else
+    scaleway_env="$(python -m scaleway_secrets.fetch "$SERVICE")"
+  fi
   eval "$scaleway_env"
 fi
 
-SCALINGO_APP="${DB_BACKUP_SCALINGO_APP:-csplab-web}"
+SCALINGO_APP="${DB_BACKUP_SCALINGO_APP:-csplab-$SERVICE}"
 SCW_REGION="${DB_BACKUP_SCW_REGION:-fr-par}"
 SCW_ENDPOINT="${DB_BACKUP_SCW_ENDPOINT:-https://s3.${SCW_REGION}.scw.cloud}"
 
@@ -90,7 +99,7 @@ if [[ -z "$BACKUP" ]]; then
   exit 1
 fi
 
-DEST="s3://${DB_BACKUP_SCW_BUCKET}/csplab-web/$(date +%Y/%m)/$(basename "$BACKUP")"
+DEST="s3://${DB_BACKUP_SCW_BUCKET}/${SCALINGO_APP}/$(date +%Y/%m)/$(basename "$BACKUP")"
 
 echo "🚀 Uploading $(basename "$BACKUP") to ${DEST}…"
 AWS_ACCESS_KEY_ID="$DB_BACKUP_SCW_ACCESS_KEY_ID" \

--- a/src/ingestion/cron.json
+++ b/src/ingestion/cron.json
@@ -7,6 +7,10 @@
     {
       "command": "0 6 * * 1 bash -c 'source bin/inject_scaleway_env.sh && bin/organismes_pipeline.py'",
       "size": "XL"
+    },
+    {
+      "command": "30 5 * * * bash ../../bin/backup-db-to-scaleway.sh ingestion",
+      "size": "S"
     }
   ]
 }

--- a/src/web/cron.json
+++ b/src/web/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "0 5 * * * bash bin/backup-db-to-scaleway.sh",
+      "command": "0 5 * * * bash ../../bin/backup-db-to-scaleway.sh web",
       "size": "S"
     }
   ]


### PR DESCRIPTION
## 📝 Description

Déplace `bin/backup-db-to-scaleway.sh` à la racine, paramétré par service, et ajoute le cron `ingestion`.

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)

J'ai testé sur ma machine :tm:

```sh
$ cd src/ingestion
$ ../../bin/backup-db-to-scaleway.sh ingestion
-----> Hello antoineaugusti, nice to see you!
📦 Fetching latest backup for csplab-ingestion (addon ad-f4d412ae-aefe-41a3-8235-b5d6395c459b)…
🚀 Uploading 20260910015258_csplab_work_3901.tar.gz to s3://csplab-db-backups/csplab-ingestion/2026/09/20260910015258_csplab_work_3901.tar.gz…
upload: ../../../../../../var/folders/2_/gt2ktshs73x93w_dh13yxyf00000gn/T/tmp.11OVuZYCG2/20260910015258_csplab_work_3901.tar.gz to s3://csplab-db-backups/csplab-ingestion/2026/09/20260910015258_csplab_work_3901.tar.gz
✅ Done. Backup archived at s3://csplab-db-backups/csplab-ingestion/2026/09/20260910015258_csplab_work_3901.tar.gz.
```

## 📸 Captures d’écran (si applicable)

Variables d'env ajoutées en prod pour `ingestion`.

<img width="1164" height="742" alt="Screenshot 2026-09-10 at 10 37 19" src="https://github.com/user-attachments/assets/9199a11a-e304-4cbc-8ae7-796c7c5ab1bc" />

<img width="1172" height="660" alt="Screenshot 2026-09-10 at 10 57 45" src="https://github.com/user-attachments/assets/dc0de2df-9b1d-4a81-b4f2-d615cc769c5e" />


## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
