### PR TITLE
refactor(tooling): migre vers Conventional Commits

### DIFF
--- a/.github/workflows/chore_require_pr_fields.yml
+++ b/.github/workflows/chore_require_pr_fields.yml
@@ -72,47 +72,63 @@ jobs:
               }
             `;
 
-            const result = await github.graphql(query, { owner, repo, number: prNumber });
-            const pr = result.repository.pullRequest;
+            const requiredFields = ['Importance', 'Size', 'Iteration', 'Epic'];
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
-            const linkedIssuesCount = pr.closingIssuesReferences.totalCount;
-            const projectItems = pr.projectItems.nodes;
+            // Filling in the "Development"/"Projects" fields on a freshly opened PR
+            // is a manual step that happens right after opening it, but doesn't fire
+            // any pull_request event itself — so retry for a bit before failing, to
+            // avoid a spurious red check on a PR whose fields are set moments later.
+            const maxAttempts = 5;
+            const delayMs = 30_000;
+            let lastErrors = [];
 
-            const hasDevelopment = linkedIssuesCount > 0;
-            const hasProjects = projectItems.length > 0;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const result = await github.graphql(query, { owner, repo, number: prNumber });
+              const pr = result.repository.pullRequest;
 
-            if (!hasDevelopment && !hasProjects) {
-              core.setFailed(
-                'This pull request must have either the "Development" field (a linked issue) or be added to a "Projects" board.'
-              );
-              return;
-            }
+              const linkedIssuesCount = pr.closingIssuesReferences.totalCount;
+              const projectItems = pr.projectItems.nodes;
 
-            if (hasProjects) {
-              const requiredFields = ['Importance', 'Size', 'Iteration', 'Epic'];
-              const errors = [];
+              const hasDevelopment = linkedIssuesCount > 0;
+              const hasProjects = projectItems.length > 0;
 
-              for (const item of projectItems) {
-                const filledFields = new Set();
+              lastErrors = [];
 
-                for (const fieldValue of item.fieldValues.nodes) {
-                  const fieldName = fieldValue.field?.name;
-                  if (!fieldName) continue;
-                  const value = fieldValue.name ?? fieldValue.title ?? fieldValue.text ?? fieldValue.number;
-                  if (value !== null && value !== undefined) {
-                    filledFields.add(fieldName);
+              if (!hasDevelopment && !hasProjects) {
+                lastErrors.push(
+                  'This pull request must have either the "Development" field (a linked issue) or be added to a "Projects" board.'
+                );
+              } else if (hasProjects) {
+                for (const item of projectItems) {
+                  const filledFields = new Set();
+
+                  for (const fieldValue of item.fieldValues.nodes) {
+                    const fieldName = fieldValue.field?.name;
+                    if (!fieldName) continue;
+                    const value = fieldValue.name ?? fieldValue.title ?? fieldValue.text ?? fieldValue.number;
+                    if (value !== null && value !== undefined) {
+                      filledFields.add(fieldName);
+                    }
+                  }
+
+                  const missingFields = requiredFields.filter(f => !filledFields.has(f));
+                  if (missingFields.length > 0) {
+                    lastErrors.push(
+                      `Project "${item.project.title}" is missing required fields: ${missingFields.join(', ')}.`
+                    );
                   }
                 }
-
-                const missingFields = requiredFields.filter(f => !filledFields.has(f));
-                if (missingFields.length > 0) {
-                  errors.push(
-                    `Project "${item.project.title}" is missing required fields: ${missingFields.join(', ')}.`
-                  );
-                }
               }
 
-              if (errors.length > 0) {
-                core.setFailed(errors.join('\n'));
+              if (lastErrors.length === 0) {
+                return;
+              }
+
+              if (attempt < maxAttempts) {
+                core.info(`Attempt ${attempt}/${maxAttempts} failed, retrying in ${delayMs / 1000}s: ${lastErrors.join(' | ')}`);
+                await sleep(delayMs);
               }
             }
+
+            core.setFailed(lastErrors.join('\n'));

--- a/.github/workflows/chore_require_pr_fields.yml
+++ b/.github/workflows/chore_require_pr_fields.yml
@@ -2,7 +2,7 @@ name: PR Fields Check
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
   merge_group:
 
 permissions:
@@ -18,12 +18,8 @@ jobs:
         with:
           github-token: ${{ secrets.GH_TOKEN || github.token }}
           script: |
-            const validLabels = new Set([
-              'breaking', 'added', 'modified', 'removed', 'bugfix', 'dependencies', 'documentation', 'pending-release'
-            ]);
-
             const { owner, repo } = context.repo;
-            let prNumber, labels;
+            let prNumber;
 
             if (context.eventName === 'merge_group') {
               // head_ref looks like refs/heads/gh-readonly-queue/main/pr-123-<sha>
@@ -33,19 +29,8 @@ jobs:
                 return;
               }
               prNumber = Number(match[1]);
-              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
-              labels = pr.labels.map(l => l.name);
             } else {
               prNumber = context.payload.pull_request.number;
-              labels = context.payload.pull_request.labels.map(l => l.name);
-            }
-
-            const matching = labels.filter(l => validLabels.has(l));
-            if (matching.length !== 1) {
-              core.setFailed(
-                `This pull request must have exactly one changelog label (${[...validLabels].join(', ')}). Found: ${matching.length === 0 ? 'none' : matching.join(', ')}.`
-              );
-              return;
             }
 
             const query = `

