### PR TITLE
✨(recruteur-back) Ajouter un agent à l'équipe de recrutement

### DIFF
--- a/src/web/application/recruteur/services/add_recrutement_agent.py
+++ b/src/web/application/recruteur/services/add_recrutement_agent.py
@@ -1,0 +1,91 @@
+from uuid import UUID, uuid4
+
+from ddd.entity import Entity
+from django.db import IntegrityError, transaction
+
+from domain.commons.services.audit_log_writer import AuditLogWriter
+from domain.identite.entities.utilisateurs import Utilisateur
+from domain.identite.errors.agent_errors import ProfilAgentNexistePas
+from domain.identite.services.organisme_permission_service import (
+    OrganismePermissionService,
+)
+from domain.identite.value_objects.organisme_action import OrganismeAction
+from domain.recruteur.errors.organisme_agent_errors import AgentNonRattache
+from domain.recruteur.errors.recrutement_agent_errors import AgentDejaMembreRecrutement
+from domain.recruteur.errors.recrutement_errors import RecrutementInexistant
+from infrastructure.django_apps.recruteur.models.organisme import OrganismeAgentModel
+from infrastructure.django_apps.recruteur.models.recrutement import (
+    RecrutementAgentModel,
+    RecrutementModel,
+)
+from infrastructure.django_apps.users.models import ProfilAgentModel
+from infrastructure.repositories.commons.postgres_audit_log_repository import (
+    PostgresAuditLogRepository,
+)
+from infrastructure.repositories.recruteur.postgres_organisme_agent_repository import (
+    PostgresOrganismeAgentRepository,
+)
+from infrastructure.repositories.recruteur.postgres_organisme_repository import (
+    PostgresOrganismeRecruteurRepository,
+)
+from infrastructure.repositories.recruteur.postgres_recrutement_agent_repository import (  # noqa: E501
+    PostgresRecrutementAgentRepository,
+)
+
+
+def add_recrutement_agent(
+    *,
+    organisme_id: UUID,
+    recrutement_id: UUID,
+    agent_id: UUID,
+    role: str,
+    utilisateur: Utilisateur,
+) -> RecrutementAgentModel:
+    # TODO : to refactor in ADR-009 style once OrganismePermissionService is migrated
+    organisme_permission_service = OrganismePermissionService(
+        organisme_recruteur_repository=PostgresOrganismeRecruteurRepository(),
+        organisme_agent_repository=PostgresOrganismeAgentRepository(),
+        recrutement_agent_repository=PostgresRecrutementAgentRepository(),
+    )
+    organisme_permission_service.est_autorise(
+        action=OrganismeAction.ADD_RECRUTEMENT_AGENT,
+        utilisateur=utilisateur,
+        organisme_id=organisme_id,
+    )
+
+    if not ProfilAgentModel.objects.filter(
+        utilisateur_id=agent_id  # type: ignore[misc]
+    ).exists():
+        raise ProfilAgentNexistePas(agent_id)
+
+    if not RecrutementModel.objects.filter(
+        pk=recrutement_id, organisme_id=organisme_id
+    ).exists():
+        raise RecrutementInexistant(recrutement_id)
+
+    agent_rattache_a_organisme = OrganismeAgentModel.objects.filter(
+        organisme_id=organisme_id,
+        agent_id=agent_id,  # type: ignore[misc]
+        date_revocation__isnull=True,
+    ).exists()
+    if not agent_rattache_a_organisme:
+        raise AgentNonRattache(organisme_id, agent_id)
+
+    try:
+        with transaction.atomic():
+            recrutement_agent = RecrutementAgentModel.objects.create(
+                id=uuid4(),
+                recrutement_id=recrutement_id,
+                agent_id=agent_id,
+                role=role,
+            )
+            AuditLogWriter(repository=PostgresAuditLogRepository()).log_action(
+                utilisateur_id=utilisateur.entity_id,
+                entity=Entity(entity_id=agent_id),
+                ressource_kind="RecrutementAgent",
+                event_name="AgentRecrutementAjoute",
+            )
+    except IntegrityError as error:
+        raise AgentDejaMembreRecrutement(recrutement_id, agent_id) from error
+
+    return recrutement_agent

