### PR TITLE
♻️(ingestion) dérive REQUIRED_TABLES des appels transcoder.translate

### DIFF
--- a/src/ingestion/tests/unit/test_data.py
+++ b/src/ingestion/tests/unit/test_data.py
@@ -1,38 +1,42 @@
 import csv
+import re
+from pathlib import Path
 
 from infrastructure.gateways.transcoding import _DATA_DIR
 
-REQUIRED_TABLES = {
-    "categories",
-    "departements",
-    "metiers",
-    "niveaux_de_diplome",
-    "niveaux_de_langue",
-    "niveaux_d_experience",
-    "oui_non",
-    "pays",
-    "regions",
-    "types_de_contrat",
-    "verses",
-    "zones_geo",
-}
+_OFFERS_CLEANER_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "infrastructure"
+    / "gateways"
+    / "offers_cleaner.py"
+)
 
 REQUIRED_COLUMNS = {"code_client", "mappe_sur_code_client_dgafp"}
 
 
+def _required_tables() -> set[str]:
+    source = _OFFERS_CLEANER_PATH.read_text(encoding="utf-8")
+    return set(re.findall(r'transcoder\.translate\(\s*"([^"]+)"', source))
+
+
 def test_each_source_has_the_required_csv_files():
+    required_tables = _required_tables()
+    assert required_tables, (
+        f"No transcoder.translate(...) call found in {_OFFERS_CLEANER_PATH}"
+    )
+
     source_directories = [d for d in _DATA_DIR.iterdir() if d.is_dir()]
     assert source_directories, f"No source directory found under {_DATA_DIR}"
 
     for source_directory in source_directories:
         present_tables = {csv_path.stem for csv_path in source_directory.glob("*.csv")}
-        missing_tables = REQUIRED_TABLES - present_tables
+        missing_tables = required_tables - present_tables
         assert not missing_tables, (
             f"Source '{source_directory.name}' is missing required CSV files: "
             f"{sorted(missing_tables)}"
         )
 
-        for table in REQUIRED_TABLES:
+        for table in required_tables:
             csv_path = source_directory / f"{table}.csv"
             with csv_path.open(encoding="utf-8") as f:
                 fieldnames = set(csv.DictReader(f, delimiter=";").fieldnames or [])


### PR DESCRIPTION
## 📝 Description

Évite l'oubli d'une table requise (ex: `specialisations`) en dérivant la liste directement des appels translate(...) dans `OffersCleaner` plutôt que de la maintenir à la main.

Suite de #1411

## 🏷️ Type de changement
- [x] 🎢 Nouvelle fonctionnalité (changement non bloquant qui ajoute une fonctionnalité)

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [x] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [ ] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