--- a/bin/git-commit-msg-hook
+++ b/bin/git-commit-msg-hook
@@ -6,13 +6,13 @@ set -eo pipefail
 MESSAGE=$(cat "$1")
 
 # commit message schema regex
-SCHEMA_REGEX="^(fixup!\s*)?(🎨|⚡️|🔥|🐛|🚑️|✨|📝|🚀|💄|💎|🎉|✅|🔒️|🔐|🔖|🚨|🚧|💚|⬇️|⬆️|📌|👷|📈|♻️|➕|➖|🔧|🔨|🌐|✏️|💩|⏪️|🔀|📦️|👽️|🚚|📄|💥|🍱|♿️|💡|🍻|💬|🗃️|🔊|🔇|👥|🚸|🏗️|📱|🤡|🥚|🙈|📸|⚗️|🔍️|🏷️|🌱|🚩|🥅|💫|🗑️|🛂|🩹|🧐|⚰️|🧪|👔|🩺|🧱|🧑‍💻|💸|🧵|🦺|✈️|💎|🤸|🧩|🖼️)\\([a-z0-9:-]+\\) [a-z].{1,50}"
+SCHEMA_REGEX="^(fixup!\s*)?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\\([a-z0-9:-]+\\): [A-zÀ-ú].{1,75}"
 
 # validate commit message schema
 if ! echo "$MESSAGE" | grep -qE "$SCHEMA_REGEX"; then
     echo "❌ Invalid commit message!"
-    echo "Required format: <emoji>(<scope>) <subject>"
-    echo "Example: ✨(auth) add support for HTTP basic auth"
+    echo "Required format: <type>(<scope>[-layer]): <subject>"
+    echo "Example: feat(auth): ajoute le support de l'authentification HTTP basic"
     echo "Use 'bin/cz commit' for more assistance (requires that commitzen is installed on your system)"
     exit 1
 fi

--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -16,39 +16,27 @@ name = "cz_customize"
 version = "0.1.0"
 
 [tool.commitizen.customize]
-message_template = "{{change_type}}({{scope}}{% if layer %}-{{layer}}{% endif %}) {{subject}}{% if body %}\n\n{{body}}{% endif %}{% if footer %}\n\n{{footer}}{% endif %}"
-example = "✨(candidate-infrastructure) add support for HTTP basic auth or ✨(candidate) add new feature"
-schema = "<emoji>(<scope>[-layer]) <subject>"
-schema_pattern = "^(🎨|⚡️|🔥|🐛|🚑️|✨|📝|🚀|💎|🎉|✅|🔒️|🚧|💚|⬇️|⬆️|👷|♻️|🔧|🏗️|🤸|🧩|🖼️)\\([a-z0-9:-]+\\) [A-zÀ-ú:-].{1,75}$"
+message_template = "{{change_type}}({{scope}}{% if layer %}-{{layer}}{% endif %}): {{subject}}{% if body %}\n\n{{body}}{% endif %}{% if footer %}\n\n{{footer}}{% endif %}"
+example = "feat(candidate-infrastructure): ajoute le support de l'authentification HTTP basic ou feat(candidate): ajoute une nouvelle fonctionnalité"
+schema = "<type>(<scope>[-layer]): <subject>"
+schema_pattern = "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\\([a-z0-9:-]+\\): [A-zÀ-ú].{1,75}$"
 
 [[tool.commitizen.customize.questions]]
 type = "list"
 name = "change_type"
 message = "Select the type of change:"
 choices = [
-    {value = "✨", name = "✨ introduce new features"},
-    {value = "🐛", name = "🐛 fix a bug"},
-    {value = "📝", name = "📝 add/update documentation"},
-    {value = "🎨", name = "🎨 improve structure / format of the code"},
-    {value = "♻️", name = "♻️ refactor code"},
-    {value = "⚡️", name = "⚡️ improve performance"},
-    {value = "✅", name = "✅ add/update/pass tests"},
-    {value = "🔧", name = "🔧 add/update configuration files"},
-    {value = "🚀", name = "🚀 deploy stuff"},
-    {value = "🔥", name = "🔥 remove code or files"},
-    {value = "🚧", name = "🚧 work in progress"},
-    {value = "💚", name = "💚 fix CI build"},
-    {value = "⬆️", name = "⬆️ upgrade dependencies"},
-    {value = "⬇️", name = "⬇️ downgrade dependencies"},
-    {value = "🎉", name = "🎉 begin a project"},
-    {value = "🚑️", name = "🚑️ critical hotfix"},
-    {value = "🔒️", name = "🔒️ fix security or privacy issues"},
-    {value = "🏗️", name = "🏗️ make architectural changes"},
-    {value = "👷", name = "👷 add/update CI build system"},
-    {value = "💎", name = "💎 add/update the UI and style files"},
-    {value = "🤸", name = "🤸 add/update a11y stuffs"},
-    {value = "🧩", name = "🧩 add/update templates"},
-    {value = "🖼️", name = "🖼️ add/update assets"}
+    {value = "feat", name = "feat: introduce new features"},
+    {value = "fix", name = "fix: fix a bug"},
+    {value = "docs", name = "docs: add/update documentation"},
+    {value = "style", name = "style: improve structure / format of the code"},
+    {value = "refactor", name = "refactor: refactor code"},
+    {value = "perf", name = "perf: improve performance"},
+    {value = "test", name = "test: add/update/pass tests"},
+    {value = "build", name = "build: add/update build system or dependencies"},
+    {value = "ci", name = "ci: add/update CI build system"},
+    {value = "chore", name = "chore: miscellaneous changes (config, assets, WIP...)"},
+    {value = "revert", name = "revert: revert a previous commit"}
 ]
 
 [[tool.commitizen.customize.questions]]