--- a/src/web/domain/identite/services/organisme_permission_service.py
+++ b/src/web/domain/identite/services/organisme_permission_service.py
@@ -47,6 +47,7 @@ _AUTORISE_POUR_STAFF: frozenset[OrganismeAction] = frozenset(
         OrganismeAction.REVOKE_ORGANISME_AGENT,
         OrganismeAction.CREATE_AGENT,
         OrganismeAction.LIST_RECRUTEMENT_AGENTS,
+        OrganismeAction.ADD_RECRUTEMENT_AGENT,
     }
 )
 
@@ -86,6 +87,7 @@ _ROLES_REQUIS: dict[OrganismeAction, frozenset[AgentOrganismeRole]] = {
     OrganismeAction.LIST_RECRUTEMENT_AGENTS: frozenset(
         {AgentOrganismeRole.RESPONSABLE}
     ),
+    OrganismeAction.ADD_RECRUTEMENT_AGENT: frozenset({AgentOrganismeRole.RESPONSABLE}),
 }
 
 # -------------------------------------

--- a/src/web/domain/identite/value_objects/organisme_action.py
+++ b/src/web/domain/identite/value_objects/organisme_action.py
@@ -21,3 +21,4 @@ class OrganismeAction(Enum):
     REVOKE_ORGANISME_AGENT = "revoke_organisme_agent"
     CREATE_AGENT = "create_agent"
     LIST_RECRUTEMENT_AGENTS = "list_recrutement_agents"
+    ADD_RECRUTEMENT_AGENT = "add_recrutement_agent"

--- a/src/web/domain/recruteur/errors/recrutement_agent_errors.py
+++ b/src/web/domain/recruteur/errors/recrutement_agent_errors.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from ddd.domain_errors import DomainError
+
+
+class RecrutementAgentError(DomainError):
+    pass
+
+
+class AgentDejaMembreRecrutement(RecrutementAgentError):
+    def __init__(self, recrutement_id: UUID, agent_id: UUID):
+        super().__init__(
+            f"Agent {agent_id} is already a member of recrutement {recrutement_id}"
+        )
+        self.recrutement_id = recrutement_id
+        self.agent_id = agent_id

--- a/src/web/frontend/src/types/api.d.ts
+++ b/src/web/frontend/src/types/api.d.ts
@@ -3441,6 +3441,17 @@ export interface operations {
                     "application/json": components["schemas"]["GenericError"];
                 };
             };