--- a/src/web/cliff.toml
+++ b/src/web/cliff.toml
@@ -39,7 +39,7 @@ postprocessors = [
 [git]
 # Parse commits according to the conventional commits specification.
 # See https://www.conventionalcommits.org
-conventional_commits = false
+conventional_commits = true
 # Exclude commits that do not match the conventional commits specification.
 filter_unconventional = false
 # Require all commits to be conventional.
@@ -57,11 +57,27 @@ commit_preprocessors = [
     #{ pattern = '.*', replace_command = 'typos --write-changes -' },
 ]
 # Prevent commits that are breaking from being excluded by commit parsers.
-protect_breaking_commits = false
+protect_breaking_commits = true
 # An array of regex based parsers for extracting data from the commit message.
 # Assigns commits to groups.
 # Optionally sets the commit's scope and can decide to exclude commits from further processing.
+#
+# NOTE: the `<!-- N -->` prefix in each group name is the sort key used by the
+# changelog template. It must be IDENTICAL for the new (type-based) and legacy
+# (label-based) parser matching the same logical category, otherwise the two
+# would render as separate, duplicate sections instead of merging into one.
 commit_parsers = [
+  # New scheme (conventional commits, no PR labels): matched first.
+  { message = "^.+!:", group = "<!-- 0 --> Breaking Changes" },
+  { body = ".*BREAKING CHANGE", group = "<!-- 0 --> Breaking Changes" },
+  { message = "^feat", group = "<!-- 1 --> Added" },
+  { message = "^refactor", group = "<!-- 2 --> Modified" },
+  { message = "^perf", group = "<!-- 2 --> Modified" },
+  { message = "^fix", group = "<!-- 4 --> Fixed" },
+  { message = "^docs", group = "<!-- 5 --> Documentation" },
+  { message = "^style|^test|^build|^ci|^chore|^revert", skip = true },
+  # Legacy scheme (Gitmoji + PR labels): fallback for commits made before the switch,
+  # so regenerating the full changelog doesn't drop pre-migration history.
   { field = "github.pr_labels", pattern = "breaking", group = "<!-- 0 --> Breaking Changes" },
   { field = "github.pr_labels", pattern = "added", group = "<!-- 1 --> Added" },
   { field = "github.pr_labels", pattern = "modified", group = "<!-- 2 --> Modified" },


### PR DESCRIPTION
## 📝 Description

- Remplace le format Gitmoji par Conventional Commits pour les commits et titres de PR (dev/pyproject.toml, bin/git-commit-msg-hook).
- Le tri du changelog se base désormais sur le type de commit (feat/fix/docs/...) plutôt que sur les labels de PR ; les parsers legacy basés sur les labels sont conservés en repli dans `cliff.toml` pour ne pas perdre l'historique déjà publié.
- Retire la vérification du label de changelog dans chore_require_pr_fields.yml.

## 🏷️ Type de changement
- [x] 🔧 Changement technique

## 🔧 Modifications
__Lister les changements principaux__

🛸 Dépendances requises pour ce changement (si applicable)

## 🏝️ Comment tester (si applicable)
__Étapes pour reproduire ou tester__

## 📸 Captures d’écran (si applicable)

## ✅ Liste de contrôle
- [ ] 💅 J’ai ajouté ou mis à jour les tests appropriés.
- [x] 📝 J’ai mis à jour ou ajouté la documentation nécessaire.
- [x] 🚀 J’ai pris en compte l’impact sur les performances, la sécurité et l’expérience utilisateur.
- [x] 👀 J’ai demandé une revue à une personne de l’équipe.