+            409: {
+                headers: {
+                    "X-RateLimit-Limit": components["headers"]["X-RateLimit-Limit"];
+                    "X-RateLimit-Remaining": components["headers"]["X-RateLimit-Remaining"];
+                    "X-RateLimit-Reset": components["headers"]["X-RateLimit-Reset"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenericError"];
+                };
+            };
             /** @description Nombre maximal d'appels autorisés dépassé. */
             429: {
                 headers: {

--- a/src/web/presentation/recruteur/views/recrutement_agents.py
+++ b/src/web/presentation/recruteur/views/recrutement_agents.py
@@ -8,14 +8,18 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from application.recruteur.services.add_recrutement_agent import add_recrutement_agent
 from application.recruteur.services.list_recrutement_agents import (
     list_recrutement_agents,
 )
 from domain.commons.errors.organisme_errors import OrganismeNexistePas
+from domain.identite.errors.agent_errors import ProfilAgentNexistePas
 from domain.identite.errors.organisme_permission_errors import (
     AccesOrganismeRefuse,
     OperationOrganismeRefusee,
 )
+from domain.recruteur.errors.organisme_agent_errors import AgentNonRattache
+from domain.recruteur.errors.recrutement_agent_errors import AgentDejaMembreRecrutement
 from domain.recruteur.errors.recrutement_errors import RecrutementInexistant
 from presentation.api.serializers import GenericErrorSerializer, generic_response_format
 from presentation.recruteur.mappers import UtilisateurMapper
@@ -42,6 +46,9 @@ from presentation.recruteur.serializers import (
             **generic_response_format,
             201: RecrutementAgentSerializer,
             400: GenericErrorSerializer,
+            403: GenericErrorSerializer,
+            404: GenericErrorSerializer,
+            409: GenericErrorSerializer,
         },
     ),
     put=extend_schema(
@@ -75,15 +82,15 @@ class RecrutementAgentsView(ListAPIView):
                 GenericErrorSerializer({"error": str(serializer.errors)}).data,
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        recrutement_agent = add_recrutement_agent(
+            organisme_id=organisme_uuid,
+            recrutement_id=recrutement_uuid,
+            agent_id=serializer.validated_data["agent_id"],
+            role=serializer.validated_data["recrutement_role"],
+            utilisateur=UtilisateurMapper().to_domain(request),
+        )
         return Response(
-            {
-                "agent_id": serializer.validated_data["agent_id"],
-                "nom": "Nom",
-                "prenom": "Prenom",
-                "poste": "Poste",
-                "email": "prenom.nom@test.com",
-                "recrutement_role": serializer.validated_data["recrutement_role"],
-            },
+            RecrutementAgentSerializer(recrutement_agent).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -115,10 +122,23 @@ class RecrutementAgentsView(ListAPIView):
                 GenericErrorSerializer({"error": str(exc)}).data,
                 status=status.HTTP_403_FORBIDDEN,
             )
-        if isinstance(exc, (OrganismeNexistePas, RecrutementInexistant)):
+        if isinstance(
+            exc,
+            (
+                OrganismeNexistePas,
+                RecrutementInexistant,
+                ProfilAgentNexistePas,
+                AgentNonRattache,
+            ),
+        ):
             return Response(
                 GenericErrorSerializer({"error": str(exc)}).data,
                 status=status.HTTP_404_NOT_FOUND,
+            )
+        if isinstance(exc, AgentDejaMembreRecrutement):
+            return Response(
+                GenericErrorSerializer({"error": str(exc)}).data,
+                status=status.HTTP_409_CONFLICT,
             )
         if isinstance(exc, (exceptions.APIException, Http404)):
             return super().handle_exception(exc)

--- a/src/web/presentation/static/api/internal-schema.yaml
+++ b/src/web/presentation/static/api/internal-schema.yaml
@@ -3083,6 +3083,19 @@ paths:
               $ref: '#/components/headers/X-RateLimit-Remaining'
             X-RateLimit-Reset:
               $ref: '#/components/headers/X-RateLimit-Reset'
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: ''
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/X-RateLimit-Limit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/X-RateLimit-Remaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/X-RateLimit-Reset'
         '429':
           description: Nombre maximal d'appels autorisés dépassé.
           content:

--- a/src/web/tests/application/recruteur/test_add_recrutement_agent.py
+++ b/src/web/tests/application/recruteur/test_add_recrutement_agent.py
@@ -1,0 +1,237 @@
+from uuid import uuid4
+
+import pytest
+
+from application.recruteur.services.add_recrutement_agent import add_recrutement_agent
+from domain.commons.errors.organisme_errors import OrganismeNexistePas
+from domain.identite.errors.agent_errors import ProfilAgentNexistePas
+from domain.identite.errors.organisme_permission_errors import AccesOrganismeRefuse
+from domain.recruteur.errors.organisme_agent_errors import AgentNonRattache
+from domain.recruteur.errors.recrutement_agent_errors import AgentDejaMembreRecrutement
+from domain.recruteur.errors.recrutement_errors import RecrutementInexistant
+from domain.recruteur.value_objects.roles import (
+    AgentOrganismeRole,
+    AgentRecrutementRole,
+)
+from infrastructure.django_apps.recruteur.models.recrutement import (
+    RecrutementAgentModel,
+)
+from infrastructure.factories.identite.agent_django_factory import AgentDjangoFactory
+from infrastructure.factories.identite.organisme_django_factory import (
+    OrganismeAgentDjangoFactory,
+    OrganismeDjangoFactory,
+    create_organisme_with_agent,
+)
+from infrastructure.factories.identite.utilisateur_factory import UtilisateurFactory
+from infrastructure.factories.recruteur.recrutement_django_factory import (
+    RecrutementDjangoFactory,
+)
+from infrastructure.repositories.commons.postgres_audit_log_repository import (
+    PostgresAuditLogRepository,
+)
+
+
+def _utilisateur(entity_id, *, is_staff=False):
+    return UtilisateurFactory.create_entity(entity_id=entity_id, is_staff=is_staff)
+
+
+def test_responsable_adds_agent_to_recrutement(db):
+    responsable, organisme = create_organisme_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
+    membre = OrganismeAgentDjangoFactory(
+        organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+    ).agent
+    recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+    recrutement_agent = add_recrutement_agent(
+        organisme_id=organisme.id,
+        recrutement_id=recrutement.pk,
+        agent_id=membre.utilisateur_id,
+        role=AgentRecrutementRole.CONTRIBUTEUR.value,
+        utilisateur=_utilisateur(responsable.utilisateur_id),
+    )
+
+    assert recrutement_agent.recrutement_id == recrutement.pk
+    assert recrutement_agent.agent_id == membre.utilisateur_id
+    assert recrutement_agent.role == AgentRecrutementRole.CONTRIBUTEUR.value
+    assert RecrutementAgentModel.objects.filter(
+        recrutement_id=recrutement.pk, agent_id=membre.utilisateur_id
+    ).exists()
+
+    logs = PostgresAuditLogRepository().get_logs_for_ressource(
+        "RecrutementAgent", membre.utilisateur_id
+    )
+    assert len(logs) == 1
+    assert logs[0].event_name == "AgentRecrutementAjoute"
+    assert logs[0].utilisateur_id == responsable.utilisateur_id
+
+
+def test_staff_bypasses_role_check(db):
+    organisme = OrganismeDjangoFactory()
+    membre = OrganismeAgentDjangoFactory(
+        organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+    ).agent
+    recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+    recrutement_agent = add_recrutement_agent(
+        organisme_id=organisme.id,
+        recrutement_id=recrutement.pk,
+        agent_id=membre.utilisateur_id,
+        role=AgentRecrutementRole.RECRUTEUR.value,
+        utilisateur=_utilisateur(uuid4(), is_staff=True),
+    )
+
+    assert recrutement_agent.role == AgentRecrutementRole.RECRUTEUR.value
+
+
+@pytest.mark.parametrize(
+    "role", [AgentOrganismeRole.MEMBRE, None], ids=["membre_role", "no_organisme_role"]
+)
+def test_denied_when_demandeur_is_not_responsable(db, role):
+    if role is None:
+        organisme = OrganismeDjangoFactory()
+        demandeur_id = uuid4()
+    else:
+        demandeur, organisme = create_organisme_with_agent(role=role)
+        demandeur_id = demandeur.utilisateur_id
+    membre = OrganismeAgentDjangoFactory(
+        organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+    ).agent
+    recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+    with pytest.raises(AccesOrganismeRefuse):
+        add_recrutement_agent(
+            organisme_id=organisme.id,
+            recrutement_id=recrutement.pk,
+            agent_id=membre.utilisateur_id,
+            role=AgentRecrutementRole.CONTRIBUTEUR.value,
+            utilisateur=_utilisateur(demandeur_id),
+        )
+
+    assert not RecrutementAgentModel.objects.filter(
+        recrutement_id=recrutement.pk, agent_id=membre.utilisateur_id
+    ).exists()
+    assert (
+        PostgresAuditLogRepository().get_logs_for_ressource(
+            "RecrutementAgent", membre.utilisateur_id
+        )
+        == []
+    )
+
+
+def test_raises_when_organisme_does_not_exist(db):
+    membre = AgentDjangoFactory()
+
+    with pytest.raises(OrganismeNexistePas):
+        add_recrutement_agent(
+            organisme_id=uuid4(),
+            recrutement_id=uuid4(),
+            agent_id=membre.utilisateur_id,
+            role=AgentRecrutementRole.CONTRIBUTEUR.value,
+            utilisateur=_utilisateur(uuid4()),
+        )
+
+
+def test_raises_when_agent_to_add_does_not_exist(db):
+    responsable, organisme = create_organisme_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
+    recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+    with pytest.raises(ProfilAgentNexistePas):
+        add_recrutement_agent(
+            organisme_id=organisme.id,
+            recrutement_id=recrutement.pk,
+            agent_id=uuid4(),
+            role=AgentRecrutementRole.CONTRIBUTEUR.value,
+            utilisateur=_utilisateur(responsable.utilisateur_id),
+        )
+
+
+def test_raises_when_recrutement_does_not_belong_to_organisme(db):
+    responsable, organisme = create_organisme_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
+    membre = OrganismeAgentDjangoFactory(
+        organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+    ).agent
+    autre_organisme = OrganismeDjangoFactory()
+    recrutement = RecrutementDjangoFactory(organisme=autre_organisme)
+
+    with pytest.raises(RecrutementInexistant):
+        add_recrutement_agent(
+            organisme_id=organisme.id,
+            recrutement_id=recrutement.pk,
+            agent_id=membre.utilisateur_id,
+            role=AgentRecrutementRole.CONTRIBUTEUR.value,
+            utilisateur=_utilisateur(responsable.utilisateur_id),
+        )
+
+
+def test_raises_when_agent_to_add_is_not_attached_to_organisme(db):
+    responsable, organisme = create_organisme_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
+    bare_agent = AgentDjangoFactory()
+    recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+    with pytest.raises(AgentNonRattache):
+        add_recrutement_agent(
+            organisme_id=organisme.id,
+            recrutement_id=recrutement.pk,
+            agent_id=bare_agent.utilisateur_id,
+            role=AgentRecrutementRole.CONTRIBUTEUR.value,
+            utilisateur=_utilisateur(responsable.utilisateur_id),
+        )
+
+
+def test_rolls_back_membership_when_audit_log_write_fails(db, monkeypatch):
+    responsable, organisme = create_organisme_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
+    membre = OrganismeAgentDjangoFactory(
+        organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+    ).agent
+    recrutement = RecrutementDjangoFactory(organisme=organisme)
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("audit log write failed")
+
+    monkeypatch.setattr(
+        "application.recruteur.services.add_recrutement_agent.AuditLogWriter.log_action",
+        _raise,
+    )
+
+    with pytest.raises(RuntimeError):
+        add_recrutement_agent(
+            organisme_id=organisme.id,
+            recrutement_id=recrutement.pk,
+            agent_id=membre.utilisateur_id,
+            role=AgentRecrutementRole.CONTRIBUTEUR.value,
+            utilisateur=_utilisateur(responsable.utilisateur_id),
+        )
+
+    assert not RecrutementAgentModel.objects.filter(
+        recrutement_id=recrutement.pk, agent_id=membre.utilisateur_id
+    ).exists()
+
+
+def test_raises_when_agent_already_member_of_recrutement(db):
+    responsable, organisme = create_organisme_with_agent(
+        role=AgentOrganismeRole.RESPONSABLE
+    )
+    recrutement = RecrutementDjangoFactory(organisme=organisme)
+    deja_membre = RecrutementAgentModel.objects.get(recrutement=recrutement).agent
+    OrganismeAgentDjangoFactory(
+        organisme=organisme, agent=deja_membre, role=AgentOrganismeRole.MEMBRE.value
+    )
+
+    with pytest.raises(AgentDejaMembreRecrutement):
+        add_recrutement_agent(
+            organisme_id=organisme.id,
+            recrutement_id=recrutement.pk,
+            agent_id=deja_membre.utilisateur_id,
+            role=AgentRecrutementRole.CONTRIBUTEUR.value,
+            utilisateur=_utilisateur(responsable.utilisateur_id),
+        )

--- a/src/web/tests/domain/identite/test_organisme_permission_service.py
+++ b/src/web/tests/domain/identite/test_organisme_permission_service.py
@@ -45,7 +45,7 @@ RESPONSABLE_ACTIONS = [
     OrganismeAction.REVOKE_ORGANISME_AGENT,
     OrganismeAction.CREATE_AGENT,
     OrganismeAction.LIST_RECRUTEMENT_AGENTS,
-    OrganismeAction.ADD_RECRUTEMENT_AGENTS,
+    OrganismeAction.ADD_RECRUTEMENT_AGENT,
 ]
 STAFF_BYPASS_ACTIONS = [
     OrganismeAction.GET_ORGANISME,
@@ -58,7 +58,7 @@ STAFF_BYPASS_ACTIONS = [
     OrganismeAction.REVOKE_ORGANISME_AGENT,
     OrganismeAction.CREATE_AGENT,
     OrganismeAction.LIST_RECRUTEMENT_AGENTS,
-    OrganismeAction.ADD_RECRUTEMENT_AGENTS,
+    OrganismeAction.ADD_RECRUTEMENT_AGENT,
 ]
 
 

--- a/src/web/tests/domain/identite/test_organisme_permission_service.py
+++ b/src/web/tests/domain/identite/test_organisme_permission_service.py
@@ -45,6 +45,7 @@ RESPONSABLE_ACTIONS = [
     OrganismeAction.REVOKE_ORGANISME_AGENT,
     OrganismeAction.CREATE_AGENT,
     OrganismeAction.LIST_RECRUTEMENT_AGENTS,
+    OrganismeAction.ADD_RECRUTEMENT_AGENTS,
 ]
 STAFF_BYPASS_ACTIONS = [
     OrganismeAction.GET_ORGANISME,
@@ -57,6 +58,7 @@ STAFF_BYPASS_ACTIONS = [
     OrganismeAction.REVOKE_ORGANISME_AGENT,
     OrganismeAction.CREATE_AGENT,
     OrganismeAction.LIST_RECRUTEMENT_AGENTS,
+    OrganismeAction.ADD_RECRUTEMENT_AGENTS,
 ]
 
 

--- a/src/web/tests/presentation/recruteur/test_views_recrutement_agents.py
+++ b/src/web/tests/presentation/recruteur/test_views_recrutement_agents.py
@@ -10,8 +10,12 @@ from domain.recruteur.value_objects.roles import (
     AgentOrganismeRole,
     AgentRecrutementRole,
 )
+from infrastructure.django_apps.recruteur.models.recrutement import (
+    RecrutementAgentModel,
+)
 from infrastructure.factories.identite.agent_django_factory import AgentDjangoFactory
 from infrastructure.factories.identite.organisme_django_factory import (
+    OrganismeAgentDjangoFactory,
     OrganismeDjangoFactory,
     create_organisme_with_agent,
 )
@@ -206,25 +210,169 @@ class TestRecrutementAgentsViewPost:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_returns_201_with_recrutement_agent_shape_for_valid_payload(
-        self, authenticated_client
+        self, authenticated_client, test_user
     ):
-        agent_id = uuid4()
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE, utilisateur=test_user
+        )
+        membre = OrganismeAgentDjangoFactory(
+            organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+        ).agent
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
         payload = {
-            "agent_id": str(agent_id),
+            "agent_id": str(membre.utilisateur_id),
             "recrutement_role": AgentRecrutementRole.RECRUTEUR.value,
         }
 
-        response = authenticated_client.post(_url(uuid4(), uuid4()), payload)
+        response = authenticated_client.post(
+            _url(organisme.id, recrutement.pk), payload
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == {
-            "agent_id": str(agent_id),
-            "nom": "Nom",
-            "prenom": "Prenom",
-            "poste": "Poste",
-            "email": "prenom.nom@test.com",
+            "agent_id": str(membre.utilisateur_id),
+            "nom": membre.utilisateur.last_name,
+            "prenom": membre.utilisateur.first_name,
+            "poste": membre.intitule_poste,
+            "email": membre.utilisateur.email,
             "recrutement_role": AgentRecrutementRole.RECRUTEUR.value,
         }
+        assert RecrutementAgentModel.objects.filter(
+            recrutement=recrutement, agent=membre
+        ).exists()
+
+    def test_staff_can_add_agent_without_organisme_role(self, api_client):
+        staff_user = UtilisateurDjangoFactory(is_staff=True)
+        refresh = RefreshToken.for_user(staff_user)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+        organisme = OrganismeDjangoFactory()
+        membre = OrganismeAgentDjangoFactory(
+            organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+        ).agent
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+        payload = {
+            "agent_id": str(membre.utilisateur_id),
+            "recrutement_role": AgentRecrutementRole.CONTRIBUTEUR.value,
+        }
+
+        response = api_client.post(_url(organisme.id, recrutement.pk), payload)
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+    @pytest.mark.parametrize(
+        "role",
+        [AgentOrganismeRole.MEMBRE, None],
+        ids=["membre_role", "no_organisme_role"],
+    )
+    def test_is_forbidden_for(self, authenticated_client, test_user, role):
+        if role is None:
+            organisme = OrganismeDjangoFactory()
+        else:
+            _, organisme = create_organisme_with_agent(role=role, utilisateur=test_user)
+        membre = OrganismeAgentDjangoFactory(
+            organisme=organisme, role=AgentOrganismeRole.MEMBRE.value
+        ).agent
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+        payload = {
+            "agent_id": str(membre.utilisateur_id),
+            "recrutement_role": AgentRecrutementRole.CONTRIBUTEUR.value,
+        }
+
+        response = authenticated_client.post(
+            _url(organisme.id, recrutement.pk), payload
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        "build_ids",
+        [
+            _unknown_organisme_ids,
+            _unknown_recrutement_ids,
+            _recrutement_from_another_organisme_ids,
+        ],
+        ids=[
+            "unknown_organisme",
+            "unknown_recrutement",
+            "recrutement_from_another_organisme",
+        ],
+    )
+    def test_returns_404_for_organisme_or_recrutement(
+        self, authenticated_client, test_user, build_ids
+    ):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE, utilisateur=test_user
+        )
+        organisme_uuid, recrutement_uuid = build_ids(organisme)
+        payload = {
+            "agent_id": str(uuid4()),
+            "recrutement_role": AgentRecrutementRole.CONTRIBUTEUR.value,
+        }
+
+        response = authenticated_client.post(
+            _url(organisme_uuid, recrutement_uuid), payload
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_when_agent_to_add_does_not_exist(
+        self, authenticated_client, test_user
+    ):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE, utilisateur=test_user
+        )
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+        payload = {
+            "agent_id": str(uuid4()),
+            "recrutement_role": AgentRecrutementRole.CONTRIBUTEUR.value,
+        }
+
+        response = authenticated_client.post(
+            _url(organisme.id, recrutement.pk), payload
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_when_agent_to_add_is_not_attached_to_organisme(
+        self, authenticated_client, test_user
+    ):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE, utilisateur=test_user
+        )
+        bare_agent = AgentDjangoFactory()
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+        payload = {
+            "agent_id": str(bare_agent.utilisateur_id),
+            "recrutement_role": AgentRecrutementRole.CONTRIBUTEUR.value,
+        }
+
+        response = authenticated_client.post(
+            _url(organisme.id, recrutement.pk), payload
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_409_when_agent_already_member_of_recrutement(
+        self, authenticated_client, test_user
+    ):
+        _, organisme = create_organisme_with_agent(
+            role=AgentOrganismeRole.RESPONSABLE, utilisateur=test_user
+        )
+        recrutement = RecrutementDjangoFactory(organisme=organisme)
+        deja_membre = RecrutementAgentModel.objects.get(recrutement=recrutement).agent
+        OrganismeAgentDjangoFactory(
+            organisme=organisme, agent=deja_membre, role=AgentOrganismeRole.MEMBRE.value
+        )
+        payload = {
+            "agent_id": str(deja_membre.utilisateur_id),
+            "recrutement_role": AgentRecrutementRole.CONTRIBUTEUR.value,
+        }
+
+        response = authenticated_client.post(
+            _url(organisme.id, recrutement.pk), payload
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
 
 
 class TestRecrutementAgentsViewPut:


### PR DESCRIPTION
## 📝 Description
🎸 Implémente l'ajout d'un agent à l'équipe de recrutement 
🎸 endpoint `POST` sur `RecrutementAgentsView`

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)


## 🔧 Modifications
- Application : nouveau service `add_recrutement_agent` ; vérifie la permission via `OrganismePermissionService`, l'existence de l'agent et du recrutement, le rattachement actif de l'agent à l'organisme, crée le `RecrutementAgentModel` et journalise l'événement `AgentRecrutementAjoute` via `AuditLogWriter`
- Domain : ajout de la valeur `ADD_RECRUTEMENT_AGENT` à `OrganismeAction`, réservée au rôle `RESPONSABLE` (staff inclus) dans `OrganismePermissionService`
- Domain : nouvelle erreur `AgentDejaMembreRecrutement`
- Presentation  : le `POST` de `RecrutementAgentsView` appelle `add_recrutement_agent` et sérialise le `RecrutementAgentModel` créé ; mapping des erreurs métier vers `404` (agent/recrutement introuvable, agent non rattaché) et `409` (agent déjà membre)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
